### PR TITLE
Overhaul auth for new auth flow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,6 +99,8 @@ Style/FormatString:
   EnforcedStyle: percent
 Style/NumericPredicate:
   IgnoredMethods: ['where']
+  Exclude:
+    - "db/migrations/*"
 Style/RedundantReturn:
   Enabled: false
 Style/RedundantSelf:

--- a/.run/web.run.xml
+++ b/.run/web.run.xml
@@ -7,8 +7,7 @@
     <COMMAND_RUN_CONFIGURATION NAME="ALTERN_SDK_NAME" VALUE="" />
     <COMMAND_RUN_CONFIGURATION NAME="myPassParentEnvs" VALUE="true" />
     <envs>
-      <env name="CUSTOMER_SKIP_EMAIL_VERIFICATION" value="true" />
-      <env name="CUSTOMER_SKIP_PHONE_VERIFICATION" value="true" />
+      <env name="CUSTOMER_SKIP_VERIFICATION_ALLOWLIST" value="*" />
     </envs>
     <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="true" />
     <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ release-staging:
 	MERGE_HEROKU_ENV=$(staging_app) bundle exec foreman start release
 
 run:
-	CUSTOMER_SKIP_EMAIL_VERIFICATION=true CUSTOMER_SKIP_PHONE_VERIFICATION=true bundle exec foreman start web
+	bundle exec foreman start web
 run-with-verification:
 	bundle exec foreman start web
 run-workers:

--- a/README.md
+++ b/README.md
@@ -29,3 +29,19 @@ This involves two non-obvious features in the codebase:
   This allows us to have a "zero configuration" deployment.
   For a faster option, you can set up your reverse proxy (nginx or whatever)
   to serve the static assets instead.
+
+## Auth
+
+Auth with Suma is based exclusively on SMS verification rather than
+an explicit registration and login step.
+
+- Client POSTs to `/v1/auth/start` with a phone number.
+- Server will create a Customer if none exists with that phone number.
+- Server no-ops if a Customer already exists with that phone number.
+- In both cases, the server dispatches a One Time Password (OTP) to the phone number.
+- At this point, the client does *not* have an authenticated session.
+- Client POSTS to `/v1/auth/verify` with the phone number and the OTP.
+- If the phone number and OTP are valid, Server sets up an authenticated session.
+- If they are invalid, Server returns an error.
+- Client can POST to `/v1/auth/start` with the phone number again to dispatch
+  a new OTP.

--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -55,13 +55,18 @@ Sequel.migration do
       text :password_digest, null: false
       text :opaque_id, null: false
 
-      citext :email, null: false, unique: true
-      constraint(:lowercase_nospace_email, Sequel[:email] => Sequel.function(:btrim, Sequel.function(:lower, :email)))
-      timestamptz :email_verified_at
+      citext :email, null: true, unique: true
+      constraint(
+        :lowercase_nospace_email,
+        Sequel[:email] => Sequel.function(:btrim, Sequel.function(:lower, :email)),
+      )
+      constraint(
+        :email_present,
+        Sequel[email: nil] | (Sequel.function(:length, :email) > 0),
+      )
 
       text :phone, null: false, unique: true
       constraint(:numeric_phone, Sequel.lit("phone ~ '^[0-9]{11,15}$'"))
-      timestamptz :phone_verified_at
 
       text :name, null: false, default: ""
       text :note, null: false, default: ""

--- a/lib/suma/admin_api/customers.rb
+++ b/lib/suma/admin_api/customers.rb
@@ -47,8 +47,6 @@ class Suma::AdminAPI::Customers < Suma::AdminAPI::V1
         optional :note, type: String
         optional :email, type: String
         optional :phone, type: Integer
-        optional :email_verified, type: Boolean
-        optional :phone_verified, type: Boolean
         optional :timezone, type: String, values: ALL_TIMEZONES
         optional :roles, type: Array[String]
       end
@@ -59,12 +57,6 @@ class Suma::AdminAPI::Customers < Suma::AdminAPI::V1
           if (roles = fields.delete(:roles))
             customer.remove_all_roles
             roles.uniq.each { |r| customer.add_role(Suma::Role[name: r]) }
-          end
-          if fields.key?(:email_verified)
-            customer.email_verified_at = fields.delete(:email_verified) ? Time.now : nil
-          end
-          if fields.key?(:phone_verified)
-            customer.phone_verified_at = fields.delete(:phone_verified) ? Time.now : nil
           end
           set_declared(customer, params)
           customer.save_changes

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -86,10 +86,8 @@ module Suma::AdminAPI
   end
 
   class DetailedCustomerEntity < CustomerEntity
-    expose :email_verified_at
     expose :opaque_id
     expose :note
-    expose :phone_verified_at
     expose :roles do |instance|
       instance.roles.map(&:name)
     end

--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -5,6 +5,8 @@ require "name_of_person"
 require "suma/api"
 
 class Suma::API::Auth < Suma::API::V1
+  include Suma::Service::Types
+
   ALL_TIMEZONES = Set.new(TZInfo::Timezone.all_identifiers)
 
   helpers do
@@ -13,101 +15,29 @@ class Suma::API::Auth < Suma::API::V1
     end
   end
 
-  resource :register do
+  resource :auth do
     helpers do
-      # Registration is a beast, since phone and email are both unique.
-      # There are a whole bunch of situations customers can be in.
-      # PLEASE keep the code and specs up to date with this matrix.
-      #
-      # - Phone nor email match an existing user:
-      #   - do registration
-      # - Email and phone match existing, different users:
-      #   - error that email and phone are in use
-      # - Email and phone match the same user:
-      #   - if both unverified, update password and log in
-      #   - if phone and/or email are verified and passwords match, log in
-      #   - else, error that user already has an account
-      # - Phone matches an existing user, email does not:
-      #   - if phone and email are unverified, replace email and password and log in
-      #   - if phone is unverified and email is verified, and password matches, error that email is already used
-      #   - if phone is verified and email is unverified, and password matches, replace email and log in
-      #   - if phone and email are verified, and password matches, error that phone is already used
-      #   - else, error that an account already exists
-      # - Same as previous, but reverse phone/email.
-      #
-      # Password
-      #
-      # Passwords are optional. If, on registration, there is no password, use the empty placeholder.
-      # This will allow the customer to change it later.
-      def check_existing_customer!(email, phone, password)
-        with_email = Suma::Customer.with_email(email)
-        with_phone = Suma::Customer.with_us_phone(phone)
-        return nil if with_email.nil? && with_phone.nil?
-
-        invalid!(["email or phone in use"], message: "Sorry, this email and phone number is already in use.") if
-          with_email && with_phone && !(with_email === with_phone)
-
-        password_match = (with_email || with_phone).authenticate(password)
-
-        if with_email && with_phone && with_email === with_phone
-          return with_email if with_email.unverified?
-          return with_email if password_match
-          invalid!(["email or phone in use"], message: "Sorry, this email and phone number is already in use.")
-        end
-
-        if with_phone && with_email.nil?
-          return with_phone if with_phone.unverified?
-          invalid!(["email in use"], message: "Sorry, this email is already in use.") if
-            !with_phone.phone_verified? && with_phone.email_verified? && password_match
-          return with_phone if with_phone.phone_verified? && !with_phone.email_verified? && password_match
-          invalid!(["phone in use"], message: "Sorry, this phone number is already in use with a different email.")
-        end
-
-        raise "Unexpected condition, should have had email user and no phone" unless with_phone.nil? && with_email
-        return with_email if with_email.unverified?
-        invalid!(["phone in use"], message: "Sorry, this phone number is already in use.") if
-          !with_email.email_verified? && with_email.phone_verified? && password_match
-        return with_email if with_email.email_verified? && !with_email.phone_verified? && password_match
-        invalid!(["email in use"], message: "Sorry, this email is already in use with a different phone number.")
+      def guard_authed!
+        merror!(409, "You are already signed in. Please sign out first.", code: "auth_conflict") if current_customer?
       end
     end
-    desc "Create a new customer"
+
+    desc "Start the authentication process"
     params do
-      requires :email, type: String, allow_blank: false
-      requires :phone, us_phone: true, allow_blank: false
+      requires :phone, us_phone: true, type: String, coerce_with: NormalizedPhone
       requires :timezone, type: String, values: ALL_TIMEZONES
-      optional :password, type: String, allow_blank: false
-      optional :name, type: String, allow_blank: false, default: ""
     end
-    post do
-      if (c = current_customer?)
-        self.logger.warn "conflicting_login",
-                         registering_phone: params[:phone],
-                         existing_phone: c.phone,
-                         existing_user_id: c.id
-      end
-
-      phone = Suma::PhoneNumber::US.normalize(params[:phone])
-      email = params[:email].strip.downcase
-      password = params.delete(:password)
-
-      customer_params = {
-        email:,
-        phone:,
-        timezone: params[:timezone],
-        password:,
-        name: params[:name].strip.squish,
-      }
-
+    post :start do
+      guard_authed!
       Suma::Customer.db.transaction do
-        customer = check_existing_customer!(email, phone, password)
-        if (is_new = customer.nil?)
-          customer_params[:password_digest] = Suma::Customer::PLACEHOLDER_PASSWORD_DIGEST if password.blank?
-          customer = Suma::Customer.new(**customer_params)
-        else
-          customer.set(customer_params)
-        end
-        Suma::Customer.handle_verification_skipping(customer)
+        customer = Suma::Customer.with_us_phone(params[:phone])
+        is_new = customer.nil?
+        customer ||= Suma::Customer.new(
+          phone: params[:phone],
+          name: "",
+          password_digest: Suma::Customer::PLACEHOLDER_PASSWORD_DIGEST,
+        )
+        customer.timezone = params[:timezone]
         save_or_error!(customer)
         if is_new
           customer.add_journey(
@@ -117,69 +47,34 @@ class Suma::API::Auth < Suma::API::V1
             subject_id: customer.id,
           )
         end
-        # Email may not be verified, but we don't want to send them an email about verification yet.
-        # We can do that later.
-        # customer.add_reset_code({transport: "email"}) unless customer.email_verified?
-        customer.add_reset_code({transport: "sms"}) unless customer.phone_verified?
-        set_customer(customer)
-        create_session(customer)
+        customer.add_reset_code({transport: "sms"})
         status 200
-        present customer, with: Suma::API::CurrentCustomerEntity, env:
+        present({})
       end
     end
-  end
 
-  resource :auth do
-    desc "Log in using phone and password"
     params do
-      optional :phone, us_phone: true, allow_blank: false
-      optional :email, allow_blank: false
-      exactly_one_of :phone, :email
-      requires :password, type: String, allow_blank: false
-    end
-    post do
-      if current_customer?
-        env["warden"].logout
-        env["warden"].clear_strategies_cache!
-      end
-      customer = authenticate!
-      create_session(customer)
-      status 200
-      present customer, with: Suma::API::CurrentCustomerEntity, env:
-    end
-
-    desc "Verify the current customer phone number using the given token"
-    params do
-      requires :token
+      requires :phone, us_phone: true, type: String, coerce_with: NormalizedPhone
+      requires :token, type: String, allow_blank: false
     end
     post :verify do
-      me = current_customer
+      guard_authed!
+      me = Suma::Customer.with_us_phone(params[:phone])
       begin
-        Suma::Customer::ResetCode.use_code_with_token(params[:token]) do |code|
-          invalid!("Invalid verification code") unless code.customer === me
-          code.verify
-          code.customer.save_changes
-          me.refresh
+        Suma::Customer::ResetCode::Unusable if me.nil?
+        unless Suma::Customer.skip_verification?(me)
+          Suma::Customer::ResetCode.use_code_with_token(params[:token]) do |code|
+            raise Suma::Customer::ResetCode::Unusable unless code.customer === me
+          end
         end
       rescue Suma::Customer::ResetCode::Unusable
-        invalid!("Invalid verification code")
+        merror!(401, "Sorry, that token is invalid or the phone number is not in our system.")
       end
 
+      set_customer(me)
+      create_session(me)
       status 200
       present me, with: Suma::API::CurrentCustomerEntity, env:
-    end
-
-    params do
-      requires :transport, values: ["sms", "email"]
-    end
-    post :resend_verification do
-      me = current_customer
-      me.db.transaction do
-        me.reset_codes_dataset.where(transport: params[:transport]).usable.each(&:expire!)
-        me.add_reset_code(transport: params[:transport])
-      end
-      body ""
-      status 204
     end
 
     delete do

--- a/lib/suma/api/me.rb
+++ b/lib/suma/api/me.rb
@@ -119,11 +119,6 @@ class Suma::API::Me < Suma::API::V1
       begin
         customer = Suma::Customer::ResetCode.use_code_with_token(params[:token]) do |code|
           code.customer.password = params[:password]
-          if code.transport == "sms"
-            code.customer.verify_phone
-          else
-            code.customer.verify_email
-          end
           code.customer.save_changes
           code.customer
         end

--- a/lib/suma/customer/reset_code.rb
+++ b/lib/suma/customer/reset_code.rb
@@ -54,11 +54,6 @@ class Suma::Customer::ResetCode < Suma::Postgres::Model(:customer_reset_codes)
     return self
   end
 
-  def verify
-    self.customer.verify_phone if self.transport == "sms"
-    self.customer.verify_email if self.transport == "email"
-  end
-
   def used?
     return self.used
   end

--- a/lib/suma/fixtures/customers.rb
+++ b/lib/suma/fixtures/customers.rb
@@ -19,17 +19,10 @@ module Suma::Fixtures::Customers
     self.email ||= Faker::Internet.email
     self.phone ||= Faker::Suma.us_phone
     self.password_digest ||= Suma::Customer::PLACEHOLDER_PASSWORD_DIGEST
-    self.email_verified_at ||= Time.now
-    self.phone_verified_at ||= Time.now
   end
 
   before_saving do |instance|
     instance
-  end
-
-  decorator :unverified do
-    self.email_verified_at = nil
-    self.phone_verified_at = nil
   end
 
   decorator :password do |pwd=nil|
@@ -81,10 +74,6 @@ module Suma::Fixtures::Customers
       json["id"] = "cus_fixtured_#{SecureRandom.hex(8)}"
     end
     self.stripe.update(stripe_customer_json: json)
-  end
-
-  decorator :verified do
-    self.identity_verified_at = Time.now
   end
 
   STRIPE_JSON = {

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -79,8 +79,6 @@ module Suma::Service::Entities
     expose :email
     expose :name
     expose :us_phone, as: :phone
-    expose :email_verified?, as: :email_verified
-    expose :phone_verified?, as: :phone_verified
     expose :onboarded?, as: :onboarded
     expose :roles do |instance|
       instance.roles.map(&:name)

--- a/spec/suma/admin_api/customers_spec.rb
+++ b/spec/suma/admin_api/customers_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Suma::AdminAPI::Customers, :db do
       def make_item(i)
         # Sorting is newest first, so the first items we create need to the the oldest.
         created = Time.now - i.days
-        return admin.update(created_at: created) if i == 0
+        return admin.update(created_at: created) if i.zero?
         return Suma::Fixtures.customer.create(created_at: created)
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe Suma::AdminAPI::Customers, :db do
       let(:url) { "/admin/v1/customers" }
       let(:order_by_field) { "note" }
       def make_item(i)
-        return admin.update(note: i.to_s) if i == 0
+        return admin.update(note: i.to_s) if i.zero?
         return Suma::Fixtures.customer.create(created_at: Time.now + rand(1..100).days, note: i.to_s)
       end
     end
@@ -131,33 +131,6 @@ RSpec.describe Suma::AdminAPI::Customers, :db do
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(roles: contain_exactly("existing", "to_add"))
       expect(customer.refresh.roles.map(&:name)).to contain_exactly("existing", "to_add")
-    end
-
-    it "removes phone and email verification time" do
-      customer = Suma::Fixtures.customer.create
-
-      post "/admin/v1/customers/#{customer.id}", phone_verified: false, email_verified: false
-
-      expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(
-        id: customer.id, phone_verified_at: nil, email_verified_at: nil,
-      )
-    end
-
-    it "creates phone and email verification time" do
-      customer = Suma::Fixtures.customer.create
-
-      now = Time.at(Time.now.to_i)
-      Timecop.freeze(now) do
-        post "/admin/v1/customers/#{customer.id}", phone_verified: true, email_verified: true
-      end
-
-      expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(
-        id: customer.id,
-        phone_verified_at: now,
-        email_verified_at: now,
-      )
     end
   end
 

--- a/spec/suma/api/me_spec.rb
+++ b/spec/suma/api/me_spec.rb
@@ -197,16 +197,6 @@ RSpec.describe Suma::API::Me, :db do
       expect(code.refresh).to be_used
     end
 
-    it "verifies the associated field if unverified" do
-      code.update(transport: "sms")
-
-      customer.update(phone_verified_at: nil, email_verified_at: nil)
-
-      post "/v1/me/reset_password", token: code.token, password: "new-password"
-
-      expect(customer.refresh).to be_phone_verified
-    end
-
     it "403s if the reset code does not exist" do
       code.destroy
 


### PR DESCRIPTION
Auth with Suma is based exclusively on SMS verification rather than
an explicit registration and login step.

- Client POSTs to `/v1/auth/start` with a phone number.
- Server will create a Customer if none exists with that phone number.
- Server no-ops if a Customer already exists with that phone number.
- In both cases, the server dispatches a One Time Password (OTP) to the phone number.
- At this point, the client does *not* have an authenticated session.
- Client POSTS to `/v1/auth/verify` with the phone number and the OTP.
- If the phone number and OTP are valid, Server sets up an authenticated session.
- If they are invalid, Server returns an error.
- Client can POST to `/v1/auth/start` with the phone number again to dispatch
  a new OTP.