### PR TITLE
Support for beginning and ending trips via the API

### DIFF
--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -259,6 +259,9 @@ Sequel.migration do
 
       foreign_key :undiscounted_rate_id, :vendor_service_rates
       index :undiscounted_rate_id
+
+      text :localization_key, null: false
+      text :name, null: false
     end
 
     create_join_table(

--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -190,6 +190,8 @@ Sequel.migration do
       text :internal_name, null: false
       text :external_name, null: false
       text :sync_url, null: false, default: ""
+
+      text :mobility_vendor_adapter_key, null: false, default: ""
     end
 
     create_table(:vendor_service_categories) do
@@ -308,7 +310,7 @@ Sequel.migration do
       index :customer_id
 
       foreign_key :mobility_trip_id, :mobility_trips, null: true, on_delete: :set_null
-      index :mobility_trip_id
+      unique :mobility_trip_id
     end
   end
 end

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -7,7 +7,6 @@ require "suma/api" unless defined? Suma::API
 
 module Suma::API
   AddressEntity = Suma::Service::Entities::Address
-  CurrentCustomerEntity = Suma::Service::Entities::CurrentCustomer
   LegalEntityEntity = Suma::Service::Entities::LegalEntityEntity
   MoneyEntity = Suma::Service::Entities::Money
   TimeRangeEntity = Suma::Service::Entities::TimeRange
@@ -70,5 +69,9 @@ module Suma::API
     expose :end_lat
     expose :end_lng
     expose :ended_at
+  end
+
+  class CurrentCustomerEntity < Suma::Service::Entities::CurrentCustomer
+    expose :ongoing_trip, with: MobilityTripEntity
   end
 end

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -25,6 +25,12 @@ module Suma::API
     expose :slug
   end
 
+  class VendorServiceRateEntity < BaseEntity
+    expose :id
+    expose :message_template
+    expose :message_vars
+  end
+
   class VendorServiceEntity < BaseEntity
     expose :id
     expose :external_name, as: :name
@@ -51,5 +57,18 @@ module Suma::API
     expose :vendor_service, with: VendorServiceEntity
     expose :vehicle_id
     expose :to_api_location, as: :loc
+  end
+
+  class MobilityTripEntity < BaseEntity
+    expose :id
+    expose :vehicle_id
+    expose :vendor_service, as: :provider, with: VendorServiceEntity
+    expose :vendor_service_rate, as: :rate, with: VendorServiceRateEntity
+    expose :begin_lat
+    expose :begin_lng
+    expose :began_at
+    expose :end_lat
+    expose :end_lng
+    expose :ended_at
   end
 end

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -26,8 +26,8 @@ module Suma::API
 
   class VendorServiceRateEntity < BaseEntity
     expose :id
-    expose :message_template
-    expose :message_vars
+    expose :localization_key
+    expose :localization_vars
   end
 
   class VendorServiceEntity < BaseEntity
@@ -56,6 +56,7 @@ module Suma::API
     expose :vendor_service, with: VendorServiceEntity
     expose :vehicle_id
     expose :to_api_location, as: :loc
+    expose :rate, &self.delegate_to(:vendor_service, :one_rate)
   end
 
   class MobilityTripEntity < BaseEntity

--- a/lib/suma/charge.rb
+++ b/lib/suma/charge.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "suma/postgres/model"
+
+class Suma::Charge < Suma::Postgres::Model(:charges)
+  plugin :timestamps
+  plugin :money_fields, :discounted_amount, :undiscounted_amount
+
+  many_to_one :customer, class: "Suma::Customer"
+end

--- a/lib/suma/charge.rb
+++ b/lib/suma/charge.rb
@@ -4,7 +4,8 @@ require "suma/postgres/model"
 
 class Suma::Charge < Suma::Postgres::Model(:charges)
   plugin :timestamps
-  plugin :money_fields, :discounted_amount, :undiscounted_amount
+  plugin :money_fields, :discounted_subtotal, :undiscounted_subtotal
 
   many_to_one :customer, class: "Suma::Customer"
+  many_to_one :mobility_trip, class: "Suma::Mobility::Trip"
 end

--- a/lib/suma/customer.rb
+++ b/lib/suma/customer.rb
@@ -41,6 +41,7 @@ class Suma::Customer < Suma::Postgres::Model(:customers)
   one_to_many :reset_codes, class: "Suma::Customer::ResetCode", order: Sequel.desc([:created_at])
   many_to_many :roles, class: "Suma::Role", join_table: :roles_customers
   one_to_many :sessions, class: "Suma::Customer::Session", order: Sequel.desc([:created_at, :id])
+  one_to_one :ongoing_trip, class: "Suma::Mobility::Trip", conditions: {ended_at: nil}
 
   dataset_module do
     def with_email(*emails)

--- a/lib/suma/fixtures/mobility_trips.rb
+++ b/lib/suma/fixtures/mobility_trips.rb
@@ -23,6 +23,13 @@ module Suma::Fixtures::MobilityTrips
     instance
   end
 
+  decorator :for_vehicle do |v|
+    self.begin_lat = v.lat
+    self.begin_lng = v.lng
+    self.vehicle_id = v.vehicle_id
+    self.vendor_service = v.vendor_service
+  end
+
   decorator :ongoing do
     self.end_lat = nil
     self.end_lng = nil

--- a/lib/suma/fixtures/mobility_trips.rb
+++ b/lib/suma/fixtures/mobility_trips.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "suma"
+require "suma/fixtures"
+require "suma/mobility/trip"
+
+module Suma::Fixtures::MobilityTrips
+  extend Suma::Fixtures
+
+  fixtured_class Suma::Mobility::Trip
+
+  base :mobility_trip do
+    self.begin_lat ||= Faker::Number.between(from: -90.0, to: 90.0)
+    self.begin_lng ||= Faker::Number.between(from: -180.0, to: 180.0)
+    self.began_at ||= Time.now
+    self.vehicle_id ||= SecureRandom.hex(8)
+  end
+
+  before_saving do |instance|
+    instance.customer ||= Suma::Fixtures.customer.create
+    instance.vendor_service ||= Suma::Fixtures.vendor_service.mobility.create
+    instance.vendor_service_rate ||= Suma::Fixtures.vendor_service_rate.create
+    instance
+  end
+
+  decorator :ongoing do
+    self.end_lat = nil
+    self.end_lng = nil
+    self.ended_at = nil
+  end
+
+  decorator :ended do
+    self.end_lat ||= self.begin_lat + 0.5
+    self.end_lng ||= self.begin_lng + 0.5
+    self.ended_at ||= Time.now
+  end
+end

--- a/lib/suma/fixtures/vendor_service_rates.rb
+++ b/lib/suma/fixtures/vendor_service_rates.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "suma"
+require "suma/fixtures"
+require "suma/vendor/service_rate"
+
+module Suma::Fixtures::VendorServiceRates
+  extend Suma::Fixtures
+
+  fixtured_class Suma::Vendor::ServiceRate
+
+  base :vendor_service_rate do
+    self.unit_amount_cents.nil? && (self.unit_amount = 0)
+    self.surcharge_cents.nil? && (self.surcharge = 0)
+  end
+
+  decorator :unit_amount do |cents|
+    self.unit_amount_cents = cents || Faker::Number.between(from: 10, to: 500)
+  end
+
+  decorator :surcharge do |cents|
+    self.surcharge_cents = cents || Faker::Number.between(from: 10, to: 500)
+  end
+
+  decorator :discounted_by do |percent|
+    # (origamt / discamt) = mult
+    # (100 / 90) = 1.1111
+    # 90 * 1.1111 = 100
+    # 100 * 0.9 = 90
+    # 90 / 0.9 = 100
+    mult = 1 - percent
+    self.undiscounted_rate = Suma::Fixtures.
+      vendor_service_rate(
+        unit_amount: self.unit_amount / mult,
+        surcharge: self.surcharge / mult,
+      ).create
+  end
+end

--- a/lib/suma/fixtures/vendor_service_rates.rb
+++ b/lib/suma/fixtures/vendor_service_rates.rb
@@ -35,4 +35,9 @@ module Suma::Fixtures::VendorServiceRates
         surcharge: self.surcharge / mult,
       ).create
   end
+
+  decorator :for_service, presave: true do |vs={}|
+    vs = Suma::Fixtures.vendor_service(vs).create unless vs.is_a?(Suma::Vendor::Service)
+    self.add_service(vs)
+  end
 end

--- a/lib/suma/fixtures/vendor_service_rates.rb
+++ b/lib/suma/fixtures/vendor_service_rates.rb
@@ -12,6 +12,8 @@ module Suma::Fixtures::VendorServiceRates
   base :vendor_service_rate do
     self.unit_amount_cents.nil? && (self.unit_amount = 0)
     self.surcharge_cents.nil? && (self.surcharge = 0)
+    self.name ||= Faker::Lorem.word
+    self.localization_key ||= self.name.downcase
   end
 
   decorator :unit_amount do |cents|

--- a/lib/suma/fixtures/vendor_services.rb
+++ b/lib/suma/fixtures/vendor_services.rb
@@ -21,6 +21,7 @@ module Suma::Fixtures::VendorServices
 
   decorator :mobility, presave: true do
     self.add_category(Suma::Fixtures.vendor_service_category.mobility.create)
+    self.mobility_vendor_adapter_key = "fake" if self.mobility_vendor_adapter_key.blank?
   end
 
   decorator :food, presave: true do

--- a/lib/suma/mobility/fake_vendor_adapter.rb
+++ b/lib/suma/mobility/fake_vendor_adapter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Suma::Mobility::FakeVendorAdapter
+  include Suma::Mobility::VendorAdapter
+
+  def begin_trip(_customer, _vehicle_id)
+    return BeginTripResult.new
+  end
+
+  def end_trip(trip)
+    ended = Time.now
+    duration = (ended - trip.began_at) / 60.0
+    return EndTripResult.new(
+      cost_cents: trip.vendor_service_rate.calculate_total(duration).cents.to_i,
+      cost_currency: "USD",
+      end_time: ended,
+      duration_minutes: duration.to_i,
+    )
+  end
+end

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "suma/mobility"
+require "suma/postgres/model"
+
+class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
+  class OngoingTrip < StandardError; end
+
+  plugin :timestamps
+
+  many_to_one :vendor_service, key: :vendor_service_id, class: "Suma::Vendor::Service"
+  many_to_one :vendor_service_rate, key: :vendor_service_rate_id, class: "Suma::Vendor::ServiceRate"
+  many_to_one :customer, key: :customer_id, class: "Suma::Customer"
+
+  def self.start_trip(customer:, vehicle_id:, vendor_service:, rate:, lat:, lng:, at: Time.now)
+    self.db.transaction(savepoint: true) do
+      return self.create(
+        customer:,
+        vehicle_id:,
+        vendor_service:,
+        vendor_service_rate: rate,
+        begin_lat: lat,
+        begin_lng: lng,
+        began_at: at,
+      )
+    end
+  rescue Sequel::UniqueConstraintViolation => e
+    raise OngoingTrip, "customer #{customer.id} is already in a trip" if
+      e.to_s.include?("one_active_ride_per_customer")
+    raise
+  end
+
+  def end_trip(lat:, lng:, at: Time.now)
+    self.update(
+      end_lat: lat,
+      end_lng: lng,
+      ended_at: at,
+    )
+  end
+end

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -12,6 +12,24 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
   many_to_one :vendor_service_rate, key: :vendor_service_rate_id, class: "Suma::Vendor::ServiceRate"
   many_to_one :customer, key: :customer_id, class: "Suma::Customer"
 
+  dataset_module do
+    def ongoing
+      return self.where(ended_at: nil)
+    end
+  end
+
+  def self.start_trip_from_vehicle(customer:, vehicle:, rate:, at: Time.now)
+    return self.start_trip(
+      customer:,
+      vehicle_id: vehicle.vehicle_id,
+      vendor_service: vehicle.vendor_service,
+      rate:,
+      lat: vehicle.lat,
+      lng: vehicle.lng,
+      at:,
+    )
+  end
+
   def self.start_trip(customer:, vehicle_id:, vendor_service:, rate:, lat:, lng:, at: Time.now)
     self.db.transaction(savepoint: true) do
       return self.create(
@@ -36,5 +54,9 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
       end_lng: lng,
       ended_at: at,
     )
+  end
+
+  def ended?
+    return !self.ended_at.nil?
   end
 end

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -11,6 +11,7 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
   many_to_one :vendor_service, key: :vendor_service_id, class: "Suma::Vendor::Service"
   many_to_one :vendor_service_rate, key: :vendor_service_rate_id, class: "Suma::Vendor::ServiceRate"
   many_to_one :customer, key: :customer_id, class: "Suma::Customer"
+  one_to_one :charge, key: :mobility_trip_id, class: "Suma::Charge"
 
   dataset_module do
     def ongoing
@@ -48,15 +49,35 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
     raise
   end
 
-  def end_trip(lat:, lng:, at: Time.now)
-    self.update(
-      end_lat: lat,
-      end_lng: lng,
-      ended_at: at,
-    )
+  def end_trip(lat:, lng:)
+    # TODO: Not sure how to handle multiple calls to this for the same trip,
+    # or if we lose track of something. We can work this out more clearly once
+    # we have a real provider to work with.
+    result = self.vendor_service.mobility_adapter.end_trip(self)
+    self.db.transaction do
+      self.update(
+        end_lat: lat,
+        end_lng: lng,
+        ended_at: result.end_time,
+      )
+      units = self.rate_units
+      self.charge = Suma::Charge.create(
+        mobility_trip: self,
+        discounted_subtotal: Money.new(result.cost_cents, result.cost_currency),
+        undiscounted_subtotal: self.vendor_service_rate.calculate_undiscounted_total(units),
+        customer: self.customer,
+      )
+    end
   end
 
   def ended?
     return !self.ended_at.nil?
+  end
+
+  def rate_units
+    x = self.ended_at - self.began_at
+    x /= 60
+    x = x.round
+    return x
   end
 end

--- a/lib/suma/mobility/vendor_adapter.rb
+++ b/lib/suma/mobility/vendor_adapter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Suma::Mobility::VendorAdapter
+  class UnknownAdapter < StandardError; end
+
+  BeginTripResult = Struct.new(:raw_result, keyword_init: true)
+  EndTripResult = Struct.new(
+    :raw_result,
+    :cost_cents,
+    :cost_currency,
+    :duration_minutes,
+    :end_time,
+    keyword_init: true,
+  )
+
+  class << self
+    def register(name, cls)
+      @registry ||= {}
+      @registry[name.to_s] = cls
+    end
+
+    def create(name)
+      (cls = @registry[name.to_s]) or
+        raise UnknownAdapter, "No registered adapter '#{name}' available: #{@registry.keys.join(', ')}"
+      return cls.new
+    end
+  end
+
+  def begin_trip(customer, vehicle_id)
+    raise NotImplementedError
+  end
+
+  def end_trip(trip)
+    raise NotImplementedError
+  end
+end
+
+require_relative "fake_vendor_adapter"
+Suma::Mobility::VendorAdapter.register("fake", Suma::Mobility::FakeVendorAdapter)

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -46,6 +46,7 @@ module Suma::Postgres
   # Require paths for all Sequel models used by the app.
   MODELS = [
     "suma/address",
+    "suma/charge",
     "suma/customer",
     "suma/customer/journey",
     "suma/customer/reset_code",
@@ -55,12 +56,14 @@ module Suma::Postgres
     "suma/market",
     "suma/message/body",
     "suma/message/delivery",
+    "suma/mobility/trip",
     "suma/mobility/vehicle",
     "suma/organization",
     "suma/role",
     "suma/vendor",
     "suma/vendor/service",
     "suma/vendor/service_category",
+    "suma/vendor/service_rate",
   ].freeze
 
   # If true, deferred model events publish immediately.

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -12,14 +12,21 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
       Suma.load_app
       org = Suma::Organization.find_or_create(name: "Spin")
       org.db.transaction do
+        rate = Suma::Vendor::ServiceRate.find_or_create(name: "Mobility $1 start $0.20/minute") do |r|
+          r.localization_key = "mobility_start_and_per_minute"
+          r.surcharge = Money.new(100)
+          r.unit_amount = Money.new(20)
+        end
         spin = Suma::Vendor.find_or_create(name: "Spin", organization: org)
         if spin.services_dataset.mobility.empty?
           svc = spin.add_service(
             internal_name: "Portland Scooters",
             external_name: "Spin E-Scooters",
             sync_url: "https://gbfs.spin.pm/api/gbfs/v2_2/portland/free_bike_status",
+            mobility_vendor_adapter_key: "fake",
           )
           svc.add_category(Suma::Vendor::ServiceCategory.find_or_create(name: "Mobility"))
+          svc.add_rate(rate)
         end
       end
       require "suma/mobility/sync_spin"

--- a/lib/suma/vendor/service.rb
+++ b/lib/suma/vendor/service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "suma/postgres/model"
+require "suma/mobility/vendor_adapter"
 
 class Suma::Vendor::Service < Suma::Postgres::Model(:vendor_services)
   plugin :timestamps
@@ -22,5 +23,9 @@ class Suma::Vendor::Service < Suma::Postgres::Model(:vendor_services)
     def with_category(slug)
       return self.where(categories: Suma::Vendor::ServiceCategory.where(slug:))
     end
+  end
+
+  def mobility_adapter
+    return Suma::Mobility::VendorAdapter.create(self.mobility_vendor_adapter_key)
   end
 end

--- a/lib/suma/vendor/service.rb
+++ b/lib/suma/vendor/service.rb
@@ -8,7 +8,11 @@ class Suma::Vendor::Service < Suma::Postgres::Model(:vendor_services)
   many_to_one :vendor, key: :vendor_id, class: "Suma::Vendor"
   many_to_many :categories, class: "Suma::Vendor::ServiceCategory",
                             join_table: :vendor_service_categories_vendor_services
-  many_to_many :rates, class: "Suma::Vendor::ServiceRate", join_table: :vendor_service_vendor_service_rates
+  many_to_many :rates,
+               class: "Suma::Vendor::ServiceRate",
+               join_table: :vendor_service_vendor_service_rates,
+               left_key: :vendor_service_id,
+               right_key: :vendor_service_rate_id
 
   dataset_module do
     def mobility

--- a/lib/suma/vendor/service.rb
+++ b/lib/suma/vendor/service.rb
@@ -8,6 +8,7 @@ class Suma::Vendor::Service < Suma::Postgres::Model(:vendor_services)
   many_to_one :vendor, key: :vendor_id, class: "Suma::Vendor"
   many_to_many :categories, class: "Suma::Vendor::ServiceCategory",
                             join_table: :vendor_service_categories_vendor_services
+  many_to_many :rates, class: "Suma::Vendor::ServiceRate", join_table: :vendor_service_vendor_service_rates
 
   dataset_module do
     def mobility

--- a/lib/suma/vendor/service.rb
+++ b/lib/suma/vendor/service.rb
@@ -28,4 +28,14 @@ class Suma::Vendor::Service < Suma::Postgres::Model(:vendor_services)
   def mobility_adapter
     return Suma::Mobility::VendorAdapter.create(self.mobility_vendor_adapter_key)
   end
+
+  # Return the one and only rate for this service, or error if it has multiple rates.
+  # In the future we will likely support determining rates per-resident,
+  # but for now, we assume one rate for all residents using a service.
+  def one_rate
+    r = self.rates
+    raise "#{self.inspect} has no rates" if r.empty?
+    raise "#{self.inspect} has too many rates" if r.length > 1
+    return r.first
+  end
 end

--- a/lib/suma/vendor/service_rate.rb
+++ b/lib/suma/vendor/service_rate.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "suma/postgres/model"
+
+class Suma::Vendor::ServiceRate < Suma::Postgres::Model(:vendor_service_rates)
+  plugin :timestamps
+  plugin :money_fields, :unit_amount, :surcharge
+
+  many_to_many :services, class: "Suma::Vendor::Service", join_table: :vendor_service_vendor_service_rates
+  many_to_one :undiscounted_rate, key: :undiscounted_rate_id, class: "Suma::Vendor::ServiceRate"
+
+  def calculate_total(units)
+    offset_units = [units - self.unit_offset, 0].max
+    t = self.unit_amount * offset_units
+    t += self.surcharge
+    return t
+  end
+
+  def calculate_undiscounted_total(units)
+    r = self.undiscounted_rate_id.nil? ? self : self.undiscounted_rate
+    return r.calculate_total(units)
+  end
+
+  def discount(units)
+    disc = self.calculate_total(units)
+    undisc = self.calculate_undiscounted_total(units)
+    return undisc - disc
+  end
+
+  def discount_percentage(units)
+    disc = self.calculate_total(units)
+    undisc = self.calculate_undiscounted_total(units)
+    f = 1 - (disc.to_f / undisc)
+    return (f * 100).to_i
+  end
+end

--- a/lib/suma/vendor/service_rate.rb
+++ b/lib/suma/vendor/service_rate.rb
@@ -40,11 +40,12 @@ class Suma::Vendor::ServiceRate < Suma::Postgres::Model(:vendor_service_rates)
     return (f * 100).to_i
   end
 
-  def message_template
-    return "some_message_template"
-  end
-
-  def message_vars
-    return {a: 5}
+  def localization_vars
+    return {
+      unit_cents: self.unit_amount.cents,
+      unit_currency: self.unit_amount.currency.to_s,
+      surcharge_cents: self.surcharge.cents,
+      surcharge_currency: self.surcharge.currency.to_s,
+    }
   end
 end

--- a/lib/suma/vendor/service_rate.rb
+++ b/lib/suma/vendor/service_rate.rb
@@ -34,7 +34,9 @@ class Suma::Vendor::ServiceRate < Suma::Postgres::Model(:vendor_service_rates)
   def discount_percentage(units)
     disc = self.calculate_total(units)
     undisc = self.calculate_undiscounted_total(units)
-    f = 1 - (disc.to_f / undisc)
+    # rubocop:disable Style/FloatDivision
+    f = 1 - (disc.to_f / undisc.to_f)
+    # rubocop:enable Style/FloatDivision
     return (f * 100).to_i
   end
 

--- a/lib/suma/vendor/service_rate.rb
+++ b/lib/suma/vendor/service_rate.rb
@@ -6,7 +6,11 @@ class Suma::Vendor::ServiceRate < Suma::Postgres::Model(:vendor_service_rates)
   plugin :timestamps
   plugin :money_fields, :unit_amount, :surcharge
 
-  many_to_many :services, class: "Suma::Vendor::Service", join_table: :vendor_service_vendor_service_rates
+  many_to_many :services,
+               class: "Suma::Vendor::Service",
+               join_table: :vendor_service_vendor_service_rates,
+               left_key: :vendor_service_rate_id,
+               right_key: :vendor_service_id
   many_to_one :undiscounted_rate, key: :undiscounted_rate_id, class: "Suma::Vendor::ServiceRate"
 
   def calculate_total(units)
@@ -32,5 +36,13 @@ class Suma::Vendor::ServiceRate < Suma::Postgres::Model(:vendor_service_rates)
     undisc = self.calculate_undiscounted_total(units)
     f = 1 - (disc.to_f / undisc)
     return (f * 100).to_i
+  end
+
+  def message_template
+    return "some_message_template"
+  end
+
+  def message_vars
+    return {a: 5}
   end
 end

--- a/spec/suma/api/me_spec.rb
+++ b/spec/suma/api/me_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Suma::API::Me, :db do
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.
-        that_includes(email: customer.email)
+        that_includes(email: customer.email, ongoing_trip: nil)
     end
 
     it "errors if the customer is soft deleted" do
@@ -46,6 +46,16 @@ RSpec.describe Suma::API::Me, :db do
       get "/v1/me"
       expect(last_response).to have_status(200)
       expect(Suma::Customer::Session.all).to have_length(1)
+    end
+
+    it "returns the customer's ongoing trip if they have one" do
+      trip = Suma::Fixtures.mobility_trip.ongoing.create(customer:)
+
+      get "/v1/me"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.
+        that_includes(ongoing_trip: include(id: trip.id))
     end
   end
 

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -207,39 +207,75 @@ RSpec.describe Suma::API::Mobility, :db do
   end
 
   describe "POST /v1/mobility/begin_trip" do
-    let(:fac) {  Suma::Fixtures.mobility_vehicle }
+    let(:vendor_service) { Suma::Fixtures.vendor_service.create }
+    let(:vehicle) { Suma::Fixtures.mobility_vehicle.create(vendor_service:) }
+    let(:rate) { Suma::Fixtures.vendor_service_rate.for_service(vendor_service).create }
 
     it "starts a trip for the resident using the given vehicle and its associated rate" do
-      b1 = fac.create
-
-      post "/v1/mobility/begin_trip", provider_id: b1.vendor_service_id, vehicle_id: b1.vehicle_id
+      post "/v1/mobility/begin_trip",
+           provider_id: vehicle.vendor_service_id, vehicle_id: vehicle.vehicle_id, rate_id: rate.id
 
       expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.
-        that_includes(
-          vendor_service: include(:name, :vendor_name, id: vsvc.id),
-          vehicle_id: b1.vehicle_id,
-        )
+      expect(last_response).to have_json_body.that_includes(:id)
+
+      trip = Suma::Mobility::Trip[last_response_json_body[:id]]
+      expect(trip).to have_attributes(customer: be === customer)
     end
 
     it "errors if the vehicle cannot be found" do
+      post "/v1/mobility/begin_trip",
+           provider_id: vehicle.vendor_service_id, vehicle_id: vehicle.vehicle_id + "1", rate_id: rate.id
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(error: include(code: "vehicle_not_found"))
     end
 
     it "errors if the resident already has an active trip" do
+      Suma::Fixtures.mobility_trip.ongoing.for_vehicle(vehicle).create(customer:)
+
+      post "/v1/mobility/begin_trip",
+           provider_id: vehicle.vendor_service_id, vehicle_id: vehicle.vehicle_id, rate_id: rate.id
+
+      expect(last_response).to have_status(409)
+      expect(last_response).to have_json_body.that_includes(error: include(code: "ongoing_trip"))
     end
 
-    it "errors if there is no rate for the vehicle" do
+    it "errors if the given rate does not exist for the provider" do
+      rate2 = Suma::Fixtures.vendor_service_rate.create
+      post "/v1/mobility/begin_trip",
+           provider_id: vehicle.vendor_service_id, vehicle_id: vehicle.vehicle_id, rate_id: rate2.id
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(error: include(code: "rate_not_found"))
     end
   end
 
   describe "POST /v1/mobility/end_trip" do
     it "ends the active trip for the resident" do
+      trip = Suma::Fixtures.mobility_trip.ongoing.create(customer:)
+      expect(trip).to_not be_ended
+
+      post "/v1/mobility/end_trip", lat: 5, lng: -5
+
+      expect(last_response).to have_status(200)
+      expect(trip.refresh).to be_ended
+      expect(trip).to have_attributes(end_lat: 5, end_lng: -5)
     end
 
     it "errors if the resident has no active trip" do
+      post "/v1/mobility/end_trip", lat: 5, lng: -5
+
+      expect(last_response).to have_status(409)
+      expect(last_response).to have_json_body.that_includes(error: include(code: "no_active_trip"))
     end
 
-    it "creates a charge using the rate attached to the trip" do
+    xit "creates a charge using the rate attached to the trip" do
+      trip = Suma::Fixtures.mobility_trip.ongoing.create(customer)
+
+      post "/v1/mobility/end_trip", lat: 5, lng: -5
+
+      expect(last_response).to have_status(200)
+      expect(trip.charges).to have_length(1)
     end
   end
 end

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -205,4 +205,41 @@ RSpec.describe Suma::API::Mobility, :db do
       expect(last_response).to have_status(401)
     end
   end
+
+  describe "POST /v1/mobility/begin_trip" do
+    let(:fac) {  Suma::Fixtures.mobility_vehicle }
+
+    it "starts a trip for the resident using the given vehicle and its associated rate" do
+      b1 = fac.create
+
+      post "/v1/mobility/begin_trip", provider_id: b1.vendor_service_id, vehicle_id: b1.vehicle_id
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.
+        that_includes(
+          vendor_service: include(:name, :vendor_name, id: vsvc.id),
+          vehicle_id: b1.vehicle_id,
+        )
+    end
+
+    it "errors if the vehicle cannot be found" do
+    end
+
+    it "errors if the resident already has an active trip" do
+    end
+
+    it "errors if there is no rate for the vehicle" do
+    end
+  end
+
+  describe "POST /v1/mobility/end_trip" do
+    it "ends the active trip for the resident" do
+    end
+
+    it "errors if the resident has no active trip" do
+    end
+
+    it "creates a charge using the rate attached to the trip" do
+    end
+  end
 end

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -141,7 +141,8 @@ RSpec.describe Suma::API::Mobility, :db do
 
   describe "GET /v1/mobility/vehicle" do
     let(:fac) {  Suma::Fixtures.mobility_vehicle }
-    let(:vsvc) { Suma::Fixtures.vendor_service.create }
+    let(:vsvc) { Suma::Fixtures.vendor_service.mobility.create }
+    let!(:rate) { Suma::Fixtures.vendor_service_rate.for_service(vsvc).create }
 
     it "returns information about the requested vehicle" do
       b1 = fac.loc(0.5, 179.5).ebike.create(vendor_service: vsvc)
@@ -156,6 +157,7 @@ RSpec.describe Suma::API::Mobility, :db do
           vendor_service: include(:name, :vendor_name, id: vsvc.id),
           vehicle_id: b1.vehicle_id,
           loc: [5_000_000, 1_795_000_000],
+          rate: include(id: rate.id),
         )
     end
 

--- a/spec/suma/customer_spec.rb
+++ b/spec/suma/customer_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe "Suma::Customer", :db do
     expect { Suma::Customer.new.inspect }.to_not raise_error
   end
 
+  describe "associations" do
+    it "has an ongoing_trip association" do
+      c = Suma::Fixtures.customer.create
+      expect(c.ongoing_trip).to be_nil
+      t = Suma::Fixtures.mobility_trip.ongoing.create(customer: c)
+      expect(c.refresh.ongoing_trip).to be === t
+      t.end_trip(lat: 1, lng: 2)
+      expect(c.refresh.ongoing_trip).to be_nil
+    end
+  end
+
   describe "greeting" do
     it "uses the name if present" do
       expect(described_class.new(name: "Huck Finn").greeting).to eq("Huck Finn")

--- a/spec/suma/mobility/trip_spec.rb
+++ b/spec/suma/mobility/trip_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::Mobility::Trip", :db do
+  let(:described_class) { Suma::Mobility::Trip }
+  let(:customer) { Suma::Fixtures.customer.create }
+  let(:vendor_service) { Suma::Fixtures.vendor_service.create }
+  let(:rate) { Suma::Fixtures.vendor_service_rate.create }
+  let(:t) { trunc_time(Time.now) }
+
+  it "can be fixtured" do
+    expect(Suma::Fixtures.mobility_trip.create).to be_a(described_class)
+  end
+
+  describe "start_trip" do
+    it "creates a trip with the given parameters" do
+      trip = described_class.start_trip(
+        customer:,
+        vehicle_id: "abcd",
+        vendor_service:,
+        rate:,
+        lat: 1.5,
+        lng: 2.5,
+        at: t,
+      )
+      expect(trip).to have_attributes(
+        customer:,
+        vehicle_id: "abcd",
+        vendor_service:,
+        vendor_service_rate: rate,
+        begin_lat: 1.5,
+        begin_lng: 2.5,
+        began_at: t,
+      )
+    end
+    it "errors if the customer already has an ongoing trip" do
+      ongoing = Suma::Fixtures.mobility_trip(customer:).ongoing.create
+      expect do
+        trip = described_class.start_trip(
+          customer:,
+          vehicle_id: "abcd",
+          vendor_service:,
+          rate:,
+          lat: 1.5,
+          lng: 2.5,
+          at: t,
+        )
+      end.to raise_error(described_class::OngoingTrip)
+    end
+  end
+
+  describe "end_trip" do
+    it "ends the trip" do
+      ongoing = Suma::Fixtures.mobility_trip(customer:).ongoing.create
+      ongoing.end_trip(lat: 1, lng: 2, at: t + 5)
+      expect(ongoing.refresh).to have_attributes(
+        end_lat: 1, end_lng: 2, ended_at: t + 5,
+      )
+    end
+    it "creates a charge using the linked rate" do
+    end
+  end
+
+  describe "validations" do
+    it "fails if the customer has multiple ongoing trips" do
+      Suma::Fixtures.mobility_trip(customer:).ended.create
+      Suma::Fixtures.mobility_trip(customer:).ongoing.create
+      expect do
+        Suma::Fixtures.mobility_trip(customer:).ongoing.create
+      end.to raise_error(Sequel::UniqueConstraintViolation, /one_active_ride_per_customer/)
+    end
+    it "fails if end fields are not set together" do
+      expect do
+        Suma::Fixtures.mobility_trip(customer:).ended.create(end_lat: nil)
+      end.to raise_error(Sequel::ConstraintViolation, /end_fields_set_together/)
+    end
+  end
+end

--- a/spec/suma/mobility/trip_spec.rb
+++ b/spec/suma/mobility/trip_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe "Suma::Mobility::Trip", :db do
     end
   end
 
+  describe "start_trip_from_vehicle" do
+    it "uses vehicle params for the trip" do
+      v = Suma::Fixtures.mobility_vehicle.create
+      trip = described_class.start_trip_from_vehicle(customer:, vehicle: v, rate:)
+      expect(trip).to have_attributes(
+        vehicle_id: v.vehicle_id,
+        vendor_service: be === v.vendor_service,
+        begin_lat: v.lat,
+        begin_lng: v.lng,
+      )
+    end
+  end
+
   describe "end_trip" do
     it "ends the trip" do
       ongoing = Suma::Fixtures.mobility_trip(customer:).ongoing.create

--- a/spec/suma/mobility/vendor_adapter_spec.rb
+++ b/spec/suma/mobility/vendor_adapter_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "suma/mobility/vendor_adapter"
+
+RSpec.describe Suma::Mobility::VendorAdapter, :db do
+  describe "registry" do
+    it "returns a registered adapter" do
+      expect(described_class.create(:fake)).to be_a(Suma::Mobility::FakeVendorAdapter)
+      expect(described_class.create("fake")).to be_a(Suma::Mobility::FakeVendorAdapter)
+    end
+
+    it "raises for an unknown adapter" do
+      expect do
+        described_class.create(:blah)
+      end.to raise_error(described_class::UnknownAdapter)
+    end
+  end
+
+  describe "FakeVendorAdapter" do
+    let(:ad) { Suma::Mobility::FakeVendorAdapter.new }
+
+    it "can start and stop" do
+      expect(ad.begin_trip(nil, nil)).to be_a(described_class::BeginTripResult)
+      trip = Suma::Fixtures.mobility_trip.ongoing.create
+      expect(ad.end_trip(trip)).to be_a(described_class::EndTripResult)
+    end
+
+    it "returns the charge based on the rate" do
+      rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).create
+      trip = Suma::Fixtures.mobility_trip.create(began_at: 5.minutes.ago, vendor_service_rate: rate)
+      endres = ad.end_trip(trip)
+      expect(endres).to have_attributes(
+        cost_cents: 200,
+        cost_currency: "USD",
+        duration_minutes: 5,
+      )
+    end
+  end
+end

--- a/spec/suma/vendor/service_rate_spec.rb
+++ b/spec/suma/vendor/service_rate_spec.rb
@@ -75,4 +75,18 @@ RSpec.describe "Suma::Vendor::ServiceRate", :db do
       expect(r.discount_percentage(5)).to be_zero
     end
   end
+
+  describe "localization" do
+    it "can describe its cost template and vars" do
+      r = Suma::Fixtures.vendor_service_rate.unit_amount(100).create
+      expect(r.localization_vars).to eq(
+        {surcharge_cents: 0, surcharge_currency: "USD", unit_cents: 100, unit_currency: "USD"},
+      )
+
+      r = Suma::Fixtures.vendor_service_rate.surcharge(150).create
+      expect(r.localization_vars).to eq(
+        {surcharge_cents: 150, surcharge_currency: "USD", unit_cents: 0, unit_currency: "USD"},
+      )
+    end
+  end
 end

--- a/spec/suma/vendor/service_rate_spec.rb
+++ b/spec/suma/vendor/service_rate_spec.rb
@@ -8,6 +8,19 @@ RSpec.describe "Suma::Vendor::ServiceRate", :db do
     expect(p).to be_a(described_class)
   end
 
+  it "has associations to vendor service" do
+    svc1 = Suma::Fixtures.vendor_service.create
+    svc2 = Suma::Fixtures.vendor_service.create
+    r = Suma::Fixtures.vendor_service_rate.for_service(svc1).create
+    expect(svc1.rates).to contain_exactly(be === r)
+
+    expect(svc2.rates).to be_empty
+    svc2.add_rate(r)
+    expect(svc2.rates).to contain_exactly(be === r)
+
+    expect(r.refresh.services).to include(be === svc1, be === svc2)
+  end
+
   describe "calculate_total" do
     it "multiplies units by unit cost" do
       r = Suma::Fixtures.vendor_service_rate(unit_amount: Money.new(500)).create

--- a/spec/suma/vendor/service_rate_spec.rb
+++ b/spec/suma/vendor/service_rate_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::Vendor::ServiceRate", :db do
+  let(:described_class) { Suma::Vendor::ServiceRate }
+
+  it "can fixture itself" do
+    p = Suma::Fixtures.vendor_service_rate.create
+    expect(p).to be_a(described_class)
+  end
+
+  describe "calculate_total" do
+    it "multiplies units by unit cost" do
+      r = Suma::Fixtures.vendor_service_rate(unit_amount: Money.new(500)).create
+      expect(r.calculate_total(5)).to cost("$25")
+    end
+    it "applies a surcharge" do
+      r = Suma::Fixtures.vendor_service_rate(unit_amount: Money.new(500), surcharge: Money.new(50)).create
+      expect(r.calculate_total(5)).to cost("$25.50")
+    end
+    it "applies a unit offset" do
+      r = Suma::Fixtures.vendor_service_rate(unit_amount: Money.new(500), unit_offset: 3).create
+      expect(r.calculate_total(5)).to cost("$10")
+    end
+    it "cannot use a negative unit offset" do
+      r = Suma::Fixtures.vendor_service_rate(unit_amount: Money.new(500), unit_offset: 30).create
+      expect(r.calculate_total(5)).to cost("$0")
+    end
+  end
+  describe "calculate_undiscounted_total" do
+    it "calculates the total of the linked undiscounted total" do
+      r = Suma::Fixtures.vendor_service_rate(surcharge: Money.new(250)).
+        discounted_by(0.75).
+        create
+      expect(r.calculate_undiscounted_total(5)).to cost("$10")
+    end
+    it "returns calculate_total if there is no undiscounted total" do
+      r = Suma::Fixtures.vendor_service_rate(surcharge: Money.new(50)).create
+      expect(r.calculate_undiscounted_total(5)).to cost("$0.50")
+    end
+  end
+  describe "discount" do
+    it "returns the discount" do
+      r = Suma::Fixtures.vendor_service_rate(surcharge: Money.new(250)).
+        discounted_by(0.75).
+        create
+      expect(r.discount(5)).to cost("$7.50")
+    end
+    it "can calculate a 0% discount" do
+      r = Suma::Fixtures.vendor_service_rate(surcharge: Money.new(50)).create
+      expect(r.discount(5)).to cost("$0")
+    end
+  end
+  describe "discount_percentage" do
+    it "returns the integer discount percentage" do
+      r = Suma::Fixtures.vendor_service_rate(surcharge: Money.new(250)).
+        discounted_by(0.75).
+        create
+      expect(r.discount_percentage(5)).to eq(75)
+    end
+    it "can calculate a 0% discount" do
+      r = Suma::Fixtures.vendor_service_rate(surcharge: Money.new(50)).create
+      expect(r.discount_percentage(5)).to be_zero
+    end
+  end
+end

--- a/spec/suma/vendor/service_spec.rb
+++ b/spec/suma/vendor/service_spec.rb
@@ -18,4 +18,23 @@ RSpec.describe "Suma::Vendor::Service", :db do
     vs = Suma::Fixtures.vendor_service.mobility.create
     expect(vs.mobility_adapter).to be_a(Suma::Mobility::FakeVendorAdapter)
   end
+
+  describe "one_rate" do
+    let(:vs) { Suma::Fixtures.vendor_service.create }
+
+    it "returns the first rate" do
+      r = Suma::Fixtures.vendor_service_rate.for_service(vs).create
+      expect(vs.one_rate).to be === r
+    end
+
+    it "errors if there are no rates" do
+      expect { vs.one_rate }.to raise_error(/no rates/)
+    end
+
+    it "errors if there is more than one rate defined" do
+      Suma::Fixtures.vendor_service_rate.for_service(vs).create
+      Suma::Fixtures.vendor_service_rate.for_service(vs).create
+      expect { vs.one_rate }.to raise_error(/too many rates/)
+    end
+  end
 end

--- a/spec/suma/vendor/service_spec.rb
+++ b/spec/suma/vendor/service_spec.rb
@@ -13,4 +13,9 @@ RSpec.describe "Suma::Vendor::Service", :db do
     expect(vs.categories).to contain_exactly(have_attributes(slug: "food"))
     Suma::Fixtures.vendor_service.food.create
   end
+
+  it "can create mobility vendor adapters" do
+    vs = Suma::Fixtures.vendor_service.mobility.create
+    expect(vs.mobility_adapter).to be_a(Suma::Mobility::FakeVendorAdapter)
+  end
 end


### PR DESCRIPTION
- The `/v1/mobility/vehicle` endpoint returns the rate used for trips with the vehicle.
- Add `/v1/mobility/begin_trip`, which requires the vendor service id, the vehicle id, and the rate id. Only one trip can be active as a time (constraint set up in #24)
- Add `/v1/mobility/end_trip`. Just lat/lng required, since we can depend on having only one ongoing trip to end.
- Add a 'mobility vendor adapter' system. It defines the interface that we'll build against 3rd parties, that we will use to actually begin and end trips (via SMS or API). Right now we only have a 'fake' adapter. The spin bootstrapping is updated to use the Fake adapter for now.
- The fake adapter uses the rate to calculate the total.
- When a trip is ended, we create a charge with the discounted total (from the adapter) and the undiscounted total (calculated from the rate directly).
- Expose an 'ongoing trip' field on the current customer entity so we can see if we're in a trip or not.
- The rate has localization information- we can use [this](https://www.i18next.com/translation-function/formatting#currency) to localize with it.