### PR TITLE
Fix precision issues, lower zoom, readonly mode, discount pricing

### DIFF
--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -71,7 +71,8 @@ Sequel.migration do
       text :name, null: false, default: ""
       text :note, null: false, default: ""
       text :timezone, null: false, default: "America/Los_Angeles"
-      text :registered_env, null: false
+
+      timestamptz :onboarding_verified_at, null: true
 
       foreign_key :legal_entity_id, :legal_entities, null: false, on_delete: :restrict
     end

--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -62,7 +62,9 @@ class Suma::API::Auth < Suma::API::V1
       me = Suma::Customer.with_us_phone(params[:phone])
       begin
         Suma::Customer::ResetCode::Unusable if me.nil?
-        unless Suma::Customer.skip_verification?(me)
+        if Suma::Customer.skip_verification?(me)
+          me.update(onboarding_verified_at: Time.now)
+        else
           Suma::Customer::ResetCode.use_code_with_token(params[:token]) do |code|
             raise Suma::Customer::ResetCode::Unusable unless code.customer === me
           end

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -74,6 +74,8 @@ module Suma::API
 
   class CurrentCustomerEntity < Suma::Service::Entities::CurrentCustomer
     expose :ongoing_trip, with: MobilityTripEntity
+    expose :read_only_mode?, as: :read_only_mode
+    expose :read_only_reason
   end
 
   class LedgerLineEntity < BaseEntity

--- a/lib/suma/fixtures/customers.rb
+++ b/lib/suma/fixtures/customers.rb
@@ -68,43 +68,12 @@ module Suma::Fixtures::Customers
     self.add_linked_legal_entity(opts)
   end
 
-  decorator :registered_as_stripe_customer, presave: true do |json=nil|
-    if json.nil?
-      json = STRIPE_JSON.dup
-      json["id"] = "cus_fixtured_#{SecureRandom.hex(8)}"
-    end
-    self.stripe.update(stripe_customer_json: json)
+  decorator :onboarding_verified do |t=Time.now|
+    self.onboarding_verified_at = t
   end
 
-  STRIPE_JSON = {
-    "id" => "cus_xyz",
-    "object" => "customer",
-    "account_balance" => 0,
-    "created" => 1_529_818_867,
-    "currency" => "usd",
-    "default_source" => nil,
-    "delinquent" => false,
-    "description" => nil,
-    "discount" => nil,
-    "email" => nil,
-    "invoice_prefix" => "A6D2E24",
-    "livemode" => false,
-    "metadata" => {
-    },
-    "shipping" => nil,
-    "sources" => {
-      "object" => "list",
-      "data" => [],
-      "has_more" => false,
-      "total_count" => 0,
-      "url" => "/v1/customers/cus_D6eGmbqyejk8s9/sources",
-    },
-    "subscriptions" => {
-      "object" => "list",
-      "data" => [],
-      "has_more" => false,
-      "total_count" => 0,
-      "url" => "/v1/customers/cus_D6eGmbqyejk8s9/subscriptions",
-    },
-  }.freeze
+  decorator :with_cash_ledger, presave: true do |amount: nil|
+    led = Suma::Payment.ensure_cash_ledger(self)
+    Suma::Fixtures.book_transaction.to(led).create(amount:) if amount
+  end
 end

--- a/lib/suma/mobility.rb
+++ b/lib/suma/mobility.rb
@@ -7,7 +7,7 @@ module Suma::Mobility
   # to get an integer coordinate?
   COORD2INT_FACTOR = 10_000_000
   # Convert an integer coordinate back to a float.
-  INT2COORD_FACTOR = 1.0 / COORD2INT_FACTOR
+  INT2COORD_FACTOR = BigDecimal("1") / COORD2INT_FACTOR
   COORD_RANGE = -180.0..180.0
   INTCOORD_RANGE = (-180.0 * COORD2INT_FACTOR)..(180.0 * COORD2INT_FACTOR)
 

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -32,8 +32,7 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
   end
 
   def self.start_trip(customer:, vehicle_id:, vendor_service:, rate:, lat:, lng:, at: Time.now)
-    raise Suma::Payment::InsufficientFunds, "customer #{customer.id} has a negative balance so cannot start a trip" if
-      customer.payment_account.total_balance <= Money.new(0)
+    customer.read_only_mode!
     self.db.transaction(savepoint: true) do
       return self.create(
         customer:,

--- a/lib/suma/service.rb
+++ b/lib/suma/service.rb
@@ -158,6 +158,14 @@ class Suma::Service < Grape::API
     )
   end
 
+  rescue_from Suma::Customer::ReadOnlyMode do |e|
+    merror!(
+      409,
+      "Customer is in read-only mode and cannot be updated: #{e.message}",
+      code: e.message,
+    )
+  end
+
   rescue_from :all do |e|
     status = e.respond_to?(:status) ? e.status : 500
     error_id = SecureRandom.uuid

--- a/spec/suma/api/auth_spec.rb
+++ b/spec/suma/api/auth_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Suma::API::Auth, :db do
       post("/v1/auth/verify", phone: c.phone, token: "abc")
 
       expect(last_response).to have_status(200)
+      expect(c.refresh).to have_attributes(onboarding_verified?: true)
     end
 
     it "returns 403 if the phone number does not map to a customer" do

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Suma::API::Mobility, :db do
   include Rack::Test::Methods
 
   let(:app) { described_class.build_app }
-  let(:customer) { Suma::Fixtures.customer.create }
+  let(:customer) { Suma::Fixtures.customer.onboarding_verified.with_cash_ledger(amount: money("$15")).create }
 
   before(:each) do
     login_as(customer)

--- a/spec/suma/mobility/trip_spec.rb
+++ b/spec/suma/mobility/trip_spec.rb
@@ -89,6 +89,20 @@ RSpec.describe "Suma::Mobility::Trip", :db do
       expect(trip.charge.book_transactions).to have_length(1)
     end
 
+    it "uses the actual charge if there is no discount" do
+      rate = Suma::Fixtures.vendor_service_rate.unit_amount(20).create
+      trip = Suma::Fixtures.mobility_trip.
+        ongoing.
+        create(began_at: 211.seconds.ago, vendor_service_rate: rate, customer:)
+      trip.end_trip(lat: 1, lng: 2)
+      expect(trip.refresh).to have_attributes(end_lat: 1, end_lng: 2)
+      expect(trip.charge).to have_attributes(
+        undiscounted_subtotal: cost("$0.70"),
+        discounted_subtotal: cost("$0.70"),
+      )
+      expect(trip.charge.book_transactions).to have_length(1)
+    end
+
     it "creates no transactions for a $0 trip" do
       rate = Suma::Fixtures.vendor_service_rate.unit_amount(0).surcharge(0).create
       trip = Suma::Fixtures.mobility_trip.

--- a/spec/suma/service_spec.rb
+++ b/spec/suma/service_spec.rb
@@ -69,6 +69,10 @@ class Suma::API::TestService < Suma::Service
     raise Suma::LockFailed
   end
 
+  get :read_only_mode do
+    raise Suma::Customer::ReadOnlyMode, "blah"
+  end
+
   get :unhandled do
     1 / 0
   end
@@ -243,6 +247,17 @@ RSpec.describe Suma::Service, :db do
     expect(last_response_json_body).to match(
       error: hash_including(
         code: "lock_failed",
+        status: 409,
+      ),
+    )
+  end
+
+  it "uses a consistent shape for ReadOnlyMode errors" do
+    get "/read_only_mode"
+    expect(last_response).to have_status(409)
+    expect(last_response_json_body).to match(
+      error: hash_including(
+        code: "blah",
         status: 409,
       ),
     )

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -167,7 +167,7 @@ export default class MapBuilder {
       })
       .on("click", (e) => {
         if (!this._vehicleSelected && !this.isScooterCentered(e.latlng)) {
-          this._map.flyTo([e.latlng.lat + this._latOffset, e.latlng.lng], 20, {
+          this._map.flyTo([e.latlng.lat + this._latOffset, e.latlng.lng], 18, {
             animate: true,
             duration: 1.3,
             easeLinearity: 1,


### PR DESCRIPTION
Fix discrepancy with undiscounted pricing

Needed to use the real undiscounted price,
not a calculated guess.

Fixes https://github.com/lithictech/suma/issues/64

---

Backend support for 'readonly' mode

Backend for https://github.com/lithictech/suma/issues/46

Also add field for onboarding verification.

---

Cannot start a trip if you have no balance

Fixes https://github.com/lithictech/suma/issues/63

---

Use a lower zoom level when clicking a scooter

20 is too zoomed in, it's disorienting

---

Fix precision issues looking up scooter

Fixes https://github.com/lithictech/suma/issues/62