### PR TITLE
Ledger improvements

### DIFF
--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -342,6 +342,7 @@ Sequel.migration do
 
       foreign_key :originating_ledger_id, :payment_ledgers, index: true
       foreign_key :receiving_ledger_id, :payment_ledgers, index: true
+      foreign_key :associated_vendor_service_category_id, :vendor_service_categories
 
       int :amount_cents, null: false
       text :amount_currency, null: false

--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -345,7 +345,7 @@ Sequel.migration do
 
       int :amount_cents, null: false
       text :amount_currency, null: false
-      constraint(:positive_amount, Sequel.lit("amount_cents > 0"))
+      constraint(:amount_not_negative, Sequel.lit("amount_cents >= 0"))
 
       text :memo, null: false
     end

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -6,11 +6,12 @@ module Suma::Payment
   # if a vendor wants to be paid only in scrip or something else).
   def self.ensure_cash_ledger(customer)
     customer.payment_account ||= Suma::Payment::Account.create(customer:)
-    cash_category = Suma::Vendor::ServiceCategory.find_or_create(name: "Cash")
-    ledger = customer.payment_account.ledgers.find { |led| led.vendor_service_categories.include?(cash_category) }
+    ledger = customer.payment_account.cash_ledger
     return ledger if ledger
     ledger = customer.payment_account.add_ledger({currency: Suma.default_currency})
+    cash_category = Suma::Vendor::ServiceCategory.find_or_create(name: "Cash")
     ledger.add_vendor_service_category(cash_category)
+    customer.payment_account.associations.delete(:cash_ledger)
     return ledger
   end
 end

--- a/lib/suma/payment/account.rb
+++ b/lib/suma/payment/account.rb
@@ -88,6 +88,7 @@ class Suma::Payment::Account < Suma::Postgres::Model(:payment_accounts)
         amount: c.amount,
         originating_ledger: c.ledger,
         receiving_ledger: Suma::Payment::Account.lookup_platform_vendor_service_category_ledger(c.category),
+        associated_vendor_service_category: c.category,
         memo:,
       )
     end

--- a/lib/suma/payment/account.rb
+++ b/lib/suma/payment/account.rb
@@ -52,7 +52,7 @@ class Suma::Payment::Account < Suma::Postgres::Model(:payment_accounts)
   end
 
   def find_chargeable_ledgers(vendor_service, amount, allow_negative_balance: false)
-    raise ArgumentError, "amount must be positive, got #{amount.format}" unless amount.positive?
+    raise ArgumentError, "amount cannot be negative, got #{amount.format}" if amount.negative?
     raise Suma::InvalidPrecondition, "#{self.inspect} has no ledgers" if self.ledgers.empty?
     contributions = []
     self.ledgers.each do |led|

--- a/lib/suma/payment/book_transaction.rb
+++ b/lib/suma/payment/book_transaction.rb
@@ -8,4 +8,5 @@ class Suma::Payment::BookTransaction < Suma::Postgres::Model(:payment_book_trans
 
   many_to_one :originating_ledger, class: "Suma::Payment::Ledger"
   many_to_one :receiving_ledger, class: "Suma::Payment::Ledger"
+  many_to_one :associated_vendor_service_category, class: "Suma::Vendor::ServiceCategory"
 end

--- a/lib/suma/postgres/model_utilities.rb
+++ b/lib/suma/postgres/model_utilities.rb
@@ -190,6 +190,12 @@ module Suma::Postgres::ModelUtilities
     return self.find(params)
   end
 
+  def find!(params)
+    x = self[params]
+    return x if x
+    raise Suma::InvalidPostcondition, "No row matching #{self.class.name}[#{params}]"
+  end
+
   module InstanceMethods
     # Return a human-readable representation of the object as a String suitable for debugging.
     def inspect
@@ -332,6 +338,12 @@ module Suma::Postgres::ModelUtilities
   end
 
   module DatasetMethods
+    def find!(**params)
+      x = self[params]
+      return x if x
+      raise Suma::InvalidPostcondition, "No matching dataset row (params: #{params})"
+    end
+
     # Helper for applying multiple conditions for Sequel, where some can be nil.
     def reduce_expr(op_symbol, operands, method: :where)
       return self if operands.blank?

--- a/spec/suma/customer_spec.rb
+++ b/spec/suma/customer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Suma::Customer", :db do
 
   describe "associations" do
     it "has an ongoing_trip association" do
-      c = Suma::Fixtures.customer.create
+      c = Suma::Fixtures.customer.with_cash_ledger.create
       Suma::Fixtures.ledger.customer(c).category(:mobility).create # So we can end trip
       expect(c.ongoing_trip).to be_nil
       t = Suma::Fixtures.mobility_trip.ongoing.create(customer: c)

--- a/spec/suma/mobility/trip_spec.rb
+++ b/spec/suma/mobility/trip_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "Suma::Mobility::Trip", :db do
           receiving_ledger: Suma::Payment::Account.lookup_platform_vendor_service_category_ledger(mobility),
           amount: cost("$0.70"),
           memo: "Suma Mobility - Super Scoot",
+          associated_vendor_service_category: be === mobility,
         ),
       )
     end

--- a/spec/suma/mobility/trip_spec.rb
+++ b/spec/suma/mobility/trip_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Suma::Mobility::Trip", :db do
   let(:described_class) { Suma::Mobility::Trip }
   let(:customer) { Suma::Fixtures.customer.onboarding_verified.with_cash_ledger(amount: money("$15")).create }
-  let(:vendor_service) { Suma::Fixtures.vendor_service.create }
+  let(:vendor_service) { Suma::Fixtures.vendor_service.mobility.create(external_name: "Super Scoot") }
   let(:rate) { Suma::Fixtures.vendor_service_rate.create }
   let(:t) { trunc_time(Time.now) }
 
@@ -91,7 +91,7 @@ RSpec.describe "Suma::Mobility::Trip", :db do
 
     it "uses the actual charge if there is no discount" do
       rate = Suma::Fixtures.vendor_service_rate.unit_amount(20).create
-      trip = Suma::Fixtures.mobility_trip.
+      trip = Suma::Fixtures.mobility_trip(vendor_service:).
         ongoing.
         create(began_at: 211.seconds.ago, vendor_service_rate: rate, customer:)
       trip.end_trip(lat: 1, lng: 2)
@@ -100,17 +100,32 @@ RSpec.describe "Suma::Mobility::Trip", :db do
         undiscounted_subtotal: cost("$0.70"),
         discounted_subtotal: cost("$0.70"),
       )
-      expect(trip.charge.book_transactions).to have_length(1)
+      mobility = Suma::Vendor::ServiceCategory.find!(slug: "mobility")
+      expect(trip.charge.book_transactions).to contain_exactly(
+        have_attributes(
+          originating_ledger: customer.payment_account.mobility_ledger!,
+          receiving_ledger: Suma::Payment::Account.lookup_platform_vendor_service_category_ledger(mobility),
+          amount: cost("$0.70"),
+          memo: "Suma Mobility - Super Scoot",
+        ),
+      )
     end
 
-    it "creates no transactions for a $0 trip" do
+    it "creates a $0 transaction for a $0 trip" do
+      Suma::Payment.ensure_cash_ledger(customer)
+      customer.refresh
       rate = Suma::Fixtures.vendor_service_rate.unit_amount(0).surcharge(0).create
       trip = Suma::Fixtures.mobility_trip.
         ongoing.
         create(began_at: 6.minutes.ago, vendor_service_rate: rate, customer:)
       trip.end_trip(lat: 1, lng: 2)
       expect(trip.charge).to have_attributes(discounted_subtotal: cost("$0"))
-      expect(trip.charge.book_transactions).to be_empty
+      expect(trip.charge.book_transactions).to contain_exactly(
+        have_attributes(
+          originating_ledger: customer.payment_account.mobility_ledger!,
+          amount: cost("$0"),
+        ),
+      )
     end
   end
 

--- a/spec/suma/payment_spec.rb
+++ b/spec/suma/payment_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Suma::Payment, :db do
     it "creates a payment account and cash ledger" do
       led = described_class.ensure_cash_ledger(customer)
       expect(led.vendor_service_categories).to contain_exactly(have_attributes(name: "Cash"))
+      expect(led).to be === customer.payment_account.cash_ledger
     end
 
     it "can reuse an existing cash ledger" do
@@ -15,6 +16,7 @@ RSpec.describe Suma::Payment, :db do
       customer.refresh
       led2 = described_class.ensure_cash_ledger(customer)
       expect(led2).to be === led1
+      expect(led1).to be === customer.payment_account.cash_ledger
     end
   end
 end

--- a/spec/suma/payments/account_spec.rb
+++ b/spec/suma/payments/account_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe "Suma::Payment::Account", :db do
   let(:account) { Suma::Fixtures.payment_account.create }
   let(:customer) { account.customer }
 
+  describe "associations" do
+    it "can find its cash ledger" do
+      acct = Suma::Fixtures.payment_account.create
+      expect(acct.cash_ledger).to be_nil
+      cashledger = Suma::Payment.ensure_cash_ledger(acct.customer)
+      expect(acct.refresh.cash_ledger).to be_a(Suma::Payment::Ledger)
+      expect(acct.cash_ledger).to be === cashledger
+    end
+  end
+
   describe "validations" do
     it "must have an owner" do
       pa = account

--- a/spec/suma/payments/account_spec.rb
+++ b/spec/suma/payments/account_spec.rb
@@ -135,9 +135,24 @@ RSpec.describe "Suma::Payment::Account", :db do
       expect(results).to all(be_a(Suma::Payment::BookTransaction))
       recip = Suma::Payment::Account.lookup_platform_vendor_service_category_ledger(food)
       expect(results).to contain_exactly(
-        have_attributes(originating_ledger: be === ledgers[0], receiving_ledger: be === recip, amount: cost("$2")),
-        have_attributes(originating_ledger: be === ledgers[1], receiving_ledger: be === recip, amount: cost("$2")),
-        have_attributes(originating_ledger: be === ledgers[2], receiving_ledger: be === recip, amount: cost("$2")),
+        have_attributes(
+          originating_ledger: be === ledgers[0],
+          receiving_ledger: be === recip,
+          associated_vendor_service_category: be === food,
+          amount: cost("$2"),
+        ),
+        have_attributes(
+          originating_ledger: be === ledgers[1],
+          receiving_ledger: be === recip,
+          associated_vendor_service_category: be === food,
+          amount: cost("$2"),
+        ),
+        have_attributes(
+          originating_ledger: be === ledgers[2],
+          receiving_ledger: be === recip,
+          associated_vendor_service_category: be === food,
+          amount: cost("$2"),
+        ),
       )
     end
   end

--- a/spec/suma/postgres/model_spec.rb
+++ b/spec/suma/postgres/model_spec.rb
@@ -165,6 +165,24 @@ RSpec.describe "Suma::Postgres::Model", :db do
     end
   end
 
+  describe "find!" do
+    let(:model_class) { Suma::Postgres::TestingPixie }
+
+    it "can error if an instance or dataset entry is not found" do
+      expect do
+        model_class.find!(name: "foo")
+      end.to raise_error(Suma::InvalidPostcondition, 'No row matching Class[{:name=>"foo"}]')
+
+      expect do
+        model_class.dataset.where(name: "foo").find!
+      end.to raise_error(Suma::InvalidPostcondition, "No matching dataset row (params: {})")
+
+      x = model_class.create(name: "foo")
+      expect(model_class.find!(name: "foo")).to be === x
+      expect(model_class.dataset.where(name: "foo").find!).to be === x
+    end
+  end
+
   context "async events", :async, db: :no_transaction do
     let(:instance) { Suma::Postgres::TestingPixie.new }
 


### PR DESCRIPTION
Record vendor service category when charging

Gives us an auditability of why a given ledger
was chosen for paying for a given service.

Fixes https://github.com/lithictech/suma/issues/57

---

Allow $0 book transactions

We need to create $0 transactions when, for example,
a trip is taken but nothing is charged.

Since book transactions are "free",
it is fine to allow this.
We probably don't want to allow $0 funding/payout transactions though.

Fixes https://github.com/lithictech/suma/issues/56

---

Add helpers for common ledgers (cash, mobility)

---

Add Model.find! helpers