### PR TITLE
Add public ledger API

### DIFF
--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -369,8 +369,11 @@ Sequel.migration do
       timestamptz :updated_at
 
       text :currency, null: false
+      text :name, null: false
 
       foreign_key :account_id, :payment_accounts, index: true
+
+      unique [:account_id, :name]
     end
 
     create_join_table(
@@ -385,6 +388,9 @@ Sequel.migration do
       primary_key :id
       timestamptz :created_at, null: false, default: Sequel.function(:now)
       timestamptz :updated_at
+      timestamptz :apply_at, null: false
+
+      text :opaque_id, null: false
 
       foreign_key :originating_ledger_id, :payment_ledgers, index: true
       foreign_key :receiving_ledger_id, :payment_ledgers, index: true
@@ -459,6 +465,8 @@ Sequel.migration do
       primary_key :id
       timestamptz :created_at, null: false, default: Sequel.function(:now)
       timestamptz :updated_at
+
+      text :opaque_id, null: false
 
       int :undiscounted_subtotal_cents, null: false
       text :undiscounted_subtotal_currency, null: false

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -86,15 +86,38 @@ module Suma::API
   end
 
   class LedgerLineEntity < BaseEntity
-    expose :at
-    expose :amount, with: MoneyEntity
+    expose :id
+    expose :opaque_id
+    expose :apply_at, as: :at
     expose :memo
+    expose :amount, with: MoneyEntity do |inst, opts|
+      if inst.directed?
+        inst.amount
+      else
+        inst.receiving_ledger === opts.fetch(:ledger) ? inst.amount : (inst.amount * -1)
+      end
+    end
+  end
+
+  class LedgerEntity < BaseEntity
+    expose :id
+    expose :name
+    expose :balance, with: MoneyEntity
   end
 
   class CustomerDashboardEntity < BaseEntity
     expose :payment_account_balance, with: MoneyEntity
     expose :lifetime_savings, with: MoneyEntity
     expose :ledger_lines, with: LedgerLineEntity
+  end
+
+  class LedgersViewEntity < BaseEntity
+    expose :total_balance, with: MoneyEntity
+    expose :ledgers, with: LedgerEntity
+    expose :recent_lines, with: LedgerLineEntity
+    expose :single_ledger_lines_first_page, with: LedgerLineEntity do |_, opts|
+      opts[:single_ledger_lines_first_page]
+    end
   end
 
   class FundingTransactionEntity < BaseEntity

--- a/lib/suma/api/ledgers.rb
+++ b/lib/suma/api/ledgers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "suma/payment/ledgers_view"
+require "suma/api"
+
+class Suma::API::Ledgers < Suma::API::V1
+  resource :ledgers do
+    desc "Return an overview of all ledgers including balances, and recent transactions."
+    get :overview do
+      me = current_customer
+      lv = Suma::Payment::LedgersView.new(me.payment_account&.ledgers || [])
+      first_page = []
+      if lv.ledgers.length == 1
+        first_page = lv.ledgers.first.combined_book_transactions_dataset
+        first_page = paginate(first_page, {page: 1, per_page: Suma::Service::PAGE_SIZE})
+        first_page = first_page.all.map { |led| led.directed(lv.ledgers.first) }
+      end
+      present lv, with: Suma::API::LedgersViewEntity, single_ledger_lines_first_page: first_page
+    end
+
+    route_param :id, type: Integer do
+      desc "Return a page of ledger lines."
+      params do
+        use :pagination
+      end
+      get :lines do
+        me = current_customer
+        me.payment_account or forbidden!
+        (ledger = me.payment_account.ledgers_dataset[params[:id]]) or forbidden!
+        ds = ledger.combined_book_transactions_dataset
+        ds = paginate(ds, params)
+        present_collection ds, with: Suma::API::LedgerLineEntity, ledger:
+      end
+    end
+  end
+end

--- a/lib/suma/api/payments.rb
+++ b/lib/suma/api/payments.rb
@@ -20,10 +20,12 @@ class Suma::API::Payments < Suma::API::V1
       (bank_account = c.legal_entity.bank_accounts_dataset.usable[params[:bank_account_id]]) or
         merror!(403, "Bank account not found", code: "resource_not_found")
       fx = bank_account.db.transaction do
+        now = Time.now
         fx = Suma::Payment::FundingTransaction.start_new(c.payment_account, amount: params[:amount], bank_account:)
         # TODO: Move this to the model layer and test it thoroughly,
         # it is too important to just have testing as a side effect in the endpoint.
         originated_book_transaction = Suma::Payment::BookTransaction.create(
+          apply_at: now,
           amount: fx.amount,
           originating_ledger: fx.platform_ledger,
           receiving_ledger: Suma::Payment.ensure_cash_ledger(c),

--- a/lib/suma/apps.rb
+++ b/lib/suma/apps.rb
@@ -11,6 +11,7 @@ require "suma/api"
 require "suma/async"
 require "suma/service"
 require "suma/api/auth"
+require "suma/api/ledgers"
 require "suma/api/me"
 require "suma/api/meta"
 require "suma/api/mobility"
@@ -28,6 +29,7 @@ module Suma::Apps
   class API < Suma::Service
     mount Suma::API::System
     mount Suma::API::Auth
+    mount Suma::API::Ledgers
     mount Suma::API::Me
     mount Suma::API::Meta
     mount Suma::API::Mobility

--- a/lib/suma/charge.rb
+++ b/lib/suma/charge.rb
@@ -14,6 +14,11 @@ class Suma::Charge < Suma::Postgres::Model(:charges)
                left_key: :charge_id,
                right_key: :book_transaction_id
 
+  def initialize(*)
+    super
+    self.opaque_id ||= Suma::Secureid.new_opaque_id("ch")
+  end
+
   def discounted_subtotal
     return self.book_transactions.sum(Money.new(0), &:amount)
   end

--- a/lib/suma/customer/dashboard.rb
+++ b/lib/suma/customer/dashboard.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "suma/customer"
+require "suma/payment/ledgers_view"
 
 class Suma::Customer::Dashboard
   def initialize(customer)
@@ -20,20 +21,6 @@ class Suma::Customer::Dashboard
   def ledger_lines
     pa = @customer.payment_account
     return [] if pa.nil?
-    lines = pa.ledgers.map(&:received_book_transactions).
-      flatten.
-      map { |bt| LedgerLine.new(at: bt.created_at, amount: bt.amount, memo: bt.memo) }
-    lines.concat(
-      pa.ledgers.map(&:originated_book_transactions).
-      flatten.
-      map { |bt| LedgerLine.new(at: bt.created_at, amount: -1 * bt.amount, memo: bt.memo) },
-    )
-    lines.sort_by!(&:at)
-    lines.reverse!
-    return lines
-  end
-
-  class LedgerLine < Suma::TypedStruct
-    attr_reader :at, :amount, :memo
+    return Suma::Payment::LedgersView.new(pa.ledgers).recent_lines
   end
 end

--- a/lib/suma/fixtures/book_transactions.rb
+++ b/lib/suma/fixtures/book_transactions.rb
@@ -12,6 +12,7 @@ module Suma::Fixtures::BookTransactions
     self.amount_cents ||= Faker::Number.between(from: 100, to: 100_00)
     self.amount_currency ||= "USD"
     self.memo ||= Faker::Lorem.words(number: 3).join(" ")
+    self.apply_at ||= Time.now
   end
 
   before_saving do |instance|

--- a/lib/suma/fixtures/ledgers.rb
+++ b/lib/suma/fixtures/ledgers.rb
@@ -15,6 +15,7 @@ module Suma::Fixtures::Ledgers
 
   before_saving do |instance|
     instance.account ||= Suma::Fixtures.payment_account.create
+    instance.name ||= Faker::Lorem.word
     instance
   end
 
@@ -31,5 +32,6 @@ module Suma::Fixtures::Ledgers
   decorator :category, presave: true do |name|
     raise ArgumentError, "#{name} must be a Symbol (the fixture decorator method)" unless name.is_a?(Symbol)
     self.add_vendor_service_category(Suma::Fixtures.vendor_service_category.send(name).create)
+    self.name ||= name
   end
 end

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -59,6 +59,7 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
     # instead of trying to figure out a solution to an impossible problem.
     raise Suma::InvalidPostcondition, "negative trip cost for #{self.inspect}" if result.cost_cents.negative?
     self.db.transaction do
+      now = Time.now
       self.update(end_lat: lat, end_lng: lng, ended_at: result.end_time)
       # The calculated rate can be different than the service actually
       # charges us, so if we aren't using a discount, always use
@@ -77,6 +78,7 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
       contributions = self.customer.payment_account!.find_chargeable_ledgers(
         self.vendor_service,
         result_cost,
+        now:,
         # At this point, ride has been taken and finished so we need to accept it
         # and deal with a potential negative balance.
         allow_negative_balance: true,

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -45,7 +45,7 @@ module Suma::Payment
    end
     ledger = payment_account.cash_ledger
     return ledger if ledger
-    ledger = payment_account.add_ledger({currency: Suma.default_currency})
+    ledger = payment_account.add_ledger({currency: Suma.default_currency, name: "Cash"})
     cash_category = Suma::Vendor::ServiceCategory.find_or_create(name: "Cash")
     ledger.add_vendor_service_category(cash_category)
     payment_account.associations.delete(:cash_ledger)

--- a/lib/suma/payment/book_transaction.rb
+++ b/lib/suma/payment/book_transaction.rb
@@ -9,4 +9,39 @@ class Suma::Payment::BookTransaction < Suma::Postgres::Model(:payment_book_trans
   many_to_one :originating_ledger, class: "Suma::Payment::Ledger"
   many_to_one :receiving_ledger, class: "Suma::Payment::Ledger"
   many_to_one :associated_vendor_service_category, class: "Suma::Vendor::ServiceCategory"
+
+  def initialize(*)
+    super
+    self.opaque_id ||= Suma::Secureid.new_opaque_id("bx")
+  end
+
+  # Return a copy of the receiver, but with id removed, and amount set to be positive or negative
+  # based on whether the receiver is the originating or receiving ledger.
+  # This is used in places we need to represent book transactions
+  # as ledger line items which have a directionality to them,
+  # and we do not have a ledger as the time to determine directionality.
+  #
+  # The returned instance is frozen so cannot be saved/updated.
+  def directed(relative_to_ledger)
+    dup = self.values.dup
+    case relative_to_ledger
+      when self.originating_ledger
+        dup[:amount_cents] *= -1
+      when self.receiving_ledger
+        nil
+      else
+        raise ArgumentError, "#{relative_to_ledger.inspect} is not associated with #{self.inspect}"
+    end
+    id = dup.delete(:id)
+    inst = self.class.new(dup)
+    inst.values[:_directed] = true
+    inst.values[:id] = id
+    inst.freeze
+    return inst
+  end
+
+  # Return true if the received is an output of +directed+.
+  def directed?
+    return self.values.fetch(:_directed, false)
+  end
 end

--- a/lib/suma/payment/ledger.rb
+++ b/lib/suma/payment/ledger.rb
@@ -13,6 +13,11 @@ class Suma::Payment::Ledger < Suma::Postgres::Model(:payment_ledgers)
                right_key: :category_id
   one_to_many :originated_book_transactions, class: "Suma::Payment::BookTransaction", key: :originating_ledger_id
   one_to_many :received_book_transactions, class: "Suma::Payment::BookTransaction", key: :receiving_ledger_id
+  one_to_many :combined_book_transactions, class: "Suma::Payment::BookTransaction", readonly: true do |_ds|
+    Suma::Payment::BookTransaction.
+      where(Sequel[originating_ledger_id: id] | Sequel[receiving_ledger_id: id]).
+      order(Sequel.desc(:apply_at), Sequel.desc(:id))
+  end
 
   def balance
     credits = self.received_book_transactions.sum(Money.new(0), &:amount)

--- a/lib/suma/payment/ledgers_view.rb
+++ b/lib/suma/payment/ledgers_view.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Suma::Payment::LedgersView
+  attr_reader :ledgers
+
+  def initialize(ledgers, now: Time.now)
+    @ledgers = ledgers || []
+    @now = now
+  end
+
+  def total_balance
+    return self.ledgers.sum(Money.new(0), &:balance)
+  end
+
+  def recent_lines
+    recent = @now - 60.days
+    lines = []
+    [:received_book_transactions_dataset, :originated_book_transactions_dataset].each do |dsmethod|
+      lines.concat(self.ledgers.map do |ledger|
+        ledger.send(dsmethod).where { apply_at > recent }.all.map { |bt| bt.directed(ledger) }
+      end.flatten)
+    end
+    lines = lines.sort_by(&:apply_at).reverse
+    return lines
+  end
+end

--- a/lib/suma/service.rb
+++ b/lib/suma/service.rb
@@ -27,6 +27,7 @@ class Suma::Service < Grape::API
   # Note that it is always 'rack.session' in code though.
   SESSION_COOKIE = "suma.session"
   DEFAULT_CORS_ORIGINS = [/localhost:\d+/, /192\.168\.\d{1,3}\.\d{1,3}:\d{3,5}/].freeze
+  PAGE_SIZE = 100
 
   configurable(:service) do
     setting :max_session_age, 30.days.to_i

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -253,7 +253,7 @@ module Suma::Service::Helpers
 
   params :pagination do
     optional :page, type: Integer, default: 1, values: (1..1_000_000)
-    optional :per_page, type: Integer, default: 100, values: (1..500)
+    optional :per_page, type: Integer, default: Suma::Service::PAGE_SIZE, values: (1..500)
   end
 
   params :searchable do

--- a/spec/suma/api/ledgers_spec.rb
+++ b/spec/suma/api/ledgers_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "suma/api/behaviors"
+require "suma/api/ledgers"
+
+RSpec.describe Suma::API::Ledgers, :db do
+  include Rack::Test::Methods
+
+  let(:app) { described_class.build_app }
+  let(:customer) { Suma::Fixtures.customer.create }
+  let(:bookfac) { Suma::Fixtures.book_transaction }
+
+  before(:each) do
+    login_as(customer)
+  end
+
+  describe "GET /v1/ledgers/overview" do
+    it "returns an overview of all ledgers" do
+      led1 = Suma::Fixtures.ledger.customer(customer).create(name: "A")
+      led2 = Suma::Fixtures.ledger.customer(customer).create(name: "B")
+      recent_xaction = bookfac.from(led1).create(apply_at: 20.days.ago, amount_cents: 100)
+      old_xaction = bookfac.to(led1).create(apply_at: 80.days.ago, amount_cents: 400)
+
+      get "/v1/ledgers/overview"
+
+      expect(last_response).to have_status(200)
+      expect(last_response_json_body).to include(
+        ledgers: contain_exactly(
+          include(id: led1.id, name: "A", balance: cost("$3")),
+          include(id: led2.id, name: "B", balance: cost("$0")),
+        ),
+        recent_lines: contain_exactly(
+          include(amount: cost("-$1"), at: match_time(recent_xaction.apply_at)),
+        ),
+        single_ledger_lines_first_page: [],
+        total_balance: cost("$3"),
+      )
+    end
+
+    it "returns the first page of ledger lines if the customer has a single ledger" do
+      led1 = Suma::Fixtures.ledger.customer(customer).create(name: "A")
+      recent_xaction = bookfac.from(led1).create(apply_at: 20.days.ago, amount_cents: 100)
+      old_xaction = bookfac.to(led1).create(apply_at: 80.days.ago, amount_cents: 400)
+
+      get "/v1/ledgers/overview"
+
+      expect(last_response).to have_status(200)
+      expect(last_response_json_body).to include(
+        ledgers: have_length(1),
+        total_balance: cost("$3"),
+        recent_lines: have_length(1),
+        single_ledger_lines_first_page: match(
+          [
+            include(amount: cost("-$1"), at: match_time(recent_xaction.apply_at)),
+            include(amount: cost("$4"), at: match_time(old_xaction.apply_at)),
+          ],
+        ),
+      )
+    end
+  end
+
+  describe "GET /v1/ledgers/:id/lines" do
+    it_behaves_like "an endpoint with pagination" do
+      let(:ledger) { Suma::Fixtures.ledger.customer(customer).create }
+      let(:url) { "/v1/ledgers/#{ledger.id}/lines" }
+      def make_item(i)
+        # Sorting is newest first, so the first items we create need to the the oldest.
+        t = Time.now - i.days
+        return Suma::Fixtures.book_transaction.from(ledger).create(amount_cents: 100 * (i + 1), apply_at: t)
+      end
+    end
+
+    it "403s if the ledger does not belong to the customer" do
+      led = Suma::Fixtures.ledger.create
+
+      get "/v1/ledgers/#{led.id}/lines"
+
+      expect(last_response).to have_status(403)
+    end
+  end
+end

--- a/spec/suma/api/me_spec.rb
+++ b/spec/suma/api/me_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Suma::API::Me, :db do
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.
-        that_includes(payment_account_balance: cost("$27"))
+        that_includes(payment_account_balance: cost("$27"), lifetime_savings: cost("$0"), ledger_lines: have_length(1))
     end
   end
 end

--- a/spec/suma/payment/book_transaction_spec.rb
+++ b/spec/suma/payment/book_transaction_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::Payment::BookTransaction", :db do
+  let(:described_class) { Suma::Payment::BookTransaction }
+
+  describe "directed" do
+    it "can represent debits and credits" do
+      bt = Suma::Fixtures.book_transaction.create(amount: money("$10"))
+      expect(bt).to_not be_directed
+
+      debit = bt.directed(bt.originating_ledger)
+      expect(debit).to have_attributes(id: bt.id, amount: cost("-$10"), directed?: true)
+
+      credit = bt.directed(bt.receiving_ledger)
+      expect(credit).to have_attributes(id: bt.id, amount: cost("$10"), directed?: true)
+
+      expect { debit.amount = money("$1") }.to raise_error(FrozenError)
+      expect { debit.save_changes }.to raise_error(Sequel::Error, /save frozen object/)
+    end
+  end
+end

--- a/spec/suma/payment/ledgers_view_spec.rb
+++ b/spec/suma/payment/ledgers_view_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "suma/payment/ledgers_view"
+
+RSpec.describe Suma::Payment::LedgersView, :db do
+  it "can represent empty ledgers" do
+    d = described_class.new([])
+    expect(d).to have_attributes(
+      total_balance: cost("$0"),
+      recent_lines: [],
+      ledgers: [],
+    )
+  end
+
+  it "can represent ledgers and transactions" do
+    account = Suma::Fixtures.payment_account.create
+    cash_ledger = Suma::Fixtures.ledger(account:).category(:cash).create(name: "Dolla")
+    grocery_ledger = Suma::Fixtures.ledger(account:).category(:food).create(name: "Grub")
+    Suma::Fixtures.book_transaction.from(cash_ledger).create(amount: money("$20"), apply_at: 20.days.ago)
+    Suma::Fixtures.book_transaction.from(grocery_ledger).create(amount: money("$5"), apply_at: 21.days.ago)
+    Suma::Fixtures.book_transaction.from(grocery_ledger).create(amount: money("$1"), apply_at: 80.days.ago)
+    Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$27"))
+    d = described_class.new(account.ledgers)
+    expect(d).to have_attributes(
+      total_balance: cost("$1"),
+      recent_lines: match(
+        [
+          have_attributes(amount: cost("$27")),
+          have_attributes(amount: cost("-$20")),
+          have_attributes(amount: cost("-$5")),
+        ],
+      ),
+      ledgers: have_same_ids_as(cash_ledger, grocery_ledger).ordered,
+    )
+  end
+end

--- a/spec/suma/payment_spec.rb
+++ b/spec/suma/payment_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Suma::Payment, :db do
       led = described_class.ensure_cash_ledger(customer)
       expect(led.vendor_service_categories).to contain_exactly(have_attributes(name: "Cash"))
       expect(led).to be === customer.payment_account.cash_ledger
+      expect(led).to have_attributes(name: "Cash")
     end
 
     it "can reuse an existing cash ledger" do


### PR DESCRIPTION
API changes:

- Add /v1/ledgers/overview, which returns a balance for all ledgers
  and recent items. It should be used for the main ledgers page,
  sort of like the dashboard is.
  There is some complexity to facilitate the
  common 'single ledger' scenario, to avoid having to make
  a call to /lines (see below) immediately.
  See the endpoint for more details.
- Add /v1/ledgers/:id/lines which returns a paginated list of
  book transactions.

Internal changes:

- Refactor the dashboard implementation to be shared
  with ledgers overview.
  It was previously not time-limited to just recent transactions.
- Add some convenience fields to different models, including:
  - Ledgers have a friendly 'name' (not user-editable yet)
  - Book transactions have an 'apply at', we should not use
    their created at time for this since it can be different.
  - Charges and book transactions have an 'opaque id'
    that can be presented to customers,
    usually for use with Customer Support.
- Add a 'directed' concept for book transactions so that
  callers, like the API, can get them relative to their
  originator or receiving ledger (ie, if a ledger originates,
  it gets a negative amount/is a debit).
- Remove 'ledger line' struct and entity,
  use directed book transactions instead.