### PR TITLE
Theme colors update and otp invalid phone redirect

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#f5cb82" />
     <meta
       name="description"
       content="Suma is a new digital justice nonprofit. We're here because technology has failed low-income people, people of color and other frontline communities."

--- a/webapp/public/locale/en/forms.json
+++ b/webapp/public/locale/en/forms.json
@@ -10,5 +10,6 @@
   "logout": "Logout",
   "get_started": "Get Started",
   "get_started_intro": "To start a new account, or sign into your existing account, please enter your phone number. We will send you a verification code to confirm the phone number.",
-  "otp_verify": "Verify Code"
+  "otp_verify": "Verify Code",
+  "phone_placeholder": "555-111-2222"
 }

--- a/webapp/public/locale/en/messages.json
+++ b/webapp/public/locale/en/messages.json
@@ -1,3 +1,3 @@
 {
-	"otp_resent": "Code resent successfully, enter the code you received."
+	"otp_resent": "New code sent to {{ phone }}."
 }

--- a/webapp/src/assets/styles/theme.scss
+++ b/webapp/src/assets/styles/theme.scss
@@ -19,8 +19,11 @@ $btn-border-radius-lg: .5rem;
 $theme-colors: map-merge-multiple(
   $theme-colors,
   (
-    "primary": rgb(245, 203, 130),
-    "primary-dark": #a77948
+    "primary": #f5cb82,
+    "primary-dark": #a77948,
+    "suma-blue": #a7b8d9,
+    "light": #f2f2f2,
+    "dark": #0d0d0d
   ),
 );
 // Adds theme colors to sub-classes e.g. text-suma, bg-suma

--- a/webapp/src/components/FormError.js
+++ b/webapp/src/components/FormError.js
@@ -2,12 +2,17 @@ import clsx from "clsx";
 import i18next from "i18next";
 import React from "react";
 
-export default function FormError({ error, noMargin, component }) {
+export default function FormError({ error, noMargin, center, component, className }) {
   if (!error) {
     return null;
   }
   const Component = component || "p";
   const msg = React.isValidElement(error) ? error : i18next.t(error, { ns: "errors" });
-  const cls = clsx("d-block text-danger small", noMargin && "m-0");
+  const cls = clsx(
+    "d-block text-danger small",
+    noMargin && "m-0",
+    center && "text-center",
+    className
+  );
   return <Component className={cls}>{msg}</Component>;
 }

--- a/webapp/src/components/FormSuccess.js
+++ b/webapp/src/components/FormSuccess.js
@@ -1,10 +1,24 @@
+import clsx from "clsx";
 import i18next from "i18next";
+import _ from "lodash";
 import React from "react";
 
-export default function FormSuccess({ message }) {
+export default function FormSuccess({ message, center, ns, className }) {
   if (!message) {
     return null;
   }
-  const msg = i18next.t(message, { ns: "messages" });
-  return <p className="d-block text-success small">{msg}</p>;
+  let msgkey, vars;
+  if (_.isArray(message)) {
+    msgkey = message[0];
+    vars = message[1];
+  } else {
+    msgkey = message;
+    vars = {};
+  }
+  const msg = i18next.t(msgkey, { ns: ns || "messages", ...vars });
+  return (
+    <p className={clsx("d-block text-success small", center && "text-center", className)}>
+      {msg}
+    </p>
+  );
 }

--- a/webapp/src/components/PageLoader.js
+++ b/webapp/src/components/PageLoader.js
@@ -2,7 +2,7 @@ import loaderRing from "../assets/images/loader-ring.svg";
 import React from "react";
 
 /**
- * Render the screen loader overlay.
+ * Render the page loader icon centered.
  * This is used when you are loading information and want to
  * display the default loading ring icon as a child while
  * the information loads (ie, `return <PageLoader show />`).
@@ -14,7 +14,7 @@ export default function PageLoader({ show }) {
     return null;
   }
   return (
-    <div className={"text-center"}>
+    <div className="text-center">
       <img src={loaderRing} alt="loading" />
     </div>
   );

--- a/webapp/src/pages/OneTimePassword.js
+++ b/webapp/src/pages/OneTimePassword.js
@@ -22,10 +22,7 @@ const OneTimePassword = () => {
   const [error, setError] = useError();
   const [message, setMessage] = useState();
   const { state } = useLocation();
-  const { phoneNumber } = state;
-  const displayPhoneNumber = phoneNumber
-    ? formatPhoneNumber(phoneNumber)
-    : "(invalid phone number)";
+  const phoneNumber = state ? state.phoneNumber : undefined;
 
   useEffect(() => {
     const isEntireCode = otp.every((number) => number !== "");
@@ -34,7 +31,10 @@ const OneTimePassword = () => {
     } else {
       submitDisabled.turnOn();
     }
-  }, [submitDisabled, otp]);
+    if (!phoneNumber) {
+      navigate("/start", { replace: true });
+    }
+  }, [navigate, phoneNumber, submitDisabled, otp]);
 
   const handleOtpChange = (event, index) => {
     const { target } = event;
@@ -94,7 +94,7 @@ const OneTimePassword = () => {
       <TopNav />
       <p>
         Enter the code that you recieved on the phone number you provided{" "}
-        {displayPhoneNumber}
+        {formatPhoneNumber(phoneNumber)}
       </p>
       <Form noValidate onSubmit={handleOtpSubmit}>
         <fieldset>

--- a/webapp/src/pages/OneTimePassword.js
+++ b/webapp/src/pages/OneTimePassword.js
@@ -24,6 +24,12 @@ const OneTimePassword = () => {
   const { state } = useLocation();
   const phoneNumber = state ? state.phoneNumber : undefined;
 
+  React.useEffect(() => {
+    if (!phoneNumber) {
+      navigate("/start", { replace: true });
+    }
+  }, [navigate, phoneNumber]);
+
   useEffect(() => {
     const isEntireCode = otp.every((number) => number !== "");
     if (isEntireCode) {
@@ -31,10 +37,7 @@ const OneTimePassword = () => {
     } else {
       submitDisabled.turnOn();
     }
-    if (!phoneNumber) {
-      navigate("/start", { replace: true });
-    }
-  }, [navigate, phoneNumber, submitDisabled, otp]);
+  }, [navigate, submitDisabled, otp]);
 
   const handleOtpChange = (event, index) => {
     const { target } = event;
@@ -75,7 +78,7 @@ const OneTimePassword = () => {
   const handleResend = () => {
     setOtp(new Array(6).fill(""));
     setError(null);
-    setMessage("otp_resent");
+    setMessage(["otp_resent", { phone: formatPhoneNumber(phoneNumber) }]);
     const firstOtpField = document.getElementById("otpContainer").firstChild;
     firstOtpField.focus();
     api
@@ -92,9 +95,8 @@ const OneTimePassword = () => {
   return (
     <div className="main-container">
       <TopNav />
-      <p>
-        Enter the code that you recieved on the phone number you provided{" "}
-        {formatPhoneNumber(phoneNumber)}
+      <p className="text-center">
+        Enter the code that we sent to {formatPhoneNumber(phoneNumber)}:
       </p>
       <Form noValidate onSubmit={handleOtpSubmit}>
         <fieldset>
@@ -102,7 +104,7 @@ const OneTimePassword = () => {
           <div id="otpContainer" className="d-flex justify-content-center">
             {otp.map((data, index) => (
               <input
-                className="otp-field"
+                className="otp-field mb-2"
                 type="text"
                 name="otp"
                 maxLength="1"
@@ -118,12 +120,17 @@ const OneTimePassword = () => {
             ))}
           </div>
         </fieldset>
-        <FormError error={error} />
-        <FormSuccess message={message} />
+        <FormError error={error} center className="mb-1" />
+        <FormSuccess message={message} center className="mb-1" />
         <p className="text-muted small text-center mt-2">
-          Did not recieve a code?{" "}
-          <Button className="p-0 align-baseline" variant="link" onClick={handleResend}>
-            Resend code again.
+          Did not recieve a text message?{" "}
+          <Button
+            className="p-0 align-baseline"
+            size="sm"
+            variant="link"
+            onClick={handleResend}
+          >
+            Send a new code.
           </Button>
         </p>
         <FormButtons

--- a/webapp/src/pages/Start.js
+++ b/webapp/src/pages/Start.js
@@ -78,7 +78,7 @@ const Start = () => {
                 pattern="^(\+\d{1,2}\s)?\(?\d{3}\)?[\s-]\d{3}[\s-]\d{4}$"
                 minLength="14"
                 maxLength="14"
-                placeholder={i18n.t("phone", { ns: "forms" })}
+                placeholder={i18n.t("phone_placeholder", { ns: "forms" })}
                 value={phoneNumber}
                 disabled={inputDisabled.isOn}
                 aria-describedby="phoneRequired"


### PR DESCRIPTION
- Updated theme.scss colors that Alan provided in email
- In One-Time-Password, I added a condition to navigate("/start", { replace: true }) if the phoneNumber is empty (or when loading that route specifically without state provided)