### PR TITLE
Add validation support via react-hook-form

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -30,6 +30,7 @@
         "react-bootstrap": "^2.2.0",
         "react-dom": "^17.0.2",
         "react-helmet-async": "^1.3.0",
+        "react-hook-form": "^7.32.0",
         "react-i18next": "^11.16.1",
         "react-phone-number-input": "^3.1.46",
         "react-router-dom": "^6.2.2",
@@ -12044,6 +12045,21 @@
         "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.32.0.tgz",
+      "integrity": "sha512-AFUwl9MwVVnZZsFZW7Egc8PVyWem6c6/9FBq29Acsikm+8ecJCkqOn2Tl48GApFnXBgoBBEHC3zosjYvPfsGNg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-i18next": {
       "version": "11.16.1",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.16.1.tgz",
@@ -23509,6 +23525,12 @@
         "react-fast-compare": "^3.2.0",
         "shallowequal": "^1.1.0"
       }
+    },
+    "react-hook-form": {
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.32.0.tgz",
+      "integrity": "sha512-AFUwl9MwVVnZZsFZW7Egc8PVyWem6c6/9FBq29Acsikm+8ecJCkqOn2Tl48GApFnXBgoBBEHC3zosjYvPfsGNg==",
+      "requires": {}
     },
     "react-i18next": {
       "version": "11.16.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,6 +25,7 @@
     "react-bootstrap": "^2.2.0",
     "react-dom": "^17.0.2",
     "react-helmet-async": "^1.3.0",
+    "react-hook-form": "^7.32.0",
     "react-i18next": "^11.16.1",
     "react-phone-number-input": "^3.1.46",
     "react-router-dom": "^6.2.2",

--- a/webapp/public/locale/en/forms.json
+++ b/webapp/public/locale/en/forms.json
@@ -11,5 +11,9 @@
   "get_started": "Get Started",
   "get_started_intro": "To start a new account, or sign into your existing account, please enter your phone number. We will send you a verification code to confirm the phone number.",
   "otp_verify": "Verify Code",
-  "phone_placeholder": "555-111-2222"
+  "phone_placeholder": "555-111-2222",
+  "invalid_field": "This field is not valid.",
+  "invalid_required": "This field is required.",
+  "invalid_min_length": "Must be at least {{constraint}} characters.",
+  "invalid_max_length": "Cannot be more than {{constraint}} characters."
 }

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -30,6 +30,7 @@ import {
 } from "./state/useScreenLoader";
 import { UserProvider } from "./state/useUser";
 import React from "react";
+import { HelmetProvider } from "react-helmet-async";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 window.Promise = bluejay.Promise;
@@ -38,9 +39,11 @@ export default function App() {
   const { i18nextLoading } = useI18Next();
   return (
     <ScreenLoaderProvider>
-      <UserProvider>
-        {i18nextLoading ? <ScreenLoader show /> : <AppRoutes />}
-      </UserProvider>
+      <HelmetProvider>
+        <UserProvider>
+          {i18nextLoading ? <ScreenLoader show /> : <AppRoutes />}
+        </UserProvider>
+      </HelmetProvider>
     </ScreenLoaderProvider>
   );
 }

--- a/webapp/src/components/FormControlGroup.js
+++ b/webapp/src/components/FormControlGroup.js
@@ -1,0 +1,41 @@
+import useValidationError from "../state/useValidationError";
+import React from "react";
+import Form from "react-bootstrap/Form";
+
+export default function FormControlGroup({
+  name,
+  className,
+  as,
+  label,
+  Component,
+  register,
+  errors,
+  required,
+  pattern,
+  minLength,
+  maxLength,
+  ...rest
+}) {
+  const registerArgs = {};
+  if (required) {
+    registerArgs.required = true;
+  }
+  if (minLength) {
+    registerArgs.minLength = minLength;
+  }
+  if (maxLength) {
+    registerArgs.maxLength = maxLength;
+  }
+  if (pattern) {
+    registerArgs.pattern = pattern;
+  }
+  const C = Component || Form.Control;
+  const message = useValidationError(name, errors, registerArgs);
+  return (
+    <Form.Group className={className} controlId={name} as={as}>
+      <Form.Label>{label}</Form.Label>
+      <C {...register(name, registerArgs)} name={name} isInvalid={!!message} {...rest} />
+      <Form.Control.Feedback type="invalid">{message}</Form.Control.Feedback>
+    </Form.Group>
+  );
+}

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -7,13 +7,10 @@ import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/leaflet.markercluster";
 import React from "react";
 import ReactDOM from "react-dom";
-import { HelmetProvider } from "react-helmet-async";
 
 ReactDOM.render(
   <React.StrictMode>
-    <HelmetProvider>
-      <App />
-    </HelmetProvider>
+    <App />
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/webapp/src/pages/OnboardingSignup.js
+++ b/webapp/src/pages/OnboardingSignup.js
@@ -1,9 +1,9 @@
 import api from "../api";
 import FormButtons from "../components/FormButtons";
+import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
 import TopNav from "../components/TopNav";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
-import useToggle from "../shared/react/useToggle";
 import { extractErrorCode } from "../state/useError";
 import { useUser } from "../state/useUser";
 import { t } from "i18next";
@@ -11,12 +11,22 @@ import React from "react";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
+import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
-function OnboardingSignup() {
+export default function OnboardingSignup() {
   const navigate = useNavigate();
   const { setUser } = useUser();
-  const validated = useToggle(false);
+  const {
+    register,
+    handleSubmit,
+    clearErrors,
+    setValue,
+    formState: { errors },
+  } = useForm({
+    mode: "all",
+  });
+
   const [error, setError] = React.useState("");
   const [name, setName] = React.useState("");
   const [address, setAddress] = React.useState("");
@@ -24,13 +34,7 @@ function OnboardingSignup() {
   const [city, setCity] = React.useState("");
   const [state, setState] = React.useState("");
   const [zipCode, setZipCode] = React.useState("");
-  const handleFormSubmit = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (e.currentTarget.checkValidity() === false) {
-      validated.turnOn();
-      return;
-    }
+  const handleFormSubmit = () => {
     api
       .updateMe({
         name: name,
@@ -51,11 +55,19 @@ function OnboardingSignup() {
       });
   };
 
-  const handleInputChange = (e, set) => set(e.target.value);
+  const runSetter = (name, set, value) => {
+    clearErrors(name);
+    setValue(name, value);
+    set(value);
+  };
+
+  const handleInputChange = (e, set) => {
+    runSetter(e.target.name, set, e.target.value);
+  };
 
   const handleZipChange = (e) => {
     const v = e.target.value.replace(/\D/, "").slice(0, 5);
-    setZipCode(v);
+    runSetter(e.target.name, setZipCode, v);
   };
 
   const { state: supportedGeographies } = useAsyncFetch(api.getSupportedGeographies, {
@@ -79,76 +91,85 @@ function OnboardingSignup() {
               We will never share this information other than to verify your identity.
             </strong>
           </p>
-          <Form noValidate validated={validated.isOn} onSubmit={handleFormSubmit}>
-            <Form.Group className="mb-3" controlId="name">
-              <Form.Label>{t("name", { ns: "forms" })}</Form.Label>
-              <Form.Control
-                name="name"
-                value={name}
-                onChange={(e) => handleInputChange(e, setName)}
-                required
-              />
-            </Form.Group>
-            <Form.Group className="mb-3" controlId="address">
-              <Form.Label>{t("address1", { ns: "forms" })}</Form.Label>
-              <Form.Control
-                type="Text"
-                name="address"
-                value={address}
-                onChange={(e) => handleInputChange(e, setAddress)}
-                required
-              />
-            </Form.Group>
-            <Form.Group className="mb-3" controlId="address2">
-              <Form.Label>{t("address2", { ns: "forms" })}</Form.Label>
-              <Form.Control
-                type="text"
-                name="address2"
-                value={address2}
-                onChange={(e) => handleInputChange(e, setAddress2)}
-              />
-            </Form.Group>
-            <Form.Group className="mb-3" controlId="cityInput">
-              <Form.Label>{t("city", { ns: "forms" })}</Form.Label>
-              <Form.Control
-                type="text"
-                name="city"
-                value={city}
-                onChange={(e) => handleInputChange(e, setCity)}
-                required
-              />
-            </Form.Group>
+          <Form noValidate onSubmit={handleSubmit(handleFormSubmit)}>
+            <FormControlGroup
+              className="mb-3"
+              name="name"
+              label={t("name", { ns: "forms" })}
+              required
+              register={register}
+              errors={errors}
+              value={name}
+              onChange={(e) => handleInputChange(e, setName)}
+            />
+            <FormControlGroup
+              className="mb-3"
+              name="address"
+              label={t("address1", { ns: "forms" })}
+              type="text"
+              required
+              register={register}
+              errors={errors}
+              value={address}
+              onChange={(e) => handleInputChange(e, setAddress)}
+            />
+            <FormControlGroup
+              className="mb-3"
+              name="address2"
+              label={t("address2", { ns: "forms" })}
+              type="text"
+              register={register}
+              errors={errors}
+              value={address2}
+              onChange={(e) => handleInputChange(e, setAddress2)}
+            />
+            <FormControlGroup
+              className="mb-3"
+              name="city"
+              label={t("city", { ns: "forms" })}
+              type="text"
+              required
+              register={register}
+              errors={errors}
+              value={city}
+              onChange={(e) => handleInputChange(e, setCity)}
+            />
             <Row className="mb-3">
-              <Form.Group as={Col} controlId="stateInput">
-                <Form.Label>{t("state", { ns: "forms" })}</Form.Label>
-                <Form.Select
-                  value={state}
-                  onChange={(e) => handleInputChange(e, setState)}
-                  required
-                >
-                  <option disabled value="">
-                    Choose state...
-                  </option>
-                  {!!supportedGeographies.provinces &&
-                    supportedGeographies.provinces.map((state) => (
-                      <option key={state.value} value={state.value}>
-                        {state.label}
-                      </option>
-                    ))}
-                </Form.Select>
-              </Form.Group>
-              <Form.Group as={Col} controlId="zipInput">
-                <Form.Label>{t("zip", { ns: "forms" })}</Form.Label>
-                <Form.Control
-                  type="text"
-                  pattern="^[0-9]{5}(?:-[0-9]{4})?$"
-                  minLength="5"
-                  maxLength="10"
-                  value={zipCode}
-                  onChange={handleZipChange}
-                  required
-                />
-              </Form.Group>
+              <FormControlGroup
+                as={Col}
+                name="state"
+                label={t("state", { ns: "forms" })}
+                required
+                Component={Form.Select}
+                register={register}
+                errors={errors}
+                value={state}
+                onChange={(e) => handleInputChange(e, setState)}
+              >
+                <option disabled value="">
+                  Choose state...
+                </option>
+                {!!supportedGeographies.provinces &&
+                  supportedGeographies.provinces.map((state) => (
+                    <option key={state.value} value={state.value}>
+                      {state.label}
+                    </option>
+                  ))}
+              </FormControlGroup>
+              <FormControlGroup
+                as={Col}
+                name="zip"
+                label={t("zip", { ns: "forms" })}
+                type="text"
+                pattern="^[0-9]{5}(?:-[0-9]{4})?$"
+                minLength="5"
+                maxLength="10"
+                required
+                register={register}
+                errors={errors}
+                value={zipCode}
+                onChange={handleZipChange}
+              />
             </Row>
             <FormError error={error} />
             <FormButtons variant="success" back primaryProps={{ children: "Submit" }} />
@@ -158,5 +179,3 @@ function OnboardingSignup() {
     </div>
   );
 }
-
-export default OnboardingSignup;

--- a/webapp/src/state/useValidationError.js
+++ b/webapp/src/state/useValidationError.js
@@ -1,0 +1,27 @@
+import i18next from "i18next";
+
+/**
+ * Return the localized validation error value for an input.
+ * @param name Name of the input.
+ * @param errors Errors from react-hook-form.
+ * @param validations Object like {required: true, minLength: 3}.
+ * @returns {null|string}
+ */
+export default function useValidationError(name, errors, validations) {
+  const err = errors && errors[name];
+  if (!err) {
+    return null;
+  }
+  const errKey = errorKeys[err.type] || "forms:invalid_field";
+  const message = i18next.t(errKey, {
+    constraint: validations[err.type],
+    value: err.ref.value,
+  });
+  return message;
+}
+
+const errorKeys = {
+  required: "forms:invalid_required",
+  minLength: "forms:invalid_min_length",
+  maxLength: "forms:invalid_max_length",
+};


### PR DESCRIPTION
Add validation support via react-hook-form

Fixes https://github.com/lithictech/suma/issues/103

Implements it all on the onboarding page;
other pages still need to be updated,
like Add Funds (see #112).

Add `FormControlGroup` to unify some of the form duplication.

Add `useValidationError` for just working with validation errors
when we can't use `FormControlGroup`.

---

Mount helmet in App.js, not index.js