### PR TITLE
Ledger line items return charge details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ cop:
 fix:
 	bundle exec rubocop --auto-correct-all
 fmt: fix
+fmt-all:
+	@make fmt
+	@cd webapp && make fmt && make lint
+	@cd adminapp && make fmt && make lint
 
 up:
 	docker-compose up -d

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -105,6 +105,11 @@ module Suma::API
     end
   end
 
+  class LedgerLineUsageDetailsEntity < Grape::Entity
+    expose :code
+    expose :args
+  end
+
   class LedgerLineEntity < BaseEntity
     expose :id
     expose :opaque_id
@@ -113,10 +118,13 @@ module Suma::API
     expose :amount, with: MoneyEntity do |inst, opts|
       if inst.directed?
         inst.amount
+      elsif (ledger = opts[:ledger])
+        inst.receiving_ledger === ledger ? inst.amount : (inst.amount * -1)
       else
-        inst.receiving_ledger === opts.fetch(:ledger) ? inst.amount : (inst.amount * -1)
+        raise "Must use directed ledger lines or pass :ledger option"
       end
     end
+    expose :usage_details, with: LedgerLineUsageDetailsEntity
   end
 
   class LedgerEntity < BaseEntity

--- a/lib/suma/fixtures/funding_transactions.rb
+++ b/lib/suma/fixtures/funding_transactions.rb
@@ -24,6 +24,10 @@ module Suma::Fixtures::FundingTransactions
     instance
   end
 
+  decorator :member do |m|
+    self.originating_payment_account ||= m.payment_account
+  end
+
   decorator :with_fake_strategy do |strategy={}|
     strategy = Suma::Payment::FakeStrategy.create(**strategy) unless strategy.is_a?(Suma::Payment::FakeStrategy)
     self.fake_strategy = strategy

--- a/lib/suma/moneyutil.rb
+++ b/lib/suma/moneyutil.rb
@@ -12,4 +12,8 @@ class Suma::Moneyutil
     end
     return result
   end
+
+  def self.to_h(m)
+    return {currency: m.currency.iso_code, cents: m.cents}
+  end
 end

--- a/lib/suma/payment/funding_transaction/increase_ach_strategy.rb
+++ b/lib/suma/payment/funding_transaction/increase_ach_strategy.rb
@@ -11,6 +11,10 @@ class Suma::Payment::FundingTransaction::IncreaseAchStrategy <
   one_to_one :funding_transaction, class: "Suma::Payment::FundingTransaction"
   many_to_one :originating_bank_account, class: "Suma::BankAccount"
 
+  def originating_instrument
+    return self.originating_bank_account
+  end
+
   def short_name
     return "Increase ACH Funding"
   end

--- a/lib/suma/payment/funding_transaction/strategy.rb
+++ b/lib/suma/payment/funding_transaction/strategy.rb
@@ -6,6 +6,11 @@ require "suma/postgres/model"
 module Suma::Payment::FundingTransaction::Strategy
   include Suma::ExternalLinks
 
+  # @return Suma::Payment::Instrument
+  def originating_instrument
+    raise NotImplementedError
+  end
+
   # Return a string that summarizes the strategy.
   # Use whatever is most useful for an admin to see,
   # it does not have to be totally unambiguous.

--- a/lib/suma/payment/instrument.rb
+++ b/lib/suma/payment/instrument.rb
@@ -32,6 +32,10 @@ module Suma::Payment::Instrument
       @admin_label += " (#{self.institution_name})" unless self.name&.include?(self.institution_name || "")
     end
 
+    def simple_label
+      return "#{self.name} x-#{self.last4}"
+    end
+
     def to_h
       return {
         institution_name: self.institution_name,
@@ -40,6 +44,7 @@ module Suma::Payment::Instrument
         name: self.name,
         last4: self.last4,
         address: self.address,
+        simple_label: self.simple_label,
         admin_label: self.admin_label,
       }
     end

--- a/spec/suma/bank_account_spec.rb
+++ b/spec/suma/bank_account_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Suma::BankAccount", :db do
         name: "Checking",
         last4: "4567",
         address: nil,
+        simple_label: "Checking x-4567",
         admin_label: "Checking/4567 (Unknown)",
       )
     end
@@ -61,6 +62,7 @@ RSpec.describe "Suma::BankAccount", :db do
         name: "Checking",
         last4: "4567",
         address: nil,
+        simple_label: "Checking x-4567",
         admin_label: "Checking/4567 (Chase)",
       )
     end

--- a/spec/suma/payment/book_transaction_spec.rb
+++ b/spec/suma/payment/book_transaction_spec.rb
@@ -18,4 +18,53 @@ RSpec.describe "Suma::Payment::BookTransaction", :db do
       expect { debit.save_changes }.to raise_error(Sequel::Error, /save frozen object/)
     end
   end
+
+  describe "usage_code" do
+    let(:member) { Suma::Fixtures.member.create }
+    it "uses 'mobility_trip' if the receiver has a mobility trip charge" do
+      ledger = Suma::Fixtures.ledger.member(member).category(:mobility).create
+      trip = Suma::Fixtures.mobility_trip(member:).create
+      trip.vendor_service.update(external_name: "Suma Bikes")
+      charge = Suma::Fixtures.charge(mobility_trip: trip, member:, undiscounted_subtotal: money("$12.50")).create
+      bx = Suma::Fixtures.book_transaction(amount: "$10.25").from(ledger).create
+      bx.add_charge(charge)
+      expect(bx).to have_attributes(
+        usage_details: contain_exactly(
+          have_attributes(code: "mobility_trip", args: {discount_amount: cost("$2.25"), service_name: "Suma Bikes"}),
+        ),
+      )
+    end
+
+    it "uses 'misc' if receiver has a charge without a mobility trip" do
+      ledger = Suma::Fixtures.ledger.member(member).create
+      charge = Suma::Fixtures.charge(member:, undiscounted_subtotal: money("$12.50")).create
+      bx = Suma::Fixtures.book_transaction(amount: "$12.50", memo: "Hello").from(ledger).create
+      bx.add_charge(charge)
+      expect(bx).to have_attributes(
+        usage_details: contain_exactly(
+          have_attributes(code: "misc", args: {discount_amount: cost("$0"), service_name: "Hello"}),
+        ),
+      )
+    end
+
+    it "uses 'funding' if receiver has a funding transaction" do
+      ba = Suma::Fixtures.bank_account.create(name: "My Savings", account_number: "991234")
+      fx = Suma::Fixtures.funding_transaction.with_fake_strategy.create
+      fx.strategy.set_response(:originating_instrument, ba)
+      expect(fx.originated_book_transaction).to have_attributes(
+        usage_details: contain_exactly(
+          have_attributes(code: "funding", args: {account_label: "My Savings x-1234"}),
+        ),
+      )
+    end
+
+    it "uses 'misc' if receiver has no charge or funding transaction" do
+      bx = Suma::Fixtures.book_transaction(memo: "Shoni").create
+      expect(bx).to have_attributes(
+        usage_details: contain_exactly(
+          have_attributes(code: "unknown", args: {memo: "Shoni"}),
+        ),
+      )
+    end
+  end
 end

--- a/webapp/public/locale/en/ledgerusage.json
+++ b/webapp/public/locale/en/ledgerusage.json
@@ -1,0 +1,6 @@
+{
+	"funding": "Transfer from {{accountLabel}}",
+	"mobility_trip": "{{serviceName}} trip. You saved {{discountAmount.cents, currency(USD)}}.",
+	"misc": "Suma charge",
+	"unknown": "Uncategorized Suma charge"
+}

--- a/webapp/src/components/TopNav.js
+++ b/webapp/src/components/TopNav.js
@@ -25,7 +25,7 @@ const TopNav = () => {
       </Navbar.Brand>
       <Nav>
         {(() => {
-          if (user.adminMember) {
+          if (user?.adminMember) {
             return (
               <Nav.Link
                 className="bi bi-exclamation-circle-fill bg-danger"

--- a/webapp/src/components/ledger/LedgerItemModal.js
+++ b/webapp/src/components/ledger/LedgerItemModal.js
@@ -8,7 +8,7 @@ import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 
 export default function ({ item, onClose }) {
-  const { amount, at, memo, opaqueId } = item || {};
+  const { amount, at, opaqueId, usageDetails } = item || {};
   return (
     <Modal show={Boolean(item)} onHide={onClose} onExit={onClose} centered>
       <Modal.Body>
@@ -24,7 +24,9 @@ export default function ({ item, onClose }) {
                 {amount}
               </Money>
             </p>
-            <p className="mb-1">{memo}</p>
+            {usageDetails.map(({ code, args }, i) => (
+              <p key={i}>{i18next.t(code, { ns: "ledgerusage", ...args })}</p>
+            ))}
             <p className="text-secondary mb-1">{dayjs(at).format("LLL")}</p>
             <p className="text-secondary">
               {i18next.t("reference_id", { ns: "common" })}: {opaqueId}

--- a/webapp/src/localization/useI18Next.js
+++ b/webapp/src/localization/useI18Next.js
@@ -14,6 +14,7 @@ export default function useI18Next() {
           "common",
           "dashboard",
           "errors",
+          "ledgerusage",
           "mobility",
           "messages",
           "forms",


### PR DESCRIPTION
Book transactions now have a collection of 'usage codes',
which are localization keys and arguments used for rendering.

The 'ledger item details' modal displays these usage codes.

Fixes https://github.com/lithictech/suma/issues/99

---

Add Instrument#simple_label and Strategy#originating_instrument

---

Add fmt-all make command