### PR TITLE
Update current member in other API calls

### DIFF
--- a/lib/suma/api.rb
+++ b/lib/suma/api.rb
@@ -40,6 +40,32 @@ module Suma::API
             optional :lookup_email, type: String
             optional :token, type: String
           end
+
+          # Set the Suma-Current-Member header to a base64 encoded version
+          # of the current member entity.
+          #
+          # In many places, we update fields about the current member,
+          # like when we add funds (removing read-only mode)
+          # or begin/end a trip (changing ongoing_trip).
+          #
+          # We want to avoid re-fetching `/v1/me` when this happens,
+          # since it's an extra API call, and we want to avoid
+          # any additional API calls.
+          #
+          # Endpoints can call `add_current_member_header`,
+          # which will set the `Suma-Current-Member` header,
+          # which is a base64 encoded version of the 'current member' entity.
+          #
+          # The on the frontend, use `tap(handleUpdateCurrentMember)`,
+          # which will look for this header, decode and parse the value,
+          # and update the stored user to it.
+          def add_current_member_header
+            c = current_member
+            h = Suma::API::CurrentMemberEntity.represent(c, env:)
+            j = h.to_json
+            b64 = Base64.strict_encode64(j)
+            header "Suma-Current-Member", b64
+          end
         end
 
         before do

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -103,6 +103,7 @@ class Suma::API::Mobility < Suma::API::V1
       rescue Suma::Mobility::Trip::OngoingTrip
         merror!(409, "Already in a trip", code: "ongoing_trip")
       end
+      add_current_member_header
       status 200
       present trip, with: Suma::API::MobilityTripEntity
     end
@@ -116,6 +117,7 @@ class Suma::API::Mobility < Suma::API::V1
       trip = Suma::Mobility::Trip.ongoing.where(member:).first
       merror!(409, "No ongoing trip", code: "no_active_trip") if trip.nil?
       trip.end_trip(lat: params[:lat], lng: params[:lng])
+      add_current_member_header
       status 200
       present trip, with: Suma::API::MobilityTripEntity
     end

--- a/lib/suma/api/payment_instruments.rb
+++ b/lib/suma/api/payment_instruments.rb
@@ -28,6 +28,7 @@ class Suma::API::PaymentInstruments < Suma::API::V1
         end
         set_declared(ba, params)
         save_or_error!(ba)
+        add_current_member_header
         status 200
         present(
           ba,

--- a/lib/suma/api/payments.rb
+++ b/lib/suma/api/payments.rb
@@ -38,6 +38,7 @@ class Suma::API::Payments < Suma::API::V1
         fx.update(originated_book_transaction:)
         fx
       end
+      add_current_member_header
       status 200
       present fx, with: Suma::API::FundingTransactionEntity
     end

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -83,8 +83,9 @@ module Suma::Service::Entities
     expose :roles do |instance|
       instance.roles.map(&:name)
     end
-    protected def impersonation
-      return @impersonation ||= Suma::Service::Auth::Impersonation.new(options[:env]["warden"])
+    protected def impersonation(env=nil)
+      env ||= options[:env]
+      return @impersonation ||= Suma::Service::Auth::Impersonation.new(env["warden"])
     end
   end
 

--- a/lib/suma/service/middleware.rb
+++ b/lib/suma/service/middleware.rb
@@ -28,7 +28,7 @@ module Suma::Service::Middleware
                  headers: :any,
                  methods: :any,
                  credentials: true,
-                 expose: ["Etag", "Created-Resource-Id", "Created-Resource-Admin"]
+                 expose: ["Etag", "Created-Resource-Id", "Created-Resource-Admin", "Suma-Current-Member"]
       end
     end
   end

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe Suma::API::Mobility, :db do
            provider_id: vehicle.vendor_service_id, vehicle_id: vehicle.vehicle_id, rate_id: rate.id
 
       expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Suma-Current-Member")
       expect(last_response).to have_json_body.that_includes(:id)
 
       trip = Suma::Mobility::Trip[last_response_json_body[:id]]
@@ -262,6 +263,7 @@ RSpec.describe Suma::API::Mobility, :db do
       post "/v1/mobility/end_trip", lat: 5, lng: -5
 
       expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Suma-Current-Member")
       expect(trip.refresh).to be_ended
       expect(trip).to have_attributes(end_lat: 5, end_lng: -5)
     end

--- a/spec/suma/api/payment_instruments_spec.rb
+++ b/spec/suma/api/payment_instruments_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Suma::API::PaymentInstruments, :db do
       post("/v1/payment_instruments/bank_accounts/create", name: "Foo", account_number:, routing_number:, account_type:)
 
       expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Suma-Current-Member")
       expect(member.refresh.bank_accounts).to contain_exactly(
         have_attributes(name: "Foo", account_number:, routing_number:, verified?: false),
       )

--- a/spec/suma/api/payments_spec.rb
+++ b/spec/suma/api/payments_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Suma::API::Payments, :db do
            payment_method_type: ba.payment_method_type
 
       expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Suma-Current-Member")
       expect(last_response).to have_json_body.that_includes(status: "created")
 
       expect(member.payment_account.originated_funding_transactions).to contain_exactly(

--- a/spec/suma/api_spec.rb
+++ b/spec/suma/api_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+require "suma/api"
+
+class Suma::API::TestV1API < Suma::API::V1
+  get :current_member_header do
+    add_current_member_header if params[:inheader]
+    body "ok"
+  end
+end
+
+RSpec.describe Suma::API::V1, :db do
+  include Rack::Test::Methods
+
+  let(:app) { Suma::API::TestV1API.build_app }
+  let(:member) { Suma::Fixtures.member.create }
+
+  describe "current member header" do
+    it "can be returned base64 encoded in a header" do
+      login_as(member)
+      get "/v1/current_member_header?inheader=true"
+      expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Suma-Current-Member")
+      j = Base64.strict_decode64(last_response.headers["Suma-Current-Member"])
+      m = JSON.parse(j)
+      expect(m).to include("onboarded", "id" => member.id)
+    end
+
+    it "does not return the header unless the helper is called" do
+      login_as(member)
+      get "/v1/current_member_header"
+      expect(last_response).to have_status(200)
+      expect(last_response.headers).to_not include("Suma-Current-Member")
+    end
+
+    it "returns the right member when impersonated" do
+      admin = Suma::Fixtures.member.admin.create
+      login_as(admin)
+      impersonate(admin:, target: member)
+      get "/v1/current_member_header?inheader=true"
+      expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Suma-Current-Member")
+      j = Base64.strict_decode64(last_response.headers["Suma-Current-Member"])
+      m = JSON.parse(j)
+      expect(m).to include("onboarded", "id" => member.id)
+    end
+  end
+end

--- a/webapp/public/locale/en/dashboard.json
+++ b/webapp/public/locale/en/dashboard.json
@@ -1,6 +1,6 @@
 {
 	"check_ongoing_trip": "You have an ongoing trip. Please make sure you end it when you are finished with your ride!",
-	"check_ongoing_trip_button": "Go to Mobility",
+	"check_ongoing_trip_button": "See My Trip",
 	"payment_account_balance": "Available Balance",
 	"lifetime_savings": "Suma Savings",
 	"recent_ledger_lines": "Recent Charges and Credits",

--- a/webapp/src/components/mobilitymap/Map.js
+++ b/webapp/src/components/mobilitymap/Map.js
@@ -14,7 +14,7 @@ import { Link } from "react-router-dom";
 
 const Map = () => {
   const mapRef = React.useRef();
-  const { user } = useUser();
+  const { user, handleUpdateCurrentMember } = useUser();
   const [loadedMap, setLoadedMap] = React.useState(null);
   const [selectedMapVehicle, setSelectedMapVehicle] = React.useState(null);
   const [loadedVehicle, setLoadedVehicle] = React.useState(null);
@@ -72,6 +72,7 @@ const Map = () => {
           vehicleId: vehicle.vehicleId,
           rateId: vehicle.rate.id,
         })
+        .tap(handleUpdateCurrentMember)
         .then((r) => {
           setOngoingTrip(r.data);
           loadedMap.beginTrip({
@@ -81,7 +82,13 @@ const Map = () => {
         })
         .catch((e) => setReserveError(extractErrorCode(e)));
     },
-    [loadedMap, handleGetLastLocation, handleGetLocationError, setReserveError]
+    [
+      handleUpdateCurrentMember,
+      loadedMap,
+      handleGetLastLocation,
+      handleGetLocationError,
+      setReserveError,
+    ]
   );
 
   const handleStopTrip = () => loadedMap.endTrip({ onVehicleClick: handleVehicleClick });

--- a/webapp/src/components/mobilitymap/TripCard.js
+++ b/webapp/src/components/mobilitymap/TripCard.js
@@ -1,6 +1,7 @@
 import api from "../../api";
 import { dayjs } from "../../modules/dayConfig";
 import { extractErrorCode, useError } from "../../state/useError";
+import { useUser } from "../../state/useUser";
 import FormError from "../FormError";
 import PageLoader from "../PageLoader";
 import CardOverlay from "./CardOverlay";
@@ -10,6 +11,7 @@ import React from "react";
 import Button from "react-bootstrap/Button";
 
 const TripCard = ({ active, trip, onCloseTrip, onStopTrip, lastLocation }) => {
+  const { handleUpdateCurrentMember } = useUser();
   const [endTrip, setEndTrip] = React.useState(null);
   const [error, setError] = useError();
   if (!active) {
@@ -29,6 +31,7 @@ const TripCard = ({ active, trip, onCloseTrip, onStopTrip, lastLocation }) => {
         lat: lat,
         lng: lng,
       })
+      .tap(handleUpdateCurrentMember)
       .then((r) => {
         onStopTrip();
         setEndTrip(r.data);

--- a/webapp/src/pages/FundingAddFunds.js
+++ b/webapp/src/pages/FundingAddFunds.js
@@ -21,7 +21,7 @@ const logger = new Logger("addfunds");
 
 export default function FundingAddFunds() {
   const [error, setError] = useError();
-  const { user } = useUser();
+  const { user, handleUpdateCurrentMember } = useUser();
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const [amountCents, setAmountCents] = React.useState();
@@ -70,6 +70,7 @@ export default function FundingAddFunds() {
         paymentMethodId: instrument.id,
         paymentMethodType: instrument.paymentMethodType,
       })
+      .tap(handleUpdateCurrentMember)
       .then(() => navigate(`/dashboard`, { replace: true }))
       .catch((e) => {
         setError(extractErrorCode(e));

--- a/webapp/src/pages/FundingLinkBankAccount.js
+++ b/webapp/src/pages/FundingLinkBankAccount.js
@@ -50,7 +50,7 @@ function LinkBankAccount({ onSuccess }) {
   const [error, setError] = useError();
   const location = useLocation();
   const navigate = useNavigate();
-  const { user, setUser } = useUser();
+  const { user, setUser, handleUpdateCurrentMember } = useUser();
 
   const screenLoader = useScreenLoader();
   const showCheckModalToggle = useHashToggle(location, navigate, "check-details");
@@ -78,6 +78,7 @@ function LinkBankAccount({ onSuccess }) {
         accountNumber,
         accountType,
       })
+      .tap(handleUpdateCurrentMember)
       .then((r) => {
         setUser({ ...user, usablePaymentInstruments: r.data.allPaymentInstruments });
         onSuccess();

--- a/webapp/src/state/useUser.js
+++ b/webapp/src/state/useUser.js
@@ -1,4 +1,7 @@
 import api from "../api";
+import { localStorageCache } from "../shared/localStorageHelper";
+import humps from "humps";
+import _ from "lodash";
 import React from "react";
 
 export const UserContext = React.createContext();
@@ -7,27 +10,58 @@ export const UserContext = React.createContext();
  */
 export const useUser = () => React.useContext(UserContext);
 export function UserProvider({ children }) {
-  const [user, setUserInner] = React.useState(null);
-  const [userLoading, setUserLoading] = React.useState(true);
+  // Store the current user in the local storage cache.
+  // Load from the cache optimistically; if we have a cached user,
+  // use it immediately while we go and fetch from the backend.
+  // This avoids blocking doing anything while we wait on the user,
+  // which normally won't change in a meaningful way
+  // (and when it does change, the app will react to its new state properly).
+  const [user, setUserInner] = React.useState(
+    localStorageCache.getItem(STORAGE_KEY, null)
+  );
+  const [userLoading, setUserLoading] = React.useState(!user);
   const [userError, setUserError] = React.useState(null);
 
-  function setUser(u) {
+  const setUser = React.useCallback((u) => {
     setUserInner(u);
+    localStorageCache.setItem(STORAGE_KEY, u);
     setUserLoading(false);
     setUserError(null);
-  }
+  }, []);
 
-  React.useEffect(() => {
-    api
+  const fetchUser = React.useCallback(() => {
+    return api
       .getMe()
       .then(api.pickData)
       .then(setUser)
       .catch((e) => {
         setUserInner(null);
+        localStorageCache.removeItem(STORAGE_KEY);
         setUserLoading(false);
         setUserError(e);
       });
-  }, []);
+  }, [setUser]);
+
+  React.useEffect(() => {
+    fetchUser().then(() => null);
+  }, [fetchUser]);
+
+  // See add_current_member_header for more info.
+  const handleUpdateCurrentMember = React.useCallback(
+    (response) => {
+      const memberBase64 = _.get(response, ["headers", "suma-current-member"]);
+      if (!memberBase64) {
+        console.warn(
+          "handleUpdateCurrentMember not used properly, response or header is malformed"
+        );
+        return;
+      }
+      const j = atob(memberBase64);
+      const member = JSON.parse(j);
+      setUser(humps.camelizeKeys(member));
+    },
+    [setUser]
+  );
 
   return (
     <UserContext.Provider
@@ -38,12 +72,15 @@ export function UserProvider({ children }) {
         userError,
         userAuthed: Boolean(user),
         userUnauthed: !userLoading && !user,
+        handleUpdateCurrentMember,
       }}
     >
       {children}
     </UserContext.Provider>
   );
 }
+
+const STORAGE_KEY = "sumauser";
 
 /**
  * @typedef User


### PR DESCRIPTION
Fixes https://github.com/lithictech/suma/issues/104

In many places, we update fields about the current member,
like when we add funds (removing read-only mode)
or start/end a trip (changing ongoing_trip).

We want to avoid re-fetching `/v1/me` when this happens,
since it's an extra API call, and we want to avoid
any additional API calls.

Endpoints can now call `add_current_member_header`,
which will set the `Suma-Current-Member` header,
which is a base64 encoded version of the 'current member' entity.

The on the frontend, we can use `tap(handleUpdateCurrentMember)`,
which will look for that header, decode and parse the value,
and update the stored user to it.

So now, when you begin/end a trip, the user gets updated along
with it.

This also adds caching of the current user into local storage,
optimistically assuming the user won't change when fetched
so we do not have to block rendering the page while fetching `/v1/me`.