### PR TITLE
Add currency formatter and fix map unmount

### DIFF
--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -11,7 +11,7 @@
     "pagination_next": "Next ›",
     "pagination_prev": "‹ Prev",
     "reference_id": "Reference ID",
-    "scooter_cost": "{{startCost, number(style: currency; currency: USD)}} to start then {{costPerMinute, number(style: currency; currency: USD)}}/min + taxes",
+    "scooter_cost": "{{startCost, sumaCurrency}} to start then {{costPerMinute, sumaCurrency}}/min + taxes",
     "view_all": "View all",
     "welcome_to_suma": "Welcome to Suma"
   },
@@ -73,7 +73,7 @@
     "invalid_field": "This field is not valid.",
     "invalid_max_length": "Cannot be more than {{constraint}} characters.",
     "invalid_min": "Must be greater than or equal to {{constraint}}.",
-    "invalid_min_amount": "Must be at least {{constraint, currency(USD)}}.",
+    "invalid_min_amount": "Must be at least {{constraint, sumaCurrency}}.",
     "invalid_min_length": "Must be at least {{constraint}} characters.",
     "invalid_required": "This field is required.",
     "invalid_routing_number": "Please enter the 9 digit number of your bank account.",
@@ -94,7 +94,7 @@
   "ledgerusage": {
     "funding": "Transfer from {{accountLabel}}",
     "misc": "Suma charge",
-    "mobility_trip": "{{serviceName}} trip. You saved {{discountAmount.cents, currency(USD)}}.",
+    "mobility_trip": "{{serviceName}} trip. You saved {{discountAmount, sumaCurrency}}.",
     "unknown": "Uncategorized Suma charge"
   },
   "messages": {
@@ -103,10 +103,10 @@
   "mobility": {
     "end_trip": "End Trip",
     "intro": "Ride with enhanced privacy and better prices.",
-    "mobility_start_and_per_minute": "Start fee is {{surchargeCents, currency(USD)}}, then {{unitCents, currency(USD)}} per minute",
+    "mobility_start_and_per_minute": "Start fee is {{surchargeCents, sumaCurrency}}, then {{unitCents, sumaCurrency}} per minute",
     "reserve_scooter": "Reserve Scooter",
     "title": "Mobility Services",
-    "trip_ended": "Your trip with {{vendor}} has ended.\n\nWe used {{totalCostCents, currency(USD)}} of your Suma balance for this trip.\n\nYou saved {{discountAmountCents, currency(USD)}}.",
+    "trip_ended": "Your trip with {{vendor}} has ended.\n\nWe used {{totalCost, sumaCurrency}} of your Suma balance for this trip.\n\nYou saved {{discountAmount, sumaCurrency}}.",
     "trip_started_at": "Trip started at {{at}}."
   },
   "payments": {

--- a/webapp/src/components/mobilitymap/Map.js
+++ b/webapp/src/components/mobilitymap/Map.js
@@ -115,11 +115,6 @@ const Map = () => {
       }
       setLoadedMap(map);
     }
-    return () => {
-      if (loadedMap) {
-        loadedMap.tripMode();
-      }
-    };
   }, [
     loadedMap,
     ongoingTrip,
@@ -127,6 +122,14 @@ const Map = () => {
     handleGetLastLocation,
     handleGetLocationError,
   ]);
+
+  React.useEffect(() => {
+    return () => {
+      if (loadedMap) {
+        loadedMap.unmount();
+      }
+    };
+  }, [loadedMap]);
 
   return (
     <div className="position-relative">

--- a/webapp/src/components/mobilitymap/ReservationCard.js
+++ b/webapp/src/components/mobilitymap/ReservationCard.js
@@ -29,8 +29,11 @@ const ReservationCard = ({ active, loading, vehicle, onReserve, reserveError }) 
       <Card.Title className="mb-2 text-muted">{vendorService.name}</Card.Title>
       <Card.Text className="text-muted">
         {t("mobility:" + rate.localizationKey, {
-          surchargeCents: locVars.surchargeCents * 0.01,
-          unitCents: locVars.unitCents * 0.01,
+          surchargeCents: {
+            cents: locVars.surchargeCents,
+            currency: locVars.surchargeCurrency,
+          },
+          unitCents: { cents: locVars.unitCents, currency: locVars.unitCurrency },
         })}
       </Card.Text>
       <FormError error={reserveError} />

--- a/webapp/src/components/mobilitymap/TransactionCard.js
+++ b/webapp/src/components/mobilitymap/TransactionCard.js
@@ -12,8 +12,8 @@ const TransactionCard = ({ endTrip, onCloseTrip, error }) => {
       <p>
         {t("mobility:trip_ended", {
           vendor: provider.vendorName,
-          totalCostCents: totalCost.cents * 0.01,
-          discountAmountCents: discountAmount.cents * 0.01,
+          totalCost: totalCost,
+          discountAmount: discountAmount,
         })}
       </p>
       <FormError error={error} />

--- a/webapp/src/localization/useI18Next.js
+++ b/webapp/src/localization/useI18Next.js
@@ -1,3 +1,4 @@
+import { formatMoney } from "../components/Money";
 import useLocalStorageState from "../shared/react/useLocalStorageState";
 import i18n from "i18next";
 import Backend from "i18next-http-backend";
@@ -43,6 +44,9 @@ export function I18NextProvider({ children }) {
         },
       })
       .finally(() => setI18NextLoading(false));
+    i18n.services.formatter.add("sumaCurrency", (value, lng, options) => {
+      return formatMoney(value);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -294,4 +294,9 @@ export default class MapBuilder {
       mLng.toPrecision(7) === lng.toPrecision(7)
     );
   }
+
+  unmount() {
+    this.stopRefreshTimer();
+    this._map.stopLocate();
+  }
 }

--- a/webapp/src/pages/Dashboard.js
+++ b/webapp/src/pages/Dashboard.js
@@ -31,7 +31,7 @@ const Dashboard = () => {
         <Alert variant="danger" className="border-radius-0">
           <p>{t("dashboard:check_ongoing_trip")}</p>
           <div className="d-flex justify-content-end">
-            <Link to="/map" className="btn btn-sm btn-danger">
+            <Link to="/mobility" className="btn btn-sm btn-danger">
               {t("dashboard:check_ongoing_trip_button")}
               <i
                 className="bi bi-box-arrow-in-right mx-1"

--- a/webapp/src/pages/FundingAddFunds.js
+++ b/webapp/src/pages/FundingAddFunds.js
@@ -52,11 +52,15 @@ export default function FundingAddFunds() {
   const handleFormSubmit = (e) => {
     e.preventDefault();
     if (amountCents < selectedCurrency?.fundingMinimumCents) {
-      // #TODO: fix FormError translation render
       setError(
-        t("forms:invalid_min_amount", {
-          constraint: selectedCurrency?.fundingMinimumCents * 0.01,
-        })
+        <span>
+          {t("forms:invalid_min_amount", {
+            constraint: {
+              cents: selectedCurrency?.fundingMinimumCents,
+              currency: selectedCurrency?.code,
+            },
+          })}
+        </span>
       );
       return;
     }

--- a/webapp/src/pages/Mobility.js
+++ b/webapp/src/pages/Mobility.js
@@ -3,7 +3,7 @@ import { t } from "../localization";
 import React from "react";
 import Container from "react-bootstrap/Container";
 
-const MapPage = () => {
+const Mobility = () => {
   return (
     <>
       <Container>
@@ -15,4 +15,4 @@ const MapPage = () => {
   );
 };
 
-export default MapPage;
+export default Mobility;


### PR DESCRIPTION
- Add i18next currency format function `sumaCurrency` after init.
- Translate and use that function where necessary
- Added `unmount` map function to use when React unmounts (halts any hanging activity like API re-fetching) 
- Rename mapPage component correctly to Mobility

Note:
There are still some react 'memory leaks' when changing pages immediately after a vehicle is clicked. This means that the API call is still active. We should look into a broader solution in later stages.