### PR TITLE
Encrypt bank account numbers

### DIFF
--- a/db/migrations/002_initial.rb
+++ b/db/migrations/002_initial.rb
@@ -344,9 +344,10 @@ Sequel.migration do
 
       text :name, null: false
       text :account_type, null: false
+      text :identity, null: false
 
-      index [:legal_entity_id, :routing_number, :account_number],
-            name: :undeleted_legal_entity_id_routing_number_account_number_key,
+      index :identity,
+            name: :unique_undeleted_bank_account_identity_key,
             unique: true,
             where: Sequel[soft_deleted_at: nil]
     end

--- a/lib/suma/api/payment_instruments.rb
+++ b/lib/suma/api/payment_instruments.rb
@@ -15,7 +15,8 @@ class Suma::API::PaymentInstruments < Suma::API::V1
         c = current_member
         account_number = params.delete(:account_number)
         routing_number = params.delete(:routing_number)
-        ba = c.legal_entity.bank_accounts_dataset[account_number:, routing_number:]
+        identity = Suma::BankAccount.identity(c.legal_entity_id, routing_number, account_number)
+        ba = c.legal_entity.bank_accounts_dataset[identity:]
         if ba.nil?
           ba = Suma::BankAccount.new(legal_entity: c.legal_entity, account_number:, routing_number:)
         elsif ba.soft_deleted?

--- a/spec/suma/postgres/model_spec.rb
+++ b/spec/suma/postgres/model_spec.rb
@@ -312,6 +312,13 @@ RSpec.describe "Suma::Postgres::Model", :db do
       state.price_per_unit_cents = 240
       expect(state.inspect).to include("price_per_unit: $2.40")
     end
+
+    it "decrypts strings and uris" do
+      ba = Suma::Fixtures.bank_account.create(account_number: "123456789")
+      expect(ba.inspect).to include('account_number: "123...789')
+      ba.account_number = "postgres://user:pass@localhost:1234/db"
+      expect(ba.inspect).to include('account_number: "postgres://*:*@localhost')
+    end
   end
 
   describe "resource_lock!" do


### PR DESCRIPTION
Fixes #82, there are no other columns to encrypt

Because we also use account numbers in a unique constraint,
we need another column that acts as this constraint.