### PR TITLE
Hook up 'waitlist' UI

### DIFF
--- a/db/migrations/003_member_keyvalues.rb
+++ b/db/migrations/003_member_keyvalues.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:member_key_values) do
+      primary_key :id
+      timestamptz :created_at, null: false, default: Sequel.function(:now)
+      foreign_key :member_id, :members, null: false, on_delete: :cascade
+      text :key, null: false
+      text :value_string, null: true
+
+      index [:key, :member_id], name: :unique_member_key_idx, unique: true
+    end
+  end
+end

--- a/lib/suma/api/me.rb
+++ b/lib/suma/api/me.rb
@@ -42,5 +42,17 @@ class Suma::API::Me < Suma::API::V1
       d = Suma::Member::Dashboard.new(current_member)
       present d, with: Suma::API::MemberDashboardEntity
     end
+
+    params do
+      requires :feature, type: String, values: ["food", "utilities"]
+    end
+    post :waitlist do
+      member = current_member
+      member.db[:member_key_values].
+        insert_conflict.
+        insert(member_id: member.id, key: "waitlist_#{params[:feature]}")
+      status 200
+      present member, with: Suma::API::CurrentMemberEntity, env:
+    end
   end
 end

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -18,6 +18,7 @@
     "reference_id": "Reference ID",
     "scooter_cost": "{{startCost, sumaCurrency}} to start then {{costPerMinute, sumaCurrency}}/min + taxes",
     "view_all": "View all",
+    "waitlisted": "Great! You are on the waiting list and we'll let you know when it's available.",
     "welcome_to_suma": "Welcome to Suma",
     "whats_this": "What's this?"
   },

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -33,6 +33,7 @@ export default {
   del,
   getMe: (data) => get(`/api/v1/me`, data),
   updateMe: (data) => post(`/api/v1/me/update`, data),
+  joinWaitlist: (data) => post(`/api/v1/me/waitlist`, data),
   getSupportedGeographies: (data) => get(`/api/v1/meta/supported_geographies`, data),
   getSupportedLocales: (data) => get(`/api/v1/meta/supported_locales`, data),
   getSupportedCurrencies: (data) => get(`/api/v1/meta/supported_currencies`, data),

--- a/webapp/src/assets/styles/animated-checkmark.scss
+++ b/webapp/src/assets/styles/animated-checkmark.scss
@@ -1,0 +1,67 @@
+@import "./_theme.scss";
+
+// Misc
+$curve: cubic-bezier(0.650, 0.000, 0.450, 1.000);
+
+.checkmark {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: block;
+  stroke-width: 2;
+  stroke: $white;
+  stroke-miterlimit: 10;
+  box-shadow: inset 0 0 0 $success;
+  animation: checkmark-fill .4s ease-in-out .4s forwards, checkmark-scale .3s ease-in-out .9s both;
+}
+
+.checkmark__circle {
+  stroke-dasharray: 166;
+  stroke-dashoffset: 166;
+  stroke-width: 2;
+  stroke-miterlimit: 10;
+  stroke: $success;
+  fill: none;
+  animation: checkmark-stroke .6s $curve forwards;
+}
+
+.checkmark__check {
+  transform-origin: 50% 50%;
+  stroke-dasharray: 48;
+  stroke-dashoffset: 48;
+  animation: checkmark-stroke .3s $curve .8s forwards;
+}
+
+@keyframes checkmark-stroke {
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes checkmark-scale {
+  0%, 100% {
+    transform: none;
+  }
+  50% {
+    transform: scale3d(1.1, 1.1, 1);
+  }
+}
+
+@keyframes checkmark-fill {
+  100% {
+    box-shadow: inset 0 0 0 30px $success;
+  }
+}
+
+.checkmark__text {
+  animation: checkmark-text-opacity 1.7s ease-in-out;
+}
+
+@keyframes checkmark-text-opacity {
+  0%, 75% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/webapp/src/assets/styles/imports.scss
+++ b/webapp/src/assets/styles/imports.scss
@@ -1,4 +1,5 @@
 @import "./_theme";
+@import "./animated-checkmark";
 @import "./breadcrumbs";
 @import "./custom";
 @import "./fonts";

--- a/webapp/src/components/AnimatedCheckmark.js
+++ b/webapp/src/components/AnimatedCheckmark.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function AnimatedCheckmark() {
+  return (
+    <svg className="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52">
+      <circle className="checkmark__circle" cx="26" cy="26" r="25" fill="none" />
+      <path className="checkmark__check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8" />
+    </svg>
+  );
+}

--- a/webapp/src/components/TopNav.js
+++ b/webapp/src/components/TopNav.js
@@ -11,7 +11,6 @@ import i18next from "i18next";
 import React from "react";
 import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
-import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 
 export default function TopNav() {
@@ -20,7 +19,7 @@ export default function TopNav() {
   return (
     <Navbar
       className="pt-1 pb-0"
-      bg="primary"
+      bg={user?.adminMember ? "danger" : "primary"}
       expand={false}
       variant="dark"
       expanded={expanded}
@@ -50,6 +49,17 @@ export default function TopNav() {
         <Container className="mb-3">
           <div className="d-flex justify-content-end mt-2">
             <div className="d-flex flex-column">
+              {user?.adminMember && (
+                <Button
+                  variant="danger"
+                  className="mt-2"
+                  href={`/admin/member/${user.id}`}
+                >
+                  Impersonating:
+                  <br />
+                  {user.name || user.phone}
+                </Button>
+              )}
               <LanguageButtons />
               {userAuthed && (
                 <Button onClick={signOut} className="mt-5" variant="primary">
@@ -58,17 +68,6 @@ export default function TopNav() {
               )}
             </div>
           </div>
-          <Nav className="me-auto text-end">
-            {user?.adminMember && (
-              <Nav.Link
-                className="bi bi-exclamation-circle-fill bg-danger"
-                as={RLink}
-                href={`/admin/member/${user.id}`}
-              >
-                {user.name || user.phone}
-              </Nav.Link>
-            )}
-          </Nav>
         </Container>
       </Navbar.Collapse>
     </Navbar>

--- a/webapp/src/components/WaitingListPage.js
+++ b/webapp/src/components/WaitingListPage.js
@@ -1,0 +1,58 @@
+import api from "../api";
+import AnimatedCheckmark from "../components/AnimatedCheckmark";
+import AppNav from "../components/AppNav";
+import PageLoader from "../components/PageLoader";
+import RLink from "../components/RLink";
+import { t } from "../localization";
+import { LayoutContainer } from "../state/withLayout";
+import React from "react";
+import Button from "react-bootstrap/Button";
+
+export default function WaitingListPage({ feature, imgSrc, imgAlt, title, text }) {
+  const [loading, setLoading] = React.useState(false);
+  const [finished, setFinished] = React.useState(false);
+  const handleClick = (e) => {
+    setLoading(true);
+    e.preventDefault();
+    api.joinWaitlist({ feature }).finally(() => setFinished(true));
+  };
+  let content;
+  if (finished) {
+    content = (
+      <div className="d-flex flex-column align-items-center">
+        <div>
+          <AnimatedCheckmark scale={2} />
+        </div>
+        <p className="mt-4 mb-0 lead checkmark__text">{t("common:waitlisted")}</p>
+        <div className="button-stack mt-4 w-100">
+          <Button variant="outline-primary" href="/dashboard" as={RLink}>
+            {t("common:go_home")}
+          </Button>
+        </div>
+      </div>
+    );
+  } else if (loading) {
+    content = <PageLoader relative />;
+  } else {
+    content = (
+      <>
+        <h2>{title}</h2>
+        {text}
+        <div className="button-stack mt-4">
+          <Button variant="outline-primary" onClick={handleClick}>
+            {t("common:join_waitlist")}
+          </Button>{" "}
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <AppNav />
+      <img src={imgSrc} alt={imgAlt} className="thin-header-image" />
+      <LayoutContainer top gutters>
+        {content}
+      </LayoutContainer>
+    </>
+  );
+}

--- a/webapp/src/pages/Food.js
+++ b/webapp/src/pages/Food.js
@@ -1,26 +1,16 @@
 import foodImage from "../assets/images/onboarding-food.jpg";
-import AppNav from "../components/AppNav";
+import WaitingListPage from "../components/WaitingListPage";
 import { mdp, t } from "../localization";
-import { LayoutContainer } from "../state/withLayout";
 import React from "react";
-import Button from "react-bootstrap/Button";
 
 export default function Food() {
   return (
-    <>
-      <AppNav />
-      <img
-        src={foodImage}
-        className="thin-header-image"
-        alt="Fresh produce in a market"
-      />
-      <LayoutContainer top gutters>
-        <h2>{t("food:page_title")}</h2>
-        {mdp("food:intro_md")}
-        <div className="button-stack mt-4">
-          <Button variant="outline-primary">{t("common:join_waitlist")}</Button>{" "}
-        </div>
-      </LayoutContainer>
-    </>
+    <WaitingListPage
+      feature="food"
+      imgSrc={foodImage}
+      imgAlt="Fresh produce in a market"
+      title={t("food:page_title")}
+      text={mdp("food:intro_md")}
+    />
   );
 }

--- a/webapp/src/pages/Utilities.js
+++ b/webapp/src/pages/Utilities.js
@@ -1,22 +1,16 @@
 import utilitiesImage from "../assets/images/onboarding-utilities.jpg";
-import AppNav from "../components/AppNav";
+import WaitingListPage from "../components/WaitingListPage";
 import { mdp, t } from "../localization";
-import { LayoutContainer } from "../state/withLayout";
 import React from "react";
-import Button from "react-bootstrap/Button";
 
 export default function Utilities() {
   return (
-    <>
-      <AppNav />
-      <img src={utilitiesImage} className="thin-header-image" alt="Solar Panels" />
-      <LayoutContainer top gutters>
-        <h2>{t("utilities:page_title")}</h2>
-        {mdp("utilities:intro_md")}
-        <div className="button-stack">
-          <Button variant="outline-primary">{t("common:join_waitlist")}</Button>{" "}
-        </div>
-      </LayoutContainer>
-    </>
+    <WaitingListPage
+      feature="utilities"
+      imgSrc={utilitiesImage}
+      imgAlt="Solar Panels"
+      title={t("utilities:page_title")}
+      text={mdp("utilities:intro_md")}
+    />
   );
 }


### PR DESCRIPTION
Improve navbar look when impersonating someone

---

Add new 'waitlist' feature, and key-value table

Add endpoints for joining a waitlist.

This uses an overly-generic `member_key_values` table
which can store any key and value.
It should rarely ever be used,
but this sort of unstructured data is needed very early on,
so here it is.

Hook up UI to endpoints.

Add an Animated Checkmark component.

Fixes https://github.com/lithictech/suma/issues/147