### PR TITLE
Add geoFences to mobility map

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14574,6 +14574,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -26180,6 +26193,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -115,7 +115,11 @@
     "reserve_scooter": "Reserve Scooter",
     "title": "Mobility Services",
     "trip_ended": "Your trip with {{vendor}} has ended.\n\nWe used {{totalCost, sumaCurrency}} of your Suma balance for this trip.\n\nYou saved {{discountAmount, sumaCurrency}}.",
-    "trip_started_at": "Trip started at {{at}}."
+    "trip_started_at": "Trip started at {{at}}.",
+    "do_not_park_title": "Please do not park here",
+    "do_not_park_intro": "You cannot park in this area. We may take action for repeated violations.",
+    "do_not_ride_title": "Please do not ride here",
+    "do_not_ride_intro": "You cannot ride in this area. We may take action for repeated violations."
   },
   "onboarding": {
     "enroll_intro": "Welcome to Suma! To get started, we will need to verify your identity. This makes sure you are eligible for the right programs, such as with our affordable housing partners.\n\n**We will never share this information other than to verify your identity.**",

--- a/webapp/src/assets/styles/mobility.scss
+++ b/webapp/src/assets/styles/mobility.scss
@@ -1,6 +1,39 @@
+@import "./theme";
+
 .leaflet-container {
+  font-family: $font-family-sans-serif !important;
+  font-size: 0.85rem;
   /* This is approximately equal to the leftover space after accounting for the header */
   height: calc(100vh - 150px);
+}
+
+.leaflet-popup-content-wrapper {
+  border-radius: 0.25rem;
+  border: 1px solid #eee;
+  background-color: white;
+}
+
+.leaflet-popup-content-wrapper, .leaflet-popup-tip {
+  box-shadow: none;
+}
+
+.leaflet-popup-tip-container {
+  overflow:unset;
+}
+
+.leaflet-popup-content {
+  width:250px!important;
+  margin: 0!important;
+  padding: 1rem 1rem!important;
+
+  p {
+    color: $gray-600;
+  }
+}
+
+.mobility-blocked-area-icon {
+  width: 24px!important;
+  height: 24px!important;
 }
 
 .mobility-map-cluster-icon {
@@ -13,7 +46,7 @@
   height: 36px !important;
   font-size: 16px;
   border-radius: 50%;
-  color: #14c260;
+  color: $primary;
   background-color: #fafafa;
   /* lower than scooter value (240) */
   z-index: 230;

--- a/webapp/src/assets/styles/mobility.scss
+++ b/webapp/src/assets/styles/mobility.scss
@@ -31,7 +31,14 @@
   }
 }
 
-.mobility-blocked-area-icon {
+.mobility-restricted-area-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: $danger;
+  color: $white;
+  font-size: $h6-font-size;
   width: 24px!important;
   height: 24px!important;
 }

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -1,6 +1,7 @@
 import api from "../api";
 import scooterIcon from "../assets/images/kick-scooter.png";
 import scooterContainer from "../assets/images/scooter-container.svg";
+import { t } from "../localization";
 import leaflet from "leaflet";
 import "leaflet.animatedmarker/src/AnimatedMarker";
 import "leaflet.markercluster/dist/MarkerCluster.css";
@@ -80,6 +81,8 @@ export default class MapBuilder {
   }
 
   loadScooters({ onVehicleClick }) {
+    // Loading geoFences here temporarily for example
+    this.loadGeoFences();
     this.setEventHandlers(onVehicleClick);
     this.getScooters(onVehicleClick);
     this._map.addLayer(this._mcg);
@@ -134,6 +137,163 @@ export default class MapBuilder {
         this.stopRefreshTimer();
         this.startRefreshTimer(r.data.refresh, onVehicleClick);
       });
+  }
+
+  loadGeoFences() {
+    // e.g.
+    // doNotParkOrRide: [
+    //    [Array of first restricted polygon latLngs area],
+    //    [Array of second restricted polygon latLngs area],
+    //    [...],
+    // ]
+    const apiResponse = {
+      doNotParkOrRide: [
+        [
+          [45.49584550855579, -122.68355369567871],
+          [45.49576278304519, -122.68331229686737],
+          [45.496168888931074, -122.68292605876921],
+          [45.49607488319949, -122.68264710903166],
+          [45.49703749446685, -122.68198192119598],
+          [45.49724806348807, -122.68259346485138],
+          [45.49600719897556, -122.68352150917053],
+          [45.495977117072165, -122.6834625005722],
+          [45.49584550855579, -122.68355369567871],
+        ],
+      ],
+      doNotRide: [
+        [
+          [45.50015270758223, -122.68442273139952],
+          [45.49948719071191, -122.68540441989899],
+          [45.49901906820077, -122.68492430448532],
+          [45.500212866911646, -122.68348127603531],
+          [45.50048734303642, -122.68365025520323],
+          [45.500530582303945, -122.68397212028502],
+          [45.50015270758223, -122.68442273139952],
+        ],
+      ],
+      doNotPark: [
+        [
+          [45.497545, -122.685026],
+          [45.4971314, -122.68488],
+          [45.497045, -122.6847],
+          [45.496717, -122.684948],
+          [45.49598, -122.68461],
+          [45.495777, -122.684347],
+          [45.495785, -122.684004],
+          [45.4959169, -122.683655],
+          [45.495728, -122.683194],
+          [45.4960335, -122.682896],
+          [45.4959827, -122.68276],
+          [45.4956349, -122.682848],
+          [45.4956349, -122.682496],
+          [45.496185, -122.68174],
+          [45.4965937, -122.68137],
+          [45.497022, -122.681212],
+          [45.4971051, -122.681268],
+          [45.497308, -122.681343],
+          [45.497797, -122.682384],
+          [45.49768, -122.68306],
+          [45.4979512, -122.683435],
+          [45.4978, -122.683945],
+          [45.497481, -122.684344],
+          [45.49751, -122.6846],
+          [45.4976071, -122.68474],
+          [45.497545, -122.685026],
+        ],
+        [
+          [45.50206179495491, -122.68491994589567],
+          [45.50153071609439, -122.68461316823958],
+          [45.501344602317154, -122.68466949462892],
+          [45.50120172667681, -122.68466010689735],
+          [45.500931013942854, -122.68455684185028],
+          [45.500531522287645, -122.68468961119653],
+          [45.50026456628402, -122.68468961119653],
+          [45.50019312713877, -122.68461316823958],
+          [45.500535282222344, -122.68412500619888],
+          [45.50083513620411, -122.68403112888336],
+          [45.50136340171654, -122.68418535590172],
+          [45.501996937805096, -122.68425107002257],
+          [45.50212665203002, -122.68437042832375],
+          [45.50216613021309, -122.6845595240593],
+          [45.50206179495491, -122.68491994589567],
+        ],
+      ],
+    };
+    Promise.resolve(apiResponse).then((r) => {
+      if (r.doNotPark) {
+        this.createRestrictedArea({
+          latlngs: r.doNotPark,
+          options: { restriction: "parking" },
+        });
+      }
+      if (r.doNotRide) {
+        this.createRestrictedArea({
+          latlngs: r.doNotRide,
+          options: { restriction: "riding" },
+        });
+      }
+      if (r.doNotParkOrRide) {
+        this.createRestrictedArea({
+          latlngs: r.doNotParkOrRide,
+          options: { restriction: "all" },
+        });
+      }
+    });
+  }
+
+  createRestrictedArea({ latlngs, options }) {
+    options = options || {};
+    const blockedIcon = this._l.divIcon({
+      iconAnchor: [12, 12],
+      iconSize: [24, 24],
+      className:
+        "mobility-blocked-area-icon bg-danger border-0 rounded-circle text-white text-center fs-6",
+      html: "<i class='bi bi-slash-circle'></i>",
+    });
+    let popup = this._l.popup({
+      direction: "top",
+      offset: [0, -5],
+    });
+    let polygonFillOpacity = 0.3;
+    const parkingRestrictionContent = `<h6 class='mb-0'>${t(
+      "mobility:do_not_park_title"
+    )}</h6><p class='m-0'>${t("mobility:do_not_park_intro")}</p>`;
+    const ridingRestrictionContent = `<h6 class='mb-0'>${t(
+      "mobility:do_not_ride_title"
+    )}</h6><p class='m-0'>${t("mobility:do_not_ride_intro")}</p>`;
+    const allRestrictionsContent =
+      parkingRestrictionContent + "<hr />" + ridingRestrictionContent;
+    if (options.restriction === "parking") {
+      popup.setContent(parkingRestrictionContent);
+      polygonFillOpacity = 0.2;
+    }
+    if (options.restriction === "riding") {
+      popup.setContent(ridingRestrictionContent);
+      polygonFillOpacity = 0.2;
+    }
+    if (options.restriction === "all") {
+      popup.setContent(allRestrictionsContent);
+    }
+
+    latlngs.forEach((area) => {
+      const marker = this._l
+        .marker(this._l.latLngBounds(area).getCenter(), {
+          icon: blockedIcon,
+          interactive: false,
+        })
+        .bindPopup(popup)
+        .addTo(this._map);
+      this._l
+        .polygon([area], {
+          fillOpacity: polygonFillOpacity,
+          color: "#b53d00",
+          weight: 1,
+        })
+        .on("click", () => {
+          marker.openPopup();
+        })
+        .addTo(this._map);
+    });
   }
 
   startRefreshTimer(interval, onVehicleClick) {


### PR DESCRIPTION
Fixes #161 
- Add function to create polygon shaped restricted areas (red color)
  - Add icon and popup content based on specific restriction (e.g. riding or parking restriction)
- Translate restriction popup warnings

<hr />
Fixes #34   

- "Spiderify"/cluster markers with same location after specific zoom level
![suma-marker-cluster-spiderify-img](https://user-images.githubusercontent.com/66847768/178377526-558a98ea-be67-4954-b410-1cd10e4df753.png)

Note: 
- Max zoom level changed to maximum allowed because some scooter markers are too close to each other and prevent a member from clicking it (in order to reserve the ride).
- A ticket will need to be made to fix bugs when removing/adding new markers on API refresh.
- Miscellaneous refactors in mapBuilder