### PR TITLE
Prefix locale paths with public url

### DIFF
--- a/webapp/src/localization/useI18Next.js
+++ b/webapp/src/localization/useI18Next.js
@@ -32,11 +32,11 @@ export function I18NextProvider({ children }) {
       .init({
         ns: ["strings"],
         // Disable fallback language for now so it's easy to see when translations are missing.
-        // fallbackLng: "en",
+        fallbackLng: false,
         initImmediate: false,
         lng: language,
         backend: {
-          loadPath: "/locale/{{lng}}/{{ns}}.json",
+          loadPath: `${process.env.PUBLIC_URL}/locale/{{lng}}/{{ns}}.json`,
         },
         interpolation: {
           // react already safes from xss


### PR DESCRIPTION
Avoid the / to /app redirect when running the build web app.
Fixes https://github.com/lithictech/suma/issues/149

Also sets fallback language to `false` to avoid loading `dev`
lang, as per https://www.i18next.com/overview/configuration-options#languages-namespaces-resources