### PR TITLE
Extension schema must be configurable

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,9 @@
     "BUILDPACK_RUN_LOAD_CONFIG": {
       "description": "https://elements.heroku.com/buildpacks/weibeld/heroku-buildpack-run",
       "value": "1"
+    },
+    "SUMA_DB_EXTENSION_SCHEMA": {
+      "required": "heroku_ext"
     }
   },
   "formation": {

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 bundle exec rake release
 if [[ "${RUN_INTEGRATION_TESTS_ON_RELEASE}" = "true" ]]; then

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -138,17 +138,9 @@ module Suma::Postgres
   def self.run_all_migrations(target: nil)
     Sequel.extension :migration
     Suma::Postgres.each_model_superclass do |cls|
-      self.install_all_extensions(cls.db)
+      cls.install_all_extensions
       Sequel::Migrator.run(cls.db, "db/migrations", target:)
     end
-  end
-
-  def self.install_all_extensions(db)
-    db.execute("CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public")
-    db.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public")
-    db.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public")
-    db.execute("CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA public")
-    db.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public")
   end
 
   # We can always register the models right away, since it does not have a side effect.

--- a/lib/suma/postgres/model.rb
+++ b/lib/suma/postgres/model.rb
@@ -25,12 +25,13 @@ class Suma::Postgres::Model
   configurable(:suma_db) do
     setting :uri, "postgres:/suma_test", key: "DATABASE_URL"
 
+    setting :extension_schema, "public"
+
     # The number of (Float) seconds that should be considered "slow" for a
     # single query; queries that take longer than this amount of time will be logged
     # at `warn` level.
     setting :slow_query_seconds, 0.01
 
-    ##
     # The maximum number of connections to use in the Sequel pool
     # Ref: http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-General+connection+options
     setting :max_connections, 4

--- a/lib/suma/postgres/model_utilities.rb
+++ b/lib/suma/postgres/model_utilities.rb
@@ -129,6 +129,23 @@ module Suma::Postgres::ModelUtilities
       return Suma::Postgres.now_sql
     end
 
+    def extension_schema
+      return "public"
+    end
+
+    def install_all_extensions
+      extensions = [
+        "citext",
+        "pg_stat_statements",
+        "pgcrypto",
+        "btree_gist",
+        "pg_trgm",
+      ]
+      extensions.each do |ext|
+        self.db.execute("CREATE EXTENSION IF NOT EXISTS #{ext} WITH SCHEMA #{self.extension_schema}")
+      end
+    end
+
     # TSort API -- yield each model class.
     def tsort_each_node(&)
       self.descendents.select(&:name).each(&)


### PR DESCRIPTION
Fixes broken release. Also sets `-e` on release script
so we don't swallow errors.

See https://stackoverflow.com/questions/73214844/error-extension-btree-gist-must-be-installed-in-schema-heroku-ext