### PR TITLE
Refactor map scooter updating and add expanded bounds function

### DIFF
--- a/webapp/src/assets/styles/mobility.scss
+++ b/webapp/src/assets/styles/mobility.scss
@@ -103,6 +103,6 @@
   border: 2px solid white;
 }
 
-.mobility-location-accuracy-circle-animation {
+.mobility-location-accuracy-circle-transition {
   transition: all 1000ms linear 0s;
 }

--- a/webapp/src/components/mobilitymap/Map.js
+++ b/webapp/src/components/mobilitymap/Map.js
@@ -47,6 +47,10 @@ const Map = () => {
     [user, setError, setReserveError]
   );
 
+  const handleVehicleRemove = () => {
+    setSelectedMapVehicle(null);
+  };
+
   const handleGetLastLocation = React.useCallback(
     (lastLocation) => setLastMarkerLocation(lastLocation),
     []
@@ -75,7 +79,10 @@ const Map = () => {
   );
 
   const handleEndTrip = () => {
-    loadedMap.loadScooters({ onVehicleClick: handleVehicleClick });
+    loadedMap.loadScooters({
+      onVehicleClick: handleVehicleClick,
+      onVehicleRemove: handleVehicleRemove,
+    });
   };
 
   const handleCloseTrip = () => {
@@ -95,7 +102,10 @@ const Map = () => {
       if (ongoingTrip) {
         map.beginTrip();
       } else {
-        map.loadScooters({ onVehicleClick: handleVehicleClick });
+        map.loadScooters({
+          onVehicleClick: handleVehicleClick,
+          onVehicleRemove: handleVehicleRemove,
+        });
       }
       setLoadedMap(map);
     }

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -86,7 +86,7 @@ export default class MapBuilder {
           this._animationTimeoutId = null;
         }
         this._locationAccuracyCircle._path.classList.remove(
-          "mobility-location-accuracy-circle-animation"
+          "mobility-location-accuracy-circle-transition"
         );
         this._locationMarker._icon.style.transition = "none";
       }
@@ -95,7 +95,7 @@ export default class MapBuilder {
       if (this._locationAccuracyCircle && this._locationMarker) {
         this._animationTimeoutId = setTimeout(() => {
           this._locationAccuracyCircle._path.classList.add(
-            "mobility-location-accuracy-circle-animation"
+            "mobility-location-accuracy-circle-transition"
           );
           this._locationMarker._icon.style.transition = "all 1000ms linear 0s";
         }, 250);
@@ -386,7 +386,7 @@ export default class MapBuilder {
             distance: 0,
           });
           this._locationAccuracyCircle = this._l.circle([loc.lat, loc.lng], {
-            className: "mobility-location-accuracy-circle-animation",
+            className: "mobility-location-accuracy-circle-transition",
             radius: location.accuracy,
             color: "#0495ff",
             fillColor: "#0495ff",

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -195,12 +195,7 @@ export default class MapBuilder {
     this._vehicleClicked = null;
   }
 
-  loadGeoFences() {
-    // TODO: Need to use new bounds logic
-    const bounds = this._l.latLngBounds(
-      this._l.latLng(45.40706339656264, -122.80156150460245),
-      this._l.latLng(45.58041884450583, -122.51986645843971)
-    );
+  loadGeoFences(bounds) {
     return api.getMobilityMapFeatures(boundsToParams(bounds)).then((d) => {
       d.data.restrictions.forEach((r) => {
         this.createRestrictedArea({
@@ -275,17 +270,6 @@ export default class MapBuilder {
       this._refreshId = null;
     }
     return this;
-  }
-
-  // Remove markers in visible bounds to prevent duplicates
-  removeVisibleLayers(bounds) {
-    const removableMarkers = [];
-    this._mcg.eachLayer((marker) => {
-      if (bounds.contains(marker._latlng)) {
-        removableMarkers.push(marker);
-      }
-    });
-    this._mcg.removeLayers(removableMarkers);
   }
 
   newMarker(id, bike, vehicleType, providers, precisionFactor) {

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -157,9 +157,7 @@ export default class MapBuilder {
     const currentMarkersIds = mcg.getLayers().map((marker) => marker.options.id);
     ["ebike", "escooter"].forEach((vehicleType) => {
       data[vehicleType]?.forEach((bike) => {
-        const id = `${bike.p}-${bike.c[0] * precisionFactor}-${
-          bike.c[1] * precisionFactor
-        }`;
+        const id = `${bike.p}-${bike.c[0]}-${bike.c[1]}${bike.d ? "-" + bike.d : ""}`;
         const marker = this.newMarker(
           id,
           bike,


### PR DESCRIPTION
Fixes part of (the comment by Rob in) #172 
Scooters now have an ID to keep track of them to add/remove every time map moves outside (expanded) bounds, or when API is refreshed periodically. This gives us the ability to add/remove any missing vehicles. Mobility scooter markers are now updated in expanded bounds instead of the current map bounds. Other miscellaneous refactors included, listed below.
- add marker ids and refactor updating scooters
- refactor lastbounds with new expanded bounds function
- fix loadGeoFences and remove unnecessary function
- fix location accuracy circle naming
- refactor function if statements to return sooner