### PR TITLE
Move endpoint-specific entities in API files

### DIFF
--- a/lib/suma/admin_api/auth.rb
+++ b/lib/suma/admin_api/auth.rb
@@ -6,11 +6,12 @@ require "suma/admin_api"
 
 class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
   include Suma::Service::Types
+  include Suma::AdminAPI::Entities
 
   resource :auth do
     desc "Return the current administrator member."
     get do
-      present admin_member, with: Suma::AdminAPI::CurrentMemberEntity, env:
+      present admin_member, with: CurrentMemberEntity, env:
     end
 
     params do
@@ -26,7 +27,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
       merror!(403, "This account is not an administrator.", code: "invalid_permissions") unless me.admin?
       set_member(me)
       status 200
-      present admin_member, with: Suma::AdminAPI::CurrentMemberEntity, env:
+      present admin_member, with: CurrentMemberEntity, env:
     end
 
     delete do
@@ -42,7 +43,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
         Suma::Service::Auth::Impersonation.new(env["warden"]).off(admin_member)
 
         status 200
-        present admin_member, with: Suma::AdminAPI::CurrentMemberEntity, env:
+        present admin_member, with: CurrentMemberEntity, env:
       end
 
       route_param :member_id, type: Integer do
@@ -53,7 +54,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
           Suma::Service::Auth::Impersonation.new(env["warden"]).on(target)
 
           status 200
-          present admin_member, with: Suma::AdminAPI::CurrentMemberEntity, env:
+          present admin_member, with: CurrentMemberEntity, env:
         end
       end
     end

--- a/lib/suma/admin_api/bank_accounts.rb
+++ b/lib/suma/admin_api/bank_accounts.rb
@@ -5,6 +5,8 @@ require "grape"
 require "suma/admin_api"
 
 class Suma::AdminAPI::BankAccounts < Suma::AdminAPI::V1
+  include Suma::AdminAPI::Entities
+
   resource :bank_accounts do
     route_param :id, type: Integer do
       helpers do
@@ -16,7 +18,7 @@ class Suma::AdminAPI::BankAccounts < Suma::AdminAPI::V1
 
       get do
         o = lookup
-        present o, with: Suma::AdminAPI::DetailedBankAccountEntity
+        present o, with: DetailedBankAccountEntity
       end
 
       delete do
@@ -24,7 +26,7 @@ class Suma::AdminAPI::BankAccounts < Suma::AdminAPI::V1
         o.db.transaction do
           o.soft_delete
         end
-        present o, with: Suma::AdminAPI::DetailedBankAccountEntity
+        present o, with: DetailedBankAccountEntity
       end
 
       params do
@@ -37,8 +39,13 @@ class Suma::AdminAPI::BankAccounts < Suma::AdminAPI::V1
           save_or_error!(o)
         end
         status 200
-        present o, with: Suma::AdminAPI::DetailedBankAccountEntity
+        present o, with: DetailedBankAccountEntity
       end
     end
+  end
+
+  class DetailedBankAccountEntity < BankAccountEntity
+    include Suma::AdminAPI::Entities
+    include AutoExposeDetail
   end
 end

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -3,9 +3,8 @@
 require "grape_entity"
 
 require "suma/service/entities"
-require "suma/admin_api" unless defined? Suma::AdminAPI
 
-module Suma::AdminAPI
+module Suma::AdminAPI::Entities
   MoneyEntity = Suma::Service::Entities::Money
   LegalEntityEntity = Suma::Service::Entities::LegalEntityEntity
   TimeRangeEntity = Suma::Service::Entities::TimeRange
@@ -68,36 +67,6 @@ module Suma::AdminAPI
     expose :timezone
   end
 
-  class MemberActivityEntity < BaseEntity
-    include AutoExposeBase
-    expose :message_name
-    expose :message_vars
-    expose :summary
-  end
-
-  class MemberResetCodeEntity < BaseEntity
-    include AutoExposeBase
-    expose :transport
-    expose :token
-    expose :used
-    expose :expire_at
-  end
-
-  class MemberSessionEntity < BaseEntity
-    include AutoExposeBase
-    expose :user_agent
-    expose :peer_ip, &self.delegate_to(:peer_ip, :to_s)
-    expose :ip_lookup_link do |instance|
-      "https://whatismyipaddress.com/ip/#{instance.peer_ip}"
-    end
-  end
-
-  class MessageBodyEntity < BaseEntity
-    include AutoExposeBase
-    expose :content
-    expose :mediatype
-  end
-
   class MessageDeliveryEntity < BaseEntity
     include AutoExposeBase
     expose :template
@@ -109,35 +78,11 @@ module Suma::AdminAPI
     expose :to
   end
 
-  class MessageDeliveryWithBodiesEntity < MessageDeliveryEntity
-    expose :bodies, with: MessageBodyEntity
-  end
-
   class BankAccountEntity < PaymentInstrumentEntity
     include AutoExposeDetail
     expose :verified_at
     expose :routing_number
     expose :account_number
     expose :account_type
-  end
-
-  class DetailedMemberEntity < MemberEntity
-    include AutoExposeDetail
-    expose :opaque_id
-    expose :note
-    expose :roles do |instance|
-      instance.roles.map(&:name)
-    end
-    expose :available_roles do |_|
-      Suma::Role.order(:name).select_map(:name)
-    end
-    expose :legal_entity, with: LegalEntityEntity
-    expose :activities, with: MemberActivityEntity
-    expose :reset_codes, with: MemberResetCodeEntity
-    expose :sessions, with: MemberSessionEntity
-  end
-
-  class DetailedBankAccountEntity < BankAccountEntity
-    include AutoExposeDetail
   end
 end

--- a/lib/suma/admin_api/message_deliveries.rb
+++ b/lib/suma/admin_api/message_deliveries.rb
@@ -5,6 +5,8 @@ require "grape"
 require "suma/admin_api"
 
 class Suma::AdminAPI::MessageDeliveries < Suma::AdminAPI::V1
+  include Suma::AdminAPI::Entities
+
   helpers do
     def lookup_delivery(params)
       (batch = Suma::Message::Delivery[params[:id]]) or forbidden!
@@ -27,20 +29,20 @@ class Suma::AdminAPI::MessageDeliveries < Suma::AdminAPI::V1
       end
       ds = order(ds, params)
       ds = paginate(ds, params)
-      present_collection ds, with: Suma::AdminAPI::MessageDeliveryEntity
+      present_collection ds, with: MessageDeliveryEntity
     end
 
     desc "Return the delivery with the last ID"
     get :last do
       delivery = Suma::Message::Delivery.last
-      present delivery, with: Suma::AdminAPI::MessageDeliveryWithBodiesEntity
+      present delivery, with: MessageDeliveryWithBodiesEntity
     end
 
     route_param :id, type: Integer do
       desc "Return the delivery"
       get do
         delivery = lookup_delivery(params)
-        present delivery, with: Suma::AdminAPI::MessageDeliveryWithBodiesEntity
+        present delivery, with: MessageDeliveryWithBodiesEntity
       end
     end
   end
@@ -51,9 +53,21 @@ class Suma::AdminAPI::MessageDeliveries < Suma::AdminAPI::V1
         desc "Return all message deliveries for member the given members, as recipients or to their emails"
         get do
           ds = Suma::Message::Delivery.to_members(Suma::Member.where(id: params[:id])).order(Sequel.desc(:id))
-          present_collection ds, with: Suma::AdminAPI::MessageDeliveryEntity
+          present_collection ds, with: MessageDeliveryEntity
         end
       end
     end
+  end
+
+  class MessageBodyEntity < BaseEntity
+    include Suma::AdminAPI::Entities
+    include AutoExposeBase
+    expose :content
+    expose :mediatype
+  end
+
+  class MessageDeliveryWithBodiesEntity < MessageDeliveryEntity
+    include Suma::AdminAPI::Entities
+    expose :bodies, with: MessageBodyEntity
   end
 end

--- a/lib/suma/admin_api/roles.rb
+++ b/lib/suma/admin_api/roles.rb
@@ -9,7 +9,7 @@ class Suma::AdminAPI::Roles < Suma::AdminAPI::V1
     desc "Return all roles, ordered by name"
     get do
       ds = Suma::Role.dataset.order(:name)
-      present_collection ds, with: Suma::AdminAPI::RoleEntity
+      present_collection ds, with: Suma::AdminAPI::Entities::RoleEntity
     end
   end
 end

--- a/lib/suma/api.rb
+++ b/lib/suma/api.rb
@@ -40,7 +40,7 @@ module Suma::API
           # and update the stored user to it.
           def add_current_member_header
             c = current_member
-            h = Suma::API::CurrentMemberEntity.represent(c, env:)
+            h = Suma::API::Entities::CurrentMemberEntity.represent(c, env:)
             j = h.to_json
             b64 = Base64.strict_encode64(j)
             header "Suma-Current-Member", b64

--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -6,6 +6,7 @@ require "suma/api"
 
 class Suma::API::Auth < Suma::API::V1
   include Suma::Service::Types
+  include Suma::API::Entities
 
   ALL_TIMEZONES = Set.new(TZInfo::Timezone.all_identifiers)
 
@@ -43,7 +44,7 @@ class Suma::API::Auth < Suma::API::V1
         end
         member.add_reset_code({transport: "sms"})
         status 200
-        present member, with: Suma::API::AuthFlowMemberEntity
+        present member, with: AuthFlowMemberEntity
       end
     end
 
@@ -75,7 +76,7 @@ class Suma::API::Auth < Suma::API::V1
       set_member(me)
       create_session(me)
       status 200
-      present me, with: Suma::API::CurrentMemberEntity, env:
+      present me, with: CurrentMemberEntity, env:
     end
 
     delete do
@@ -83,5 +84,9 @@ class Suma::API::Auth < Suma::API::V1
       status 204
       body ""
     end
+  end
+
+  class AuthFlowMemberEntity < BaseEntity
+    expose :requires_terms_agreement?, as: :requires_terms_agreement
   end
 end

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -5,7 +5,7 @@ require "grape_entity"
 require "suma/service/entities"
 require "suma/api" unless defined? Suma::API
 
-module Suma::API
+module Suma::API::Entities
   AddressEntity = Suma::Service::Entities::Address
   LegalEntityEntity = Suma::Service::Entities::LegalEntityEntity
   MoneyEntity = Suma::Service::Entities::Money
@@ -28,16 +28,6 @@ module Suma::API
     expose :native
   end
 
-  class AuthFlowMemberEntity < BaseEntity
-    expose :requires_terms_agreement?, as: :requires_terms_agreement
-  end
-
-  class MobilityMapVehicleEntity < BaseEntity
-    expose :c
-    expose :p
-    expose :d, expose_nil: false
-  end
-
   class OrganizationEntity < BaseEntity
     expose :name
     expose :slug
@@ -51,12 +41,6 @@ module Suma::API
     expose :can_use_for_funding?, as: :can_use_for_funding
   end
 
-  class MutationPaymentInstrumentEntity < PaymentInstrumentEntity
-    expose :all_payment_instruments, with: PaymentInstrumentEntity do |_inst, opts|
-      opts.fetch(:all_payment_instruments)
-    end
-  end
-
   class VendorServiceRateEntity < BaseEntity
     expose :id
     expose :localization_key
@@ -68,38 +52,6 @@ module Suma::API
     expose :external_name, as: :name
     expose :vendor_name, &self.delegate_to(:vendor, :name)
     expose :vendor_slug, &self.delegate_to(:vendor, :slug)
-  end
-
-  class MobilityMapEntity < BaseEntity
-    expose :precision do |_|
-      Suma::Mobility::COORD2INT_FACTOR
-    end
-    expose :refresh do |_|
-      30_000
-    end
-    expose :providers, with: VendorServiceEntity
-    expose :escooter, with: MobilityMapVehicleEntity, expose_nil: false
-    expose :ebike, with: MobilityMapVehicleEntity, expose_nil: false
-  end
-
-  class MobilityMapRestrictionEntity < BaseEntity
-    expose :restriction
-    expose :polygon_numeric, as: :polygon
-    expose :bounds_numeric, as: :bounds
-  end
-
-  class MobilityMapFeaturesEntity < BaseEntity
-    expose :restrictions, with: MobilityMapRestrictionEntity
-  end
-
-  class MobilityVehicleEntity < BaseEntity
-    expose :precision do |_|
-      Suma::Mobility::COORD2INT_FACTOR
-    end
-    expose :vendor_service, with: VendorServiceEntity
-    expose :vehicle_id
-    expose :to_api_location, as: :loc
-    expose :rate, with: VendorServiceRateEntity, &self.delegate_to(:vendor_service, :one_rate)
   end
 
   class MobilityTripEntity < BaseEntity
@@ -153,30 +105,5 @@ module Suma::API
     expose :id
     expose :name
     expose :balance, with: MoneyEntity
-  end
-
-  class MemberDashboardEntity < BaseEntity
-    expose :payment_account_balance, with: MoneyEntity
-    expose :lifetime_savings, with: MoneyEntity
-    expose :ledger_lines, with: LedgerLineEntity
-  end
-
-  class LedgersViewEntity < BaseEntity
-    expose :total_balance, with: MoneyEntity
-    expose :ledgers, with: LedgerEntity
-    expose :single_ledger_lines_first_page, with: LedgerLineEntity do |_, opts|
-      opts.fetch(:single_ledger_lines_first_page)
-    end
-    expose :single_ledger_page_count do |_, opts|
-      opts.fetch(:single_ledger_page_count)
-    end
-  end
-
-  class FundingTransactionEntity < BaseEntity
-    expose :id
-    expose :created_at
-    expose :status
-    expose :amount, with: MoneyEntity
-    expose :memo
   end
 end

--- a/lib/suma/api/ledgers.rb
+++ b/lib/suma/api/ledgers.rb
@@ -4,6 +4,8 @@ require "suma/payment/ledgers_view"
 require "suma/api"
 
 class Suma::API::Ledgers < Suma::API::V1
+  include Suma::API::Entities
+
   resource :ledgers do
     desc "Return an overview of all ledgers including balances, and recent transactions."
     get :overview do
@@ -19,7 +21,7 @@ class Suma::API::Ledgers < Suma::API::V1
       end
       present(
         lv,
-        with: Suma::API::LedgersViewEntity,
+        with: LedgersViewEntity,
         single_ledger_lines_first_page: first_page,
         single_ledger_page_count: page_count,
       )
@@ -36,8 +38,20 @@ class Suma::API::Ledgers < Suma::API::V1
         (ledger = me.payment_account.ledgers_dataset[params[:id]]) or forbidden!
         ds = ledger.combined_book_transactions_dataset
         ds = paginate(ds, params)
-        present_collection ds, with: Suma::API::LedgerLineEntity, ledger:
+        present_collection ds, with: LedgerLineEntity, ledger:
       end
+    end
+  end
+
+  class LedgersViewEntity < BaseEntity
+    include Suma::API::Entities
+    expose :total_balance, with: MoneyEntity
+    expose :ledgers, with: LedgerEntity
+    expose :single_ledger_lines_first_page, with: LedgerLineEntity do |_, opts|
+      opts.fetch(:single_ledger_lines_first_page)
+    end
+    expose :single_ledger_page_count do |_, opts|
+      opts.fetch(:single_ledger_page_count)
     end
   end
 end

--- a/lib/suma/api/meta.rb
+++ b/lib/suma/api/meta.rb
@@ -6,6 +6,8 @@ require "suma/api"
 require "suma/i18n"
 
 class Suma::API::Meta < Suma::API::V1
+  include Suma::API::Entities
+
   resource :meta do
     get :supported_geographies do
       use_http_expires_caching 2.days
@@ -26,12 +28,12 @@ class Suma::API::Meta < Suma::API::V1
       use_http_expires_caching 2.days
       cur = Suma::SupportedCurrency.dataset.order(:ordinal).all
       raise Suma::InvalidPrecondition, "no currencies set up, app is busted" if cur.empty?
-      present_collection cur, with: Suma::API::CurrencyEntity
+      present_collection cur, with: CurrencyEntity
     end
 
     get :supported_locales do
       use_http_expires_caching 2.days
-      present_collection Suma::I18n::SUPPORTED_LOCALES.values, with: Suma::API::LocaleEntity
+      present_collection Suma::I18n::SUPPORTED_LOCALES.values, with: LocaleEntity
     end
   end
 end

--- a/lib/suma/api/payment_instruments.rb
+++ b/lib/suma/api/payment_instruments.rb
@@ -3,6 +3,8 @@
 require "suma/api"
 
 class Suma::API::PaymentInstruments < Suma::API::V1
+  include Suma::API::Entities
+
   resource :payment_instruments do
     resource :bank_accounts do
       params do
@@ -33,7 +35,7 @@ class Suma::API::PaymentInstruments < Suma::API::V1
         status 200
         present(
           ba,
-          with: Suma::API::MutationPaymentInstrumentEntity,
+          with: MutationPaymentInstrumentEntity,
           all_payment_instruments: c.usable_payment_instruments,
         )
       end
@@ -52,11 +54,18 @@ class Suma::API::PaymentInstruments < Suma::API::V1
           ba.soft_delete
           present(
             ba,
-            with: Suma::API::MutationPaymentInstrumentEntity,
+            with: MutationPaymentInstrumentEntity,
             all_payment_instruments: current_member.usable_payment_instruments,
           )
         end
       end
+    end
+  end
+
+  class MutationPaymentInstrumentEntity < PaymentInstrumentEntity
+    include Suma::API::Entities
+    expose :all_payment_instruments, with: PaymentInstrumentEntity do |_inst, opts|
+      opts.fetch(:all_payment_instruments)
     end
   end
 end

--- a/lib/suma/api/payments.rb
+++ b/lib/suma/api/payments.rb
@@ -6,6 +6,7 @@ require "suma/api"
 
 class Suma::API::Payments < Suma::API::V1
   include Suma::Service::Types
+  include Suma::API::Entities
 
   resource :payments do
     params do
@@ -46,7 +47,16 @@ class Suma::API::Payments < Suma::API::V1
       end
       add_current_member_header
       status 200
-      present fx, with: Suma::API::FundingTransactionEntity
+      present fx, with: FundingTransactionEntity
     end
+  end
+
+  class FundingTransactionEntity < BaseEntity
+    include Suma::API::Entities
+    expose :id
+    expose :created_at
+    expose :status
+    expose :amount, with: MoneyEntity
+    expose :memo
   end
 end


### PR DESCRIPTION
As mostly a legacy decision, all entities are in one file. But they're better off where endpoint-specific entities can hang out in the entity file.