### PR TITLE
Mobility vehicle offset

### DIFF
--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -54,7 +54,7 @@ class Suma::API::Mobility < Suma::API::V1
         arr = map_obj[vehicle.vehicle_type.to_sym] ||= []
         arr << vhash
       end
-      Suma::Mobility.offset_disambiguated_vehicles(map_obj:)
+      Suma::Mobility.offset_disambiguated_vehicles(map_obj)
       map_obj[:providers] = vnd_services
       present map_obj, with: MobilityMapEntity
     end

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -54,24 +54,7 @@ class Suma::API::Mobility < Suma::API::V1
         arr = map_obj[vehicle.vehicle_type.to_sym] ||= []
         arr << vhash
       end
-      map_obj.each_value do |vehicles|
-        vehicles.group_by { |v| v[:c] }.each do |_, shared_loc_vehicles|
-          next if shared_loc_vehicles.count <= 1
-          two_pi = Math::PI * 2
-          circle_circumference = 50 * (2 + shared_loc_vehicles.count)
-          leg_length = circle_circumference / two_pi
-          angle_step = two_pi / shared_loc_vehicles.count
-          d = 0.5
-
-          shared_loc_vehicles.each_with_index do |v, idx|
-            angle = angle_step * idx
-            lat, lng = v[:c]
-            offset_lat = (lat + (leg_length * (d * Math.cos(angle)))).round
-            offset_lng = (lng + (leg_length * (d * Math.sin(angle)))).round
-            v[:c] = [offset_lat, offset_lng]
-          end
-        end
-      end
+      Suma::Mobility.offset_disambiguated_vehicles(map_obj:)
       map_obj[:providers] = vnd_services
       present map_obj, with: MobilityMapEntity
     end
@@ -161,6 +144,7 @@ class Suma::API::Mobility < Suma::API::V1
     expose :c
     expose :p
     expose :d, expose_nil: false
+    expose :o, expose_nil: false
   end
 
   class MobilityMapEntity < BaseEntity

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -54,6 +54,24 @@ class Suma::API::Mobility < Suma::API::V1
         arr = map_obj[vehicle.vehicle_type.to_sym] ||= []
         arr << vhash
       end
+      map_obj.each_value do |vehicles|
+        vehicles.group_by { |v| v[:c] }.each do |_, shared_loc_vehicles|
+          next if shared_loc_vehicles.count <= 1
+          two_pi = Math::PI * 2
+          circle_circumference = 50 * (2 + shared_loc_vehicles.count)
+          leg_length = circle_circumference / two_pi
+          angle_step = two_pi / shared_loc_vehicles.count
+          d = 0.5
+
+          shared_loc_vehicles.each_with_index do |v, idx|
+            angle = angle_step * idx
+            lat, lng = v[:c]
+            offset_lat = (lat + (leg_length * (d * Math.cos(angle)))).round
+            offset_lng = (lng + (leg_length * (d * Math.sin(angle)))).round
+            v[:c] = [offset_lat, offset_lng]
+          end
+        end
+      end
       map_obj[:providers] = vnd_services
       present map_obj, with: MobilityMapEntity
     end

--- a/lib/suma/mobility.rb
+++ b/lib/suma/mobility.rb
@@ -20,4 +20,25 @@ module Suma::Mobility
     raise OutOfBounds, "#{i} must be between -1.8b and 1.8b" unless INTCOORD_RANGE.cover?(i)
     return i * INT2COORD_FACTOR
   end
+
+  # Same location vehicles are spread equally around that location in a circular manner.
+  # We pass an offset variable for each vehicle to evaluate their new position.
+  def self.offset_disambiguated_vehicles(map_obj:)
+    map_obj.each_value do |vehicles|
+      vehicles.group_by { |v| v[:c] }.each do |_, shared_loc_vehicles|
+        next if shared_loc_vehicles.count <= 1
+        two_pi = Math::PI * 2
+        circle_circumference = 50 * shared_loc_vehicles.count
+        spread_length = circle_circumference / two_pi
+        angle_step = two_pi / shared_loc_vehicles.count
+        shared_loc_vehicles.each_with_index do |v, idx|
+          angle = angle_step * idx
+          lat, lng = v[:c]
+          offset_lat = (lat + (spread_length * Math.cos(angle))).round
+          offset_lng = (lng + (spread_length * Math.sin(angle))).round
+          v[:o] = [offset_lat, offset_lng]
+        end
+      end
+    end
+  end
 end

--- a/lib/suma/mobility.rb
+++ b/lib/suma/mobility.rb
@@ -10,6 +10,10 @@ module Suma::Mobility
   INT2COORD_FACTOR = BigDecimal("1") / COORD2INT_FACTOR
   COORD_RANGE = -180.0..180.0
   INTCOORD_RANGE = (-180.0 * COORD2INT_FACTOR)..(180.0 * COORD2INT_FACTOR)
+  # This 'magnitude' is in lat/lng degrees/minutes. It is not an actual
+  # distance like in meters (it isn't worth the complexity).
+  # 0.0000080 degrees is about 1 meter.
+  SPIDERIFY_OFFSET_MAGNITUDE = 0.000016
 
   def self.coord2int(c)
     raise OutOfBounds, "#{c} must be between -180 and 180" unless COORD_RANGE.cover?(c)
@@ -50,7 +54,7 @@ module Suma::Mobility
       # This 'magnitude' is in lat/lng degrees/minutes. It is not an actual
       # distance like in meters (it isn't worth the complexity).
       # 0.0000080 degrees is about 1 meter.
-      offset_magnitude = 0.000016 * COORD2INT_FACTOR
+      offset_magnitude = Suma::Mobility::SPIDERIFY_OFFSET_MAGNITUDE * COORD2INT_FACTOR
       shared_loc_vehicles.each_with_index do |v, idx|
         angle = angle_step * idx
         # The first step is 'up' and we want to avoid scooters vertically stacked

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Suma::API::Mobility, :db do
 
   before(:each) do
     login_as(member)
+    stub_const("Suma::Mobility::SPIDERIFY_OFFSET_MAGNITUDE", 0.000004)
   end
 
   describe "GET /v1/mobility/map" do
@@ -121,13 +122,13 @@ RSpec.describe Suma::API::Mobility, :db do
       expect(last_response).to have_json_body.
         that_includes(
           escooter: [
-            {c: [200_000_000, 1_200_000_000], p: 0, o: [0, -40]},
+            {c: [200_000_000, 1_200_000_000], p: 0, o: [28, -28]},
           ],
           ebike: [
-            {c: [200_000_000, 1_200_000_000], p: 0, d: "111", o: [40, 0]},
-            {c: [200_000_000, 1_200_000_000], p: 0, d: "211", o: [0, 40]},
+            {c: [200_000_000, 1_200_000_000], p: 0, d: "111", o: [28, 28]},
+            {c: [200_000_000, 1_200_000_000], p: 0, d: "211", o: [-28, 28]},
             {c: [400_000_000, 1_400_000_000], p: 0},
-            {c: [200_000_000, 1_200_000_000], p: 1, o: [-40, 0]},
+            {c: [200_000_000, 1_200_000_000], p: 1, o: [-28, -28]},
           ],
         )
     end
@@ -146,8 +147,8 @@ RSpec.describe Suma::API::Mobility, :db do
         expect(last_response).to have_json_body.
           that_includes(
             escooter: contain_exactly(
-              include(o: [40, 0]),
-              include(o: [-40, 0]),
+              include(o: [0, 40]),
+              include(o: [0, -40]),
             ),
           )
       end
@@ -158,10 +159,10 @@ RSpec.describe Suma::API::Mobility, :db do
         expect(last_response).to have_json_body.
           that_includes(
             escooter: contain_exactly(
-              include(o: [40, 0]),
-              include(o: [0, 40]),
-              include(o: [-40, 0]),
-              include(o: [0, -40]),
+              include(o: [28, 28]),
+              include(o: [-28, 28]),
+              include(o: [-28, -28]),
+              include(o: [28, -28]),
             ),
           )
       end
@@ -172,11 +173,11 @@ RSpec.describe Suma::API::Mobility, :db do
         expect(last_response).to have_json_body.
           that_includes(
             escooter: contain_exactly(
-              include(o: [40, 0]),
-              include(o: [12, 38]),
-              include(o: [-32, 24]),
-              include(o: [-32, -24]),
-              include(o: [12, -38]),
+              include(o: [32, 24]),
+              include(o: [-12, 38]),
+              include(o: [-40, 0]),
+              include(o: [-12, -38]),
+              include(o: [32, -24]),
             ),
           )
       end

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Suma::API::Mobility, :db do
   describe "GET /v1/mobility/map" do
     it "returns the location of all vehicles within the requested bounds" do
       fac = Suma::Fixtures.mobility_vehicle(vendor_service: Suma::Fixtures.vendor_service.mobility.create)
-      v1 = fac.loc(10, 100).escooter.create
-      v2 = fac.loc(20, 120).escooter.create
-      bike = fac.loc(20, 120).ebike.create
-      v3 = fac.loc(30, 130).escooter.create
+      v1 = fac.loc(11, 100).escooter.create
+      v2 = fac.loc(22, 120).escooter.create
+      bike = fac.loc(23, 120).ebike.create
+      v3 = fac.loc(31, 130).escooter.create
 
       get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
 
@@ -26,10 +26,10 @@ RSpec.describe Suma::API::Mobility, :db do
       expect(last_response).to have_json_body.
         that_includes(
           escooter: [
-            {c: [200_000_000, 1_200_000_000], p: 0},
+            {c: [220_000_000, 1_200_000_000], p: 0},
           ],
           ebike: [
-            {c: [200_000_000, 1_200_000_000], p: 0},
+            {c: [230_000_000, 1_200_000_000], p: 0},
           ],
         )
     end
@@ -121,13 +121,13 @@ RSpec.describe Suma::API::Mobility, :db do
       expect(last_response).to have_json_body.
         that_includes(
           escooter: [
-            {c: [200_000_000, 1_200_000_000], p: 0},
+            {c: [200_000_000, 1_200_000_000], p: 0, o: [0, -40]},
           ],
           ebike: [
-            {c: [200_000_000, 1_200_000_000], p: 0, d: "111", o: [200_000_024, 1_200_000_000]},
-            {c: [200_000_000, 1_200_000_000], p: 0, d: "211", o: [199_999_988, 1_200_000_021]},
+            {c: [200_000_000, 1_200_000_000], p: 0, d: "111", o: [40, 0]},
+            {c: [200_000_000, 1_200_000_000], p: 0, d: "211", o: [0, 40]},
             {c: [400_000_000, 1_400_000_000], p: 0},
-            {c: [200_000_000, 1_200_000_000], p: 1, o: [199_999_988, 1_199_999_979]},
+            {c: [200_000_000, 1_200_000_000], p: 1, o: [-40, 0]},
           ],
         )
     end
@@ -146,8 +146,8 @@ RSpec.describe Suma::API::Mobility, :db do
         expect(last_response).to have_json_body.
           that_includes(
             escooter: contain_exactly(
-              include(o: [200_000_016, 1_200_000_000]),
-              include(o: [199_999_984, 1_200_000_000]),
+              include(o: [40, 0]),
+              include(o: [-40, 0]),
             ),
           )
       end
@@ -158,10 +158,10 @@ RSpec.describe Suma::API::Mobility, :db do
         expect(last_response).to have_json_body.
           that_includes(
             escooter: contain_exactly(
-              include(o: [200_000_032, 1_200_000_000]),
-              include(o: [200_000_000, 1_200_000_032]),
-              include(o: [199_999_968, 1_200_000_000]),
-              include(o: [200_000_000, 1_199_999_968]),
+              include(o: [40, 0]),
+              include(o: [0, 40]),
+              include(o: [-40, 0]),
+              include(o: [0, -40]),
             ),
           )
       end
@@ -172,11 +172,11 @@ RSpec.describe Suma::API::Mobility, :db do
         expect(last_response).to have_json_body.
           that_includes(
             escooter: contain_exactly(
-              include(o: [200_000_040, 1_200_000_000]),
-              include(o: [200_000_012, 1_200_000_038]),
-              include(o: [199_999_968, 1_200_000_023]),
-              include(o: [199_999_968, 1_199_999_977]),
-              include(o: [200_000_012, 1_199_999_962]),
+              include(o: [40, 0]),
+              include(o: [12, 38]),
+              include(o: [-32, 24]),
+              include(o: [-32, -24]),
+              include(o: [12, -38]),
             ),
           )
       end

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -280,6 +280,8 @@ export default class MapBuilder {
   }
 
   newMarker(id, bike, vehicleType, providers, precisionFactor) {
+    // use offset coordinates when available
+    bike.c = !bike.o ? bike.c : bike.o;
     const [lat, lng] = bike.c;
     return this._l
       .marker([lat * precisionFactor, lng * precisionFactor], {

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -31,11 +31,9 @@ export default class MapBuilder {
     this.newLocateControl().addTo(this._map);
     this._lastExtendedBounds = expandBounds(this._map.getBounds());
     this._mcg = this._l.markerClusterGroup({
+      spiderfyOnMaxZoom: false,
       showCoverageOnHover: false,
-      maxClusterRadius: (mapZoom) => {
-        // only cluster same location markers above zoom 17
-        return mapZoom >= 17 ? 0 : 32;
-      },
+      maxClusterRadius: 32,
       iconCreateFunction: (cluster) => {
         return this._l.divIcon({
           html: "<b>" + cluster.getChildCount() + "</b>",
@@ -280,9 +278,12 @@ export default class MapBuilder {
   }
 
   newMarker(id, bike, vehicleType, providers, precisionFactor) {
-    // use offset coordinates when available
-    bike.c = !bike.o ? bike.c : bike.o;
-    const [lat, lng] = bike.c;
+    // calculate lat, lng offsets when available
+    let [lat, lng] = bike.c;
+    if (bike.o) {
+      lat += bike.o[0];
+      lng += bike.o[1];
+    }
     return this._l
       .marker([lat * precisionFactor, lng * precisionFactor], {
         id,

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -33,7 +33,10 @@ export default class MapBuilder {
     this._mcg = this._l.markerClusterGroup({
       spiderfyOnMaxZoom: false,
       showCoverageOnHover: false,
-      maxClusterRadius: 32,
+      maxClusterRadius: (mapZoom) => {
+        // only cluster same location markers above zoom 17
+        return mapZoom >= 17 ? 0 : 32;
+      },
       iconCreateFunction: (cluster) => {
         return this._l.divIcon({
           html: "<b>" + cluster.getChildCount() + "</b>",
@@ -284,8 +287,13 @@ export default class MapBuilder {
       lat += bike.o[0];
       lng += bike.o[1];
     }
+    lat = lat * precisionFactor;
+    lng = lng * precisionFactor;
+    // if (bike.o) {
+    //   this._l.circle([lat, lng], {radius: 10}).addTo(this._map)
+    // }
     return this._l
-      .marker([lat * precisionFactor, lng * precisionFactor], {
+      .marker([lat, lng], {
         id,
         icon: this._scooterIcon,
         riseOnHover: true,


### PR DESCRIPTION
Fixes #172 
On the mobility map, instead of "spiderfying" same location vehicles, we implement offsetting function on the back-end that will spread vehicles locations in a circular manner

### Mobility map vehicle offsetting visual examples 
(images may differ with #[2e6d87f](https://github.com/lithictech/suma/pull/215/commits/2e6d87fb93e9b1a6a37f29574c3b919801856f1a) changes)

**Two vehicles**
![two_scooters](https://user-images.githubusercontent.com/66847768/195234387-fc598d51-ac75-44bd-9203-f21102ad5530.png)

**Three vehicles**
![three_scooters](https://user-images.githubusercontent.com/66847768/195234443-dc6bb42e-25d6-441d-aecb-5b784d412296.png)

**Four vehicles**
![Screenshot 2022-10-10 171353](https://user-images.githubusercontent.com/66847768/195234759-d6c2ecae-50ad-4378-b4f4-0a67e0a6a10f.png)

**Five vehicles**
![five_scooters](https://user-images.githubusercontent.com/66847768/195234809-4b86a6f3-95b8-414d-8c6c-6e22b54f25fa.png)

**Six Vehicles**
![six_scooters](https://user-images.githubusercontent.com/66847768/195234866-299fbaae-fa97-444c-ab9c-ac03abc33cd3.png)
