### PR TITLE
Fix ledgers overview next pagination button bugs

### DIFF
--- a/webapp/src/components/ForwardBackPagination.js
+++ b/webapp/src/components/ForwardBackPagination.js
@@ -25,7 +25,7 @@ export default function ForwardBackPagination({
         {t("common:pagination_prev")}
       </Pagination.Prev>
       <Pagination.Next
-        className={clsx(page >= pageCount && "disabled")}
+        className={clsx((page >= pageCount || pageCount <= 1) && "disabled")}
         onClick={() => handlePageChange(page + 1)}
       >
         {t("common:pagination_next")}

--- a/webapp/src/pages/LedgersOverview.js
+++ b/webapp/src/pages/LedgersOverview.js
@@ -17,7 +17,7 @@ import Container from "react-bootstrap/Container";
 import Table from "react-bootstrap/Table";
 
 export default function LedgersOverview() {
-  const { page, setPage } = useListQueryControls();
+  const { page, setListQueryParams } = useListQueryControls();
   const { state: ledgersOverview, loading: ledgersOverviewLoading } = useAsyncFetch(
     api.getLedgersOverview,
     {
@@ -46,7 +46,7 @@ export default function LedgersOverview() {
   }, [ledger]);
 
   const handleLinesPageChange = (pg) => {
-    setPage(pg);
+    setListQueryParams({ page: pg });
     ledgerLinesFetch({ id: ledger.id, page: pg });
   };
   return (

--- a/webapp/src/shared/react/useListQueryControls.js
+++ b/webapp/src/shared/react/useListQueryControls.js
@@ -3,7 +3,7 @@ import { useSearchParams } from "react-router-dom";
 
 export default function useListQueryControls() {
   const [params, setParams] = useSearchParams(new URLSearchParams());
-  const page = Number(params.get("page") || "0");
+  const page = Number(params.get("page") || "1");
   const perPage = Number(params.get("pagesize") || "50");
   const search = params.get("search");
   const order = params.get("order");


### PR DESCRIPTION
Fixes #217 
- **useListQueryControls** page variable begins at 1 instead of 0 (otherwise the first click on "next" pagination will re-render the first page)
- use correct function to change pages in LedgersOverview component
- add extra "next" pagination condition to disable "next" button if the page is equal to "1" (or less)