### PR TITLE
Refactor/add appNav below topNav to the withLayout method

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -144,7 +144,7 @@ function AppRoutes() {
             redirectIfUnboarded,
             withScreenLoaderMount(),
             withMetatags({ title: t("titles:dashboard") }),
-            withLayout({}),
+            withLayout({ appNav: true }),
             Dashboard
           )}
         />
@@ -156,7 +156,7 @@ function AppRoutes() {
             redirectIfUnboarded,
             withScreenLoaderMount(),
             withMetatags({ title: t("mobility:title") }),
-            withLayout({ noBottom: true }),
+            withLayout({ noBottom: true, appNav: true }),
             Mobility
           )}
         />
@@ -168,7 +168,7 @@ function AppRoutes() {
             redirectIfUnboarded,
             withScreenLoaderMount(),
             withMetatags({ title: t("food:title") }),
-            withLayout({}),
+            withLayout({ appNav: true }),
             Food
           )}
         />
@@ -180,7 +180,7 @@ function AppRoutes() {
             redirectIfUnboarded,
             withScreenLoaderMount(),
             withMetatags({ title: t("utilities:title") }),
-            withLayout({}),
+            withLayout({ appNav: true }),
             Utilities
           )}
         />

--- a/webapp/src/components/AppNav.js
+++ b/webapp/src/components/AppNav.js
@@ -5,32 +5,27 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 
 export default function AppNav() {
-  const { setAppNav, topNav } = useGlobalViewState();
-  const top = topNav?.clientHeight || 0;
+  const { setAppNav } = useGlobalViewState();
   return (
-    <div ref={setAppNav} className="app-nav d-flex flex-row sticky-top" style={{ top }}>
-      <AppLink to="/dashboard" label={t("titles:home")} style={{ borderRightWidth: 0 }} />
-      <AppLink
-        to="/mobility"
-        label={t("titles:mobility")}
-        style={{ borderRightWidth: 0 }}
-      />
-      <AppLink to="/food" label={t("food:title")} style={{ borderRightWidth: 0 }} />
+    <div ref={setAppNav} className="app-nav d-flex flex-row">
+      <AppLink to="/dashboard" label={t("titles:home")} className="border-end-0" />
+      <AppLink to="/mobility" label={t("titles:mobility")} className="border-end-0" />
+      <AppLink to="/food" label={t("food:title")} className="border-end-0" />
       <AppLink to="/utilities" label={t("utilities:title")} />
     </div>
   );
 }
 
-const AppLink = ({ to, label, style }) => {
+const AppLink = ({ to, label, className }) => {
   const location = useLocation();
   return (
     <Link
       to={to}
       className={clsx(
         "btn btn-outline-primary app-link",
-        location.pathname === to && "app-link-active"
+        location.pathname === to && "app-link-active",
+        className
       )}
-      style={style}
     >
       {label}
     </Link>

--- a/webapp/src/components/WaitingListPage.js
+++ b/webapp/src/components/WaitingListPage.js
@@ -1,6 +1,5 @@
 import api from "../api";
 import AnimatedCheckmark from "../components/AnimatedCheckmark";
-import AppNav from "../components/AppNav";
 import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
 import { t } from "../localization";
@@ -48,7 +47,6 @@ export default function WaitingListPage({ feature, imgSrc, imgAlt, title, text }
   }
   return (
     <>
-      <AppNav />
       <img src={imgSrc} alt={imgAlt} className="thin-header-image" />
       <LayoutContainer top gutters>
         {content}

--- a/webapp/src/pages/Dashboard.js
+++ b/webapp/src/pages/Dashboard.js
@@ -1,5 +1,4 @@
 import api from "../api";
-import AppNav from "../components/AppNav";
 import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
 import { md, t } from "../localization";
@@ -26,7 +25,6 @@ const Dashboard = () => {
 
   return (
     <>
-      <AppNav />
       {user.ongoingTrip && (
         <Alert variant="danger" className="border-radius-0">
           <p>{t("dashboard:check_ongoing_trip")}</p>

--- a/webapp/src/pages/Mobility.js
+++ b/webapp/src/pages/Mobility.js
@@ -1,4 +1,3 @@
-import AppNav from "../components/AppNav";
 import ExternalLink from "../components/ExternalLink";
 import Map from "../components/mobilitymap/Map";
 import { t } from "../localization";
@@ -9,7 +8,6 @@ import React from "react";
 export default function Mobility() {
   return (
     <>
-      <AppNav />
       <LayoutContainer top gutters>
         <h5>{t("mobility:title")}</h5>
         <p className="text-secondary">

--- a/webapp/src/state/withLayout.js
+++ b/webapp/src/state/withLayout.js
@@ -1,4 +1,5 @@
 import "../assets/styles/screenloader.scss";
+import AppNav from "../components/AppNav";
 import TopNav from "../components/TopNav";
 import ScrollTopOnMount from "../shared/ScrollToTopOnMount";
 import clsx from "clsx";
@@ -14,6 +15,7 @@ import Row from "react-bootstrap/Row";
  *
  * @param {object=} options
  * @param {string=} options.nav 'top' or 'none'
+ * @param {boolean=} options.appNav If true, display appNav below topNav
  * @param {boolean=} options.gutters If true, put this page in a Container/Row/Column,
  *   which provides automatic gutters.
  * @param {boolean=} options.top If true, add an mt-3 to the page content,
@@ -28,6 +30,7 @@ import Row from "react-bootstrap/Row";
 export default function withLayout(options) {
   options = options || {};
   const nav = options.nav || "top";
+  const appNav = options.appNav;
   const bg = options.bg || "bg-light";
   const gutterCls = options.gutters ? guttersClass : null;
   const topCls = options.top ? topMarginClass : null;
@@ -59,7 +62,10 @@ export default function withLayout(options) {
         <div className={clsx(bg, "root", noBottomCls)}>
           {scrollTop && <ScrollTopOnMount />}
           <div className="main-container">
-            {nav === "top" && <TopNav />}
+            <div className="sticky-top">
+              {nav === "top" && <TopNav />}
+              {appNav === true && <AppNav />}
+            </div>
             {node}
           </div>
         </div>

--- a/webapp/src/state/withLayout.js
+++ b/webapp/src/state/withLayout.js
@@ -31,6 +31,7 @@ export default function withLayout(options) {
   options = options || {};
   const nav = options.nav || "top";
   const appNav = options.appNav;
+  const hasNav = nav !== "none" || options.navApp;
   const bg = options.bg || "bg-light";
   const gutterCls = options.gutters ? guttersClass : null;
   const topCls = options.top ? topMarginClass : null;
@@ -62,10 +63,12 @@ export default function withLayout(options) {
         <div className={clsx(bg, "root", noBottomCls)}>
           {scrollTop && <ScrollTopOnMount />}
           <div className="main-container">
-            <div className="sticky-top">
-              {nav === "top" && <TopNav />}
-              {appNav === true && <AppNav />}
-            </div>
+            {hasNav && (
+              <div className="sticky-top">
+                {nav === "top" && <TopNav />}
+                {appNav === true && <AppNav />}
+              </div>
+            )}
             {node}
           </div>
         </div>


### PR DESCRIPTION
Fixes #230 
- Remove appNav from components and instead render it to withLayout as an option (displayed below topNav)
- Configure withLayouts in App.js for routes that need appNav (e.g dashboard, mobility, etc.)
- Refactor the border style of the appNav tabs