### PR TITLE
Fix bug with admin links and PUBLIC_URL

### DIFF
--- a/adminapp/src/modules/relativeLink.js
+++ b/adminapp/src/modules/relativeLink.js
@@ -1,8 +1,17 @@
 /**
- * Parse the given href as a relative link,
- * if it has the same root as the current URL.
- * Return the relative link and true if the given href is relative,
- * or the given href and false if not relative.
+ * Return [relative href, true] or
+ * [href, false], depending on the following:
+ *
+ * - If href is relative, return it as relative verbatim: [href, true].
+ * - If href starts with the current protocol/host and the app public url,
+ *   return it as a real relative url to the application.
+ *   For example, at `http://x.y/myapp` (that is, a PUBLIC_URL of 'myapp')
+ *   using href `http://xy.y/myapp/page1`, return `/page1`.
+ *   At `http://x.y` (that is, a PUBLIC_URL of '')
+ *   using href `http://xy.y/myapp/page1`, return `/myapp/page1`.
+ * - Otherwise, return [href, false]. That is, at `http://x.y/myapp`,
+ *   the hrefs `http://a.b/myapp/page` and `http://x.y/page1`
+ *   would both be treated as non-relative.
  *
  * @param {string} href
  * @returns {[string,boolean]}
@@ -15,4 +24,4 @@ export default function relativeLink(href) {
   }
 }
 
-const start = `${window.location.protocol}//${window.location.host}`;
+const start = `${window.location.protocol}//${window.location.host}${process.env.PUBLIC_URL}`;


### PR DESCRIPTION
For https://app.mysuma.org/admin/member/1,
`relativeUrl` would return `/admin/member/1`,
which would be added to the app url and yield `/admin/admin/member/1`. Instead it should be relative to the current app.

Fixes #240 