### PR TITLE
Fix hard-coded cart subtotal, and fix error deleting cart items

### DIFF
--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -167,6 +167,7 @@ class Suma::API::Commerce < Suma::API::V1
 
   class CartEntity < BaseEntity
     expose :items, with: CartItemEntity
+    expose :customer_cost, with: Suma::Service::Entities::Money
   end
 
   class OfferingEntity < BaseEntity

--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -94,6 +94,7 @@ class Suma::API::Commerce < Suma::API::V1
           def lookup!
             (ch = Suma::Commerce::Checkout[params[:id]]) or forbidden!
             forbidden! unless ch.cart.member === current_member
+            forbidden! if ch.items.empty? # This can happen when cart items are cleared after checkout starts
             return ch
           end
 

--- a/lib/suma/commerce/cart.rb
+++ b/lib/suma/commerce/cart.rb
@@ -62,6 +62,7 @@ class Suma::Commerce::Cart < Suma::Postgres::Model(:commerce_carts)
     bad_ts = timestamp != IGNORE && (timestamp.nil? || timestamp <= item.timestamp)
     raise OutOfOrderUpdate.new(item, timestamp) if bad_ts
     if quantity <= 0
+      item.checkout_items_dataset.delete
       item.delete
       self.items.delete(item)
     else

--- a/lib/suma/commerce/cart.rb
+++ b/lib/suma/commerce/cart.rb
@@ -31,6 +31,10 @@ class Suma::Commerce::Cart < Suma::Postgres::Model(:commerce_carts)
     return self.find_or_create_or_find(member:, offering:)
   end
 
+  def customer_cost
+    return self.items.sum(Money.new(0)) { |ci| ci.offering_product.customer_price * ci.quantity }
+  end
+
   IGNORE = Object.new.freeze
 
   # Add, updated, or remove (quantity <= 0 ) the given product on this cart.

--- a/lib/suma/commerce/cart_item.rb
+++ b/lib/suma/commerce/cart_item.rb
@@ -8,6 +8,7 @@ class Suma::Commerce::CartItem < Suma::Postgres::Model(:commerce_cart_items)
 
   many_to_one :cart, class: "Suma::Commerce::Cart"
   many_to_one :product, class: "Suma::Commerce::Product"
+  one_to_many :checkout_items, class: "Suma::Commerce::CheckoutItem"
   one_to_one :offering_product,
              class: "Suma::Commerce::OfferingProduct",
              readonly: true,

--- a/lib/suma/fixtures/carts.rb
+++ b/lib/suma/fixtures/carts.rb
@@ -20,4 +20,10 @@ module Suma::Fixtures::Carts
   decorator :with_product, presave: true do |product, quantity=1, **opts|
     self.add_item(product:, quantity:, timestamp: 0, **opts)
   end
+
+  decorator :with_any_product, presave: true do |quantity: 1|
+    product = Suma::Fixtures.product.create
+    Suma::Fixtures.offering_product(product:, offering: self.offering).create
+    self.add_item(product:, quantity:, timestamp: 0)
+  end
 end

--- a/spec/suma/api/commerce_spec.rb
+++ b/spec/suma/api/commerce_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe Suma::API::Commerce, :db do
   end
 
   describe "GET /v1/commerce/checkouts/:id" do
-    let!(:cart) { Suma::Fixtures.cart(member:).create }
-    let(:checkout) { Suma::Fixtures.checkout(cart:).create }
+    let!(:cart) { Suma::Fixtures.cart(member:).with_any_product.create }
+    let(:checkout) { Suma::Fixtures.checkout(cart:).populate_items.create }
 
     it "returns the checkout and other data" do
       get "/v1/commerce/checkouts/#{checkout.id}"
@@ -179,6 +179,14 @@ RSpec.describe Suma::API::Commerce, :db do
 
     it "errors if the checkout does not belong to the member" do
       checkout.cart.update(member: Suma::Fixtures.member.create)
+
+      get "/v1/commerce/checkouts/#{checkout.id}"
+
+      expect(last_response).to have_status(403)
+    end
+
+    it "errors if the checkout has no items" do
+      checkout.items_dataset.delete
 
       get "/v1/commerce/checkouts/#{checkout.id}"
 
@@ -277,8 +285,8 @@ RSpec.describe Suma::API::Commerce, :db do
   end
 
   describe "GET /v1/commerce/checkouts/:id/confirmation" do
-    let!(:cart) { Suma::Fixtures.cart(member:).create }
-    let(:checkout) { Suma::Fixtures.checkout(cart:).create }
+    let!(:cart) { Suma::Fixtures.cart(member:).with_any_product.create }
+    let(:checkout) { Suma::Fixtures.checkout(cart:).populate_items.create }
 
     it "returns the completed checkout" do
       checkout.complete.save_changes

--- a/spec/suma/commerce/cart_spec.rb
+++ b/spec/suma/commerce/cart_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe "Suma::Commerce::Cart", :db do
       cart.set_item(product, 0, timestamp:)
       expect(cart.items).to be_empty
     end
+
+    it "deletes any associated checkout items" do
+      cart.set_item(product, 10, timestamp: 10)
+      co = Suma::Fixtures.checkout(cart:).populate_items.create
+      expect(co.items).to contain_exactly(have_attributes(cart_item: be === cart.items.first))
+
+      cart.set_item(product, 0, timestamp: 20)
+      expect(co.refresh.items).to be_empty
+    end
   end
 
   describe "Suma::Commerce::CartItem" do

--- a/webapp/src/pages/FoodCart.js
+++ b/webapp/src/pages/FoodCart.js
@@ -78,7 +78,7 @@ export default function FoodCart() {
               <p>
                 Subtotal ({cart.items.length} items):{" "}
                 <b className="ms-2">
-                  <Money>{temporaryOrderSummaryObj.subtotalPrice}</Money>
+                  <Money>{cart.customerCost}</Money>
                 </b>
               </p>
               <Button onClick={handleCheckout} variant="success">
@@ -127,11 +127,3 @@ function CartItem({ offeringId, product, vendor }) {
     </>
   );
 }
-
-// TODO: Remove
-const temporaryOrderSummaryObj = {
-  subtotalPrice: {
-    cents: 4600,
-    currency: "USD",
-  },
-};


### PR DESCRIPTION
Fix bug after deleting cart items

If a cart item was deleted while it pointed to a checkout,
it would error due to a non-null constraint.

Instead we need to delete the checkout item entirely.
This however can lead to zero-item checkouts;
in these cases, we 403 when trying to fetch them,
since they are as good as deleted.

---

Expose cart subtotal and render that on cart page

