### PR TITLE
Fix localization warning errors

### DIFF
--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -157,9 +157,9 @@
     "zoom_out": "Zoom out"
   },
   "onboarding": {
-    "enroll_intro": "Welcome to Suma! To get started, we will need to verify your identity. This makes sure you are eligible for the right programs, such as with our affordable housing partners.\n\n**We will never share this information other than to verify your identity.**",
+    "enroll_intro_md": "Welcome to Suma! To get started, we will need to verify your identity. This makes sure you are eligible for the right programs, such as with our affordable housing partners.\n\n**We will never share this information other than to verify your identity.**",
     "enroll_title": "Enroll in Suma",
-    "finish": "Thanks! Our team will check things out and be in touch with any questions, or as soon as you&rsquo;re verified.\n\nVerification usually happens within 1-2 business days.\n\nIn the meantime, you can learn more about the application and see what is available.",
+    "finish_md": "Thanks! Our team will check things out and be in touch with any questions, or as soon as you&rsquo;re verified.\n\nVerification usually happens within 1-2 business days.\n\nIn the meantime, you can learn more about the application and see what is available.",
     "food_text": "Suma partners with the grocers you already use to offer discounts and bundled benefits",
     "food_title": "Fresh Groceries",
     "mobility_text": "Reduced-fare clean-energy transportation with electric scooters and bikes",

--- a/webapp/src/pages/OnboardingFinish.js
+++ b/webapp/src/pages/OnboardingFinish.js
@@ -5,7 +5,7 @@ import Button from "react-bootstrap/Button";
 export default function OnboardingFinish() {
   return (
     <>
-      {mdp("onboarding:finish")}
+      {mdp("onboarding:finish_md")}
       <div className="button-stack">
         <Button href="/dashboard" variant="outline-primary" className="mt-3">
           {t("common:okay_ex")}

--- a/webapp/src/pages/OnboardingSignup.js
+++ b/webapp/src/pages/OnboardingSignup.js
@@ -77,7 +77,7 @@ export default function OnboardingSignup() {
   return (
     <>
       <h2 className="page-header">{t("onboarding:enroll_title")}</h2>
-      {mdp("onboarding:enroll_intro")}
+      {mdp("onboarding:enroll_intro_md")}
       <Form noValidate onSubmit={handleSubmit(handleFormSubmit)}>
         <FormControlGroup
           className="mb-3"


### PR DESCRIPTION
Fixes #246 
- Fixes bugs where localization strings were not matching the correct localization function.

`food:intro_md` should use function `md("food:intro")` instead of `t("food:intro")` for markdown conversion to work properly and efficiently.