### PR TITLE
Fix bug with funding strategy specs

### DIFF
--- a/lib/suma/payment/fake_strategy.rb
+++ b/lib/suma/payment/fake_strategy.rb
@@ -11,6 +11,7 @@ class Suma::Payment::FakeStrategy < Suma::Postgres::Model(:payment_fake_strategi
   def initialize(*)
     @memory_responses = {}
     super
+    self[:responses] ||= Sequel.pg_json({})
   end
 
   def short_name
@@ -56,6 +57,12 @@ class Suma::Payment::FakeStrategy < Suma::Postgres::Model(:payment_fake_strategi
       result.is_a?(Suma::Postgres::Model)
     self.responses = self.responses.merge(symbol.to_s => result)
     self.save_changes
+    return self
+  end
+
+  def not_ready
+    return self.set_response(:check_validity, []).
+        set_response(:ready_to_collect_funds?, false)
   end
 end
 

--- a/spec/suma/admin_api/funding_transactions_spec.rb
+++ b/spec/suma/admin_api/funding_transactions_spec.rb
@@ -83,10 +83,12 @@ RSpec.describe Suma::AdminAPI::FundingTransactions, :db do
       member = Suma::Fixtures.member.create
       ba = Suma::Fixtures.bank_account.member(member).verified.create
 
-      post "/v1/funding_transactions/create_for_self",
-           amount: {cents: 500, currency: "USD"},
-           payment_instrument_id: ba.id,
-           payment_method_type: ba.payment_method_type
+      Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.not_ready) do
+        post "/v1/funding_transactions/create_for_self",
+             amount: {cents: 500, currency: "USD"},
+             payment_instrument_id: ba.id,
+             payment_method_type: ba.payment_method_type
+      end
 
       expect(last_response).to have_status(200)
       expect(last_response.headers).to include("Created-Resource-Admin")

--- a/spec/suma/api/payments_spec.rb
+++ b/spec/suma/api/payments_spec.rb
@@ -16,10 +16,12 @@ RSpec.describe Suma::API::Payments, :db do
     it "creates a new funding and book transaction" do
       ba = Suma::Fixtures.bank_account.member(member).verified.create
 
-      post "/v1/payments/create_funding",
-           amount: {cents: 500, currency: "USD"},
-           payment_instrument_id: ba.id,
-           payment_method_type: ba.payment_method_type
+      Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.not_ready) do
+        post "/v1/payments/create_funding",
+             amount: {cents: 500, currency: "USD"},
+             payment_instrument_id: ba.id,
+             payment_method_type: ba.payment_method_type
+      end
 
       expect(last_response).to have_status(200)
       expect(last_response.headers).to include("Suma-Current-Member")

--- a/spec/suma/payment/funding_transaction_spec.rb
+++ b/spec/suma/payment/funding_transaction_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe "Suma::Payment::FundingTransaction", :db do
         amount: Money.new(500, "USD"),
         vendor_service_category: category,
         instrument: bank_account,
+        strategy: Suma::Payment::FakeStrategy.create.not_ready,
       )
       expect(fx).to have_attributes(status: "created")
       expect(member.payment_account.originated_funding_transactions).to contain_exactly(be === fx)


### PR DESCRIPTION
They were implicitly using the ACH strategy,
so would fail during ACH hours.
This allows us to force a fake strategy.