### PR TITLE
Finish integrating commerce and ledger system

### DIFF
--- a/db/migrations/013_commerce_ledgers.rb
+++ b/db/migrations/013_commerce_ledgers.rb
@@ -14,5 +14,17 @@ Sequel.migration do
     alter_table(:payment_ledgers) do
       add_foreign_key :contribution_text_id, :translated_texts, null: false
     end
+
+    create_table(:automation_triggers) do
+      primary_key :id
+      timestamptz :created_at, null: false, default: Sequel.function(:now)
+      timestamptz :updated_at
+
+      text :name, null: false, unique: true
+      tstzrange :active_during, null: false
+      text :topic, null: false
+      text :klass_name, null: false
+      jsonb :parameter, null: false, default: "{}"
+    end
   end
 end

--- a/db/migrations/013_commerce_ledgers.rb
+++ b/db/migrations/013_commerce_ledgers.rb
@@ -10,5 +10,9 @@ Sequel.migration do
     alter_table(:charges) do
       add_foreign_key :commerce_order_id, :commerce_orders, null: true, on_delete: :set_null, index: true
     end
+
+    alter_table(:payment_ledgers) do
+      add_foreign_key :contribution_text_id, :translated_texts, null: false
+    end
   end
 end

--- a/db/migrations/013_commerce_ledgers.rb
+++ b/db/migrations/013_commerce_ledgers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_join_table(
+      {category_id: :vendor_service_categories, product_id: :commerce_products},
+      name: :vendor_service_categories_commerce_products,
+    )
+
+    alter_table(:charges) do
+      add_foreign_key :commerce_order_id, :commerce_orders, null: true, on_delete: :set_null, index: true
+    end
+  end
+end

--- a/lib/suma/admin_api/funding_transactions.rb
+++ b/lib/suma/admin_api/funding_transactions.rb
@@ -43,7 +43,7 @@ class Suma::AdminAPI::FundingTransactions < Suma::AdminAPI::V1
       fx = Suma::Payment::FundingTransaction.start_and_transfer(
         Suma::Payment.ensure_cash_ledger(c),
         amount: params[:amount],
-        vendor_service_category: Suma::Vendor::ServiceCategory.find_or_create(name: "Cash"),
+        vendor_service_category: Suma::Vendor::ServiceCategory.cash,
         instrument:,
       )
       created_resource_headers(fx.id, fx.admin_link)

--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -225,7 +225,7 @@ class Suma::API::Commerce < Suma::API::V1
 
   class ChargeContributionEntity < BaseEntity
     expose :amount, with: Suma::Service::Entities::Money
-    expose :name, &self.delegate_to(:ledger, :name)
+    expose :name, &self.delegate_to(:ledger, :contribution_text, :string)
   end
 
   class CheckoutEntity < BaseEntity

--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -223,6 +223,11 @@ class Suma::API::Commerce < Suma::API::V1
     expose :quantity
   end
 
+  class ChargeContributionEntity < BaseEntity
+    expose :amount, with: Suma::Service::Entities::Money
+    expose :name, &self.delegate_to(:ledger, :name)
+  end
+
   class CheckoutEntity < BaseEntity
     expose :id
     expose :items, with: CheckoutItemEntity
@@ -240,6 +245,8 @@ class Suma::API::Commerce < Suma::API::V1
     expose :taxable_cost, with: Suma::Service::Entities::Money
     expose :tax, with: Suma::Service::Entities::Money
     expose :total, with: Suma::Service::Entities::Money
+    expose :chargeable_total, with: Suma::Service::Entities::Money
+    expose :usable_ledger_contributions, as: :existing_funds_available, with: ChargeContributionEntity
   end
 
   class CheckoutConfirmationEntity < BaseEntity

--- a/lib/suma/api/payments.rb
+++ b/lib/suma/api/payments.rb
@@ -23,7 +23,7 @@ class Suma::API::Payments < Suma::API::V1
         Suma::Payment.ensure_cash_ledger(c),
         amount: params[:amount],
         instrument:,
-        vendor_service_category: Suma::Vendor::ServiceCategory.find_or_create(name: "Cash"),
+        vendor_service_category: Suma::Vendor::ServiceCategory.cash,
       )
       add_current_member_header
       status 200

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -20,6 +20,7 @@ module Suma::Async
 
   # Registry of all jobs that will be required when the async system is started/run.
   JOBS = [
+    "suma/async/automation_trigger_runner",
     "suma/async/emailer",
     "suma/async/ensure_default_member_ledgers_on_create",
     "suma/async/funding_transaction_processor",

--- a/lib/suma/async/automation_trigger_runner.rb
+++ b/lib/suma/async/automation_trigger_runner.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "amigo/job"
+
+class Suma::Async::AutomationTriggerRunner
+  extend Amigo::Job
+
+  on "suma.*"
+
+  def _perform(event)
+    Suma::AutomationTrigger.active_at(Time.now).each do |at|
+      next unless File.fnmatch(at.topic, event.name, File::FNM_EXTGLOB)
+      at.klass.run(at, event)
+    end
+  end
+
+  Amigo.register_job(self)
+end

--- a/lib/suma/automation_trigger.rb
+++ b/lib/suma/automation_trigger.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "suma/postgres/model"
+
+# These are basically data-driven async jobs.
+# Implementation classes in suma/automation_trigger do the work;
+# these set up some parameters and call them for the heavy lifting.
+#
+# They will only run during active_during, so can be used to make
+# time-dependent jobs, like adding ledgers or funds automatically when a user is registered.
+#
+# The `parameter` field is generally used to control the implementation,
+# like specifying subsidy amounts or ledger names.
+class Suma::AutomationTrigger < Suma::Postgres::Model(:automation_triggers)
+  plugin :timestamps
+  plugin :tstzrange_fields, :active_during
+
+  dataset_module do
+    def active_at(t)
+      return self.where(Sequel.pg_range(:active_during).contains(Sequel.cast(t, :timestamptz)))
+    end
+  end
+
+  def klass
+    return self.klass_name.constantize
+  end
+
+  def run_with_payload(*payload)
+    event = Amigo::Event.new("test", self.topic, payload)
+    self.klass.run(self, event)
+  end
+
+  def self.load_implementations
+    root = Pathname(__FILE__).dirname + "automation_trigger/"
+    root.glob("*.rb").each do |path|
+      base = path.basename.to_s[..-4]
+      require("suma/automation_trigger/#{base}")
+    end
+  end
+end
+
+Suma::AutomationTrigger.load_implementations

--- a/lib/suma/automation_trigger/create_and_subsidize_ledger.rb
+++ b/lib/suma/automation_trigger/create_and_subsidize_ledger.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "suma/automation_trigger"
+
+class Suma::AutomationTrigger::CreateAndSubsidizeLedger
+  def self.run(instance, event)
+    acct = Suma::Payment::Account.find!(event.payload.first)
+    instance.db.transaction do
+      acct.lock!
+      params = instance.parameter.deep_symbolize_keys
+      return if acct.ledgers_dataset[name: params[:ledger_name]]
+      ledger = acct.add_ledger(
+        currency: Suma.default_currency,
+        name: params[:ledger_name],
+        contribution_text: Suma::TranslatedText.create(**params[:contribution_text]),
+      )
+      vsc = Suma::Vendor::ServiceCategory.find!(name: params[:category_name])
+      ledger.add_vendor_service_category(vsc)
+      Suma::Payment::BookTransaction.create(
+        apply_at: Time.now,
+        amount_cents: params[:amount_cents],
+        amount_currency: params[:amount_currency],
+        originating_ledger: Suma::Payment::Account.lookup_platform_vendor_service_category_ledger(vsc),
+        receiving_ledger: ledger,
+        associated_vendor_service_category: vsc,
+        memo: Suma::TranslatedText.create(**params[:subsidy_memo]),
+      )
+    end
+  end
+end

--- a/lib/suma/automation_trigger/tester.rb
+++ b/lib/suma/automation_trigger/tester.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "suma/automation_trigger"
+
+class Suma::AutomationTrigger::Tester
+  def self.run(_instance, _event); end
+end

--- a/lib/suma/charge.rb
+++ b/lib/suma/charge.rb
@@ -8,6 +8,7 @@ class Suma::Charge < Suma::Postgres::Model(:charges)
 
   many_to_one :member, class: "Suma::Member"
   many_to_one :mobility_trip, class: "Suma::Mobility::Trip"
+  many_to_one :commerce_order, class: "Suma::Commerce::Order"
   many_to_many :book_transactions,
                class: "Suma::Payment::BookTransaction",
                join_table: :charges_payment_book_transactions,

--- a/lib/suma/commerce/order.rb
+++ b/lib/suma/commerce/order.rb
@@ -9,6 +9,7 @@ class Suma::Commerce::Order < Suma::Postgres::Model(:commerce_orders)
 
   one_to_many :audit_logs, class: "Suma::Commerce::OrderAuditLog", order: Sequel.desc(:at)
   many_to_one :checkout, class: "Suma::Commerce::Checkout"
+  one_to_many :charges, class: "Suma::Charge", key: :commerce_order_id
 
   state_machine :order_status, initial: :open do
     state :open

--- a/lib/suma/commerce/product.rb
+++ b/lib/suma/commerce/product.rb
@@ -3,6 +3,7 @@
 require "suma/commerce"
 require "suma/image"
 require "suma/postgres/model"
+require "suma/vendor/has_service_categories"
 
 class Suma::Commerce::Product < Suma::Postgres::Model(:commerce_products)
   include Suma::Image::AssociatedMixin
@@ -13,6 +14,12 @@ class Suma::Commerce::Product < Suma::Postgres::Model(:commerce_products)
   plugin :translated_text, :description, Suma::TranslatedText
 
   many_to_one :vendor, class: "Suma::Vendor"
+
+  many_to_many :vendor_service_categories, class: "Suma::Vendor::ServiceCategory",
+                                           join_table: :vendor_service_categories_commerce_products,
+                                           left_key: :product_id,
+                                           right_key: :category_id
+  include Suma::Vendor::HasServiceCategories
 end
 
 # Table: commerce_products

--- a/lib/suma/fixtures/automation_triggers.rb
+++ b/lib/suma/fixtures/automation_triggers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "suma/fixtures"
+require "suma/automation_trigger"
+
+module Suma::Fixtures::AutomationTriggers
+  extend Suma::Fixtures
+
+  fixtured_class Suma::AutomationTrigger
+
+  base :automation_trigger do
+    self.active_during ||=
+      Faker::Number.between(from: 50, to: 2).days.ago..Faker::Number.between(from: 2, to: 50).days.from_now
+    self.name ||= Faker::Lorem.sentence
+    self.klass_name ||= "Suma::AutomationTrigger::Tester"
+    self.topic ||= "*"
+  end
+
+  decorator :inactive do
+    self.active_during_begin = 4.days.ago
+    self.active_during_end = 2.days.ago
+  end
+end

--- a/lib/suma/fixtures/ledgers.rb
+++ b/lib/suma/fixtures/ledgers.rb
@@ -34,4 +34,8 @@ module Suma::Fixtures::Ledgers
     self.add_vendor_service_category(Suma::Fixtures.vendor_service_category.send(name).create)
     self.name ||= name
   end
+
+  def self.ensure_platform_cash
+    return Suma::Payment.ensure_cash_ledger(Suma::Payment::Account.lookup_platform_account)
+  end
 end

--- a/lib/suma/fixtures/ledgers.rb
+++ b/lib/suma/fixtures/ledgers.rb
@@ -15,7 +15,7 @@ module Suma::Fixtures::Ledgers
 
   before_saving do |instance|
     instance.account ||= Suma::Fixtures.payment_account.create
-    instance.name ||= Faker::Lorem.word
+    instance.name ||= Faker::Lorem.word + SecureRandom.hex(2)
     instance
   end
 

--- a/lib/suma/fixtures/ledgers.rb
+++ b/lib/suma/fixtures/ledgers.rb
@@ -11,11 +11,12 @@ module Suma::Fixtures::Ledgers
 
   base :ledger do
     self.currency ||= "USD"
+    self.name ||= Faker::Lorem.word + SecureRandom.hex(2)
   end
 
   before_saving do |instance|
     instance.account ||= Suma::Fixtures.payment_account.create
-    instance.name ||= Faker::Lorem.word + SecureRandom.hex(2)
+    instance.contribution_text ||= Suma::TranslatedText.create(all: "Credit from #{instance.name}")
     instance
   end
 

--- a/lib/suma/fixtures/offering_products.rb
+++ b/lib/suma/fixtures/offering_products.rb
@@ -21,6 +21,11 @@ module Suma::Fixtures::OfferingProducts
     instance
   end
 
+  decorator :costing do |customer, undiscounted|
+    self.customer_price = Suma::SpecHelpers.money(customer)
+    self.undiscounted_price = Suma::SpecHelpers.money(undiscounted)
+  end
+
   decorator :closed do
     self.closed_at = 2.days.ago
   end

--- a/lib/suma/fixtures/offerings.rb
+++ b/lib/suma/fixtures/offerings.rb
@@ -22,4 +22,9 @@ module Suma::Fixtures::Offerings
     self.period_begin = 4.days.ago
     self.period_end = 2.days.ago
   end
+
+  decorator :with_fulfillment, presave: true do |options|
+    Suma::Fixtures.offering_fulfillment_option(options).create(offering: self) unless
+      options.is_a?(Suma::Commerce::OfferingFulfillmentOption)
+  end
 end

--- a/lib/suma/fixtures/orders.rb
+++ b/lib/suma/fixtures/orders.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "suma/fixtures"
+require "suma/commerce/order"
+
+module Suma::Fixtures::Orders
+  extend Suma::Fixtures
+
+  fixtured_class Suma::Commerce::Order
+
+  base :order do
+  end
+
+  before_saving do |instance|
+    instance.checkout ||= Suma::Fixtures.checkout.create
+    instance
+  end
+end

--- a/lib/suma/fixtures/products.rb
+++ b/lib/suma/fixtures/products.rb
@@ -23,4 +23,13 @@ module Suma::Fixtures::Products
   decorator :in_offering, presave: true do |offering|
     Suma::Fixtures.offering_product.create(offering:, product: self)
   end
+
+  decorator :with_categories, presave: true do |*cats|
+    cats.each { |c| self.add_vendor_service_category(c) }
+  end
+
+  decorator :category, presave: true do |name|
+    raise ArgumentError, "#{name} must be a Symbol (the fixture decorator method)" unless name.is_a?(Symbol)
+    self.add_vendor_service_category(Suma::Fixtures.vendor_service_category.send(name).create)
+  end
 end

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -81,7 +81,7 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
         now:,
         # At this point, ride has been taken and finished so we need to accept it
         # and deal with a potential negative balance.
-        allow_negative_balance: true,
+        remainder_ledger: :last,
       )
       xactions = self.member.payment_account.debit_contributions(
         contributions,

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -47,8 +47,7 @@ module Suma::Payment
     ledger = payment_account.cash_ledger
     return ledger if ledger
     ledger = payment_account.add_ledger({currency: Suma.default_currency, name: "Cash"})
-    cash_category = Suma::Vendor::ServiceCategory.find_or_create(name: "Cash")
-    ledger.add_vendor_service_category(cash_category)
+    ledger.add_vendor_service_category(Suma::Vendor::ServiceCategory.cash)
     payment_account.associations.delete(:cash_ledger)
     return ledger
   end

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -47,6 +47,7 @@ module Suma::Payment
     ledger = payment_account.cash_ledger
     return ledger if ledger
     ledger = payment_account.add_ledger({currency: Suma.default_currency, name: "Cash"})
+    ledger.usage_text.update(en: "Account Balance", es: "Saldo de la cuenta")
     ledger.add_vendor_service_category(Suma::Vendor::ServiceCategory.cash)
     payment_account.associations.delete(:cash_ledger)
     return ledger

--- a/lib/suma/payment/book_transaction.rb
+++ b/lib/suma/payment/book_transaction.rb
@@ -68,7 +68,10 @@ class Suma::Payment::BookTransaction < Suma::Postgres::Model(:payment_book_trans
       if ch.mobility_trip
         code = "mobility_trip"
         service_name = ch.mobility_trip.vendor_service.external_name
-     end
+      elsif ch.commerce_order
+        code = "commerce_order"
+        service_name = ch.commerce_order.checkout.cart.offering.description.string
+      end
       UsageDetails.new(
         code, {
           discount_amount: Suma::Moneyutil.to_h(ch.discount_amount),

--- a/lib/suma/payment/ledger.rb
+++ b/lib/suma/payment/ledger.rb
@@ -71,8 +71,8 @@ class Suma::Payment::Ledger < Suma::Postgres::Model(:payment_ledgers)
   # only vendor services with 'organic' assigned could be used.
   #
   # Note that ledgers and services can have multiple service categories.
-  def can_be_used_to_purchase?(vendor_service)
-    match = self.category_used_to_purchase(vendor_service)
+  def can_be_used_to_purchase?(has_vnd_svc_categories)
+    match = self.category_used_to_purchase(has_vnd_svc_categories)
     return !match.nil?
   end
 
@@ -80,8 +80,8 @@ class Suma::Payment::Ledger < Suma::Postgres::Model(:payment_ledgers)
   # which qualifies this ledger to pay for the vendor service.
   # We may need to refind this search algorithm in the future
   # if we find it doesn't select the right category.
-  def category_used_to_purchase(vendor_service)
-    service_cat_ids = vendor_service.categories.map(&:id)
+  def category_used_to_purchase(has_vnd_svc_categories)
+    service_cat_ids = has_vnd_svc_categories.vendor_service_categories.map(&:id)
     return self.vendor_service_categories.find do |c|
       chain_ids = c.tsort.map(&:id)
       !(service_cat_ids & chain_ids).empty?

--- a/lib/suma/payment/ledger.rb
+++ b/lib/suma/payment/ledger.rb
@@ -7,6 +7,7 @@ class Suma::Payment::Ledger < Suma::Postgres::Model(:payment_ledgers)
   include Suma::AdminLinked
 
   plugin :timestamps
+  plugin :translated_text, :contribution_text, Suma::TranslatedText
 
   many_to_one :account, class: "Suma::Payment::Account"
   many_to_many :vendor_service_categories,

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -48,6 +48,7 @@ module Suma::Postgres
   # Require paths for all Sequel models used by the app.
   MODELS = [
     "suma/address",
+    "suma/automation_trigger",
     "suma/charge",
     "suma/commerce/cart",
     "suma/commerce/cart_item",

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -24,6 +24,7 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
 
         self.setup_offerings
         self.setup_products
+        self.setup_automation
       end
     end
   end
@@ -266,5 +267,24 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
         undiscounted_price: Money.new(180_00),
       )
     end
+  end
+
+  def setup_automation
+    Suma::AutomationTrigger.dataset.delete
+    Suma::AutomationTrigger.create(
+      name: "Holidays 2022",
+      topic: "suma.payment.account.created",
+      active_during_begin: Time.now,
+      active_during_end: Time.parse("2022-12-12T23:00:00-0800"),
+      klass_name: "Suma::AutomationTrigger::CreateAndSubsidizeLedger",
+      parameter: {
+        ledger_name: "Holidays2022",
+        contribution_text: {en: "Holidays 2022 Gift", es: "Regalo de Vacaciones 2022"},
+        category_name: "Holiday 2022 Promo",
+        amount_cents: 80_00,
+        amount_currency: "USD",
+        subsidy_memo: {en: "Subsidy from Meyer Memorial Trust", es: "Subsidio de Meyer Memorial Trust"},
+      },
+    )
   end
 end

--- a/lib/suma/vendor/has_service_categories.rb
+++ b/lib/suma/vendor/has_service_categories.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "suma/vendor"
+
+# Mixin for objects that have vendor service categories.
+module Suma::Vendor::HasServiceCategories
+  # @!attribute vendor_service_categories
+  # @return [Array<Suma::Vendor::ServiceCategory>]
+
+  def self.included(mod)
+    return if mod.instance_methods.include?(:vendor_service_categories)
+    raise TypeError, "#{mod} must define a vendor_service_categories method or association"
+  end
+end

--- a/lib/suma/vendor/service.rb
+++ b/lib/suma/vendor/service.rb
@@ -2,13 +2,18 @@
 
 require "suma/postgres/model"
 require "suma/mobility/vendor_adapter"
+require "suma/vendor/has_service_categories"
 
 class Suma::Vendor::Service < Suma::Postgres::Model(:vendor_services)
   plugin :timestamps
 
   many_to_one :vendor, key: :vendor_id, class: "Suma::Vendor"
+
   many_to_many :categories, class: "Suma::Vendor::ServiceCategory",
                             join_table: :vendor_service_categories_vendor_services
+  def vendor_service_categories = self.categories
+  include Suma::Vendor::HasServiceCategories
+
   many_to_many :rates,
                class: "Suma::Vendor::ServiceRate",
                join_table: :vendor_service_vendor_service_rates,

--- a/lib/suma/vendor/service_category.rb
+++ b/lib/suma/vendor/service_category.rb
@@ -4,13 +4,20 @@ require "suma/postgres/model"
 
 class Suma::Vendor::ServiceCategory < Suma::Postgres::Model(:vendor_service_categories)
   include TSort
-  many_to_many :services,
-               class: "Suma::Vendor::Service",
-               join_table: :vendor_service_categories_vendor_services,
-               left_key: :category_id,
-               right_key: :service_id
+
+  # Because a service category can point to many services and many products,
+  # we don't model the backref association.
+  # many_to_many :services
+  # many_to_many :products
+
   many_to_one :parent, class: self
   one_to_many :children, class: self, key: :parent_id
+
+  def self.cash
+    return Suma.cached_get("vendor_service_category_cash") do
+      self.find_or_create_or_find(name: "Cash")
+    end
+  end
 
   # TSort API: Iterate self and children to go through entire graph.
   def tsort_each_node(&)

--- a/spec/sequel/translated_text/translated_text_spec.rb
+++ b/spec/sequel/translated_text/translated_text_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe SequelTranslatedText, :db do
       x = cls.create(text: TranslatedTextEx.create(en: "x"))
       y = cls.create(text: TranslatedTextEx.create(en: "y"))
       q = cls.dataset.translation_join(:text, [:en, :fr])
-      puts q.sql
       expect(q.sql).to eq('SELECT * FROM (SELECT "articles".*, "text"."en" AS "text_en", "text"."fr" AS "text_fr" ' \
                           'FROM "articles" INNER JOIN "translated_texts" AS "text" ' \
                           'ON ("text"."id" = "articles"."text_id")) AS "t1"')

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
     Suma::Async.setup_tests
   end
 
+  describe "AutomationTriggerRunner" do
+    it "runs active automations" do
+      active = Suma::Fixtures.automation_trigger.create
+      active_mismatch_topic = Suma::Fixtures.automation_trigger.create(topic: "suma.z")
+      inactive = Suma::Fixtures.automation_trigger.inactive.create
+      expect(Suma::AutomationTrigger::Tester).to receive(:run).with(be === active, have_attributes(payload: [5, 6]))
+
+      expect do
+        Amigo.publish("suma.x", 5, 6)
+      end.to perform_async_job(Suma::Async::AutomationTriggerRunner)
+    end
+  end
+
   describe "EnsureDefaultMemberLedgersOnCreate" do
     it "creates ledgers" do
       expect do

--- a/spec/suma/automation_trigger_spec.rb
+++ b/spec/suma/automation_trigger_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::AutomationTrigger", :db do
+  let(:described_class) { Suma::AutomationTrigger }
+
+  describe Suma::AutomationTrigger::CreateAndSubsidizeLedger do
+    let(:at) do
+      at = Suma::Fixtures.automation_trigger(
+        klass_name: "Suma::AutomationTrigger::CreateAndSubsidizeLedger",
+        parameter: {
+          ledger_name: "Holidays2022",
+          contribution_text: {en: "Ledger En", es: "Ledger Es"},
+          category_name: "Test Category",
+          amount_cents: 80_00,
+          amount_currency: "USD",
+          subsidy_memo: {en: "Subsidy En", es: "Subsidy Es"},
+        },
+      ).create
+    end
+    let(:pa) { Suma::Fixtures.payment_account.create }
+
+    it "creates and subsidizes the specified ledger", lang: :es do
+      Suma::Fixtures.vendor_service_category(name: "Test Category").create
+      at.run_with_payload(pa.id)
+      expect(pa.ledgers).to contain_exactly(have_attributes(name: "Holidays2022"))
+      expect(pa.ledgers.first.received_book_transactions).to contain_exactly(have_attributes(memo_string: "Subsidy Es"))
+    end
+
+    it "noops if the ledger exists" do
+      Suma::Fixtures.ledger(account: pa).create(name: "Holidays2022")
+      at.run_with_payload(pa.id)
+      expect(pa.refresh.ledgers.first.received_book_transactions).to be_empty
+    end
+  end
+end

--- a/spec/suma/vendor/service_category_spec.rb
+++ b/spec/suma/vendor/service_category_spec.rb
@@ -8,11 +8,14 @@ RSpec.describe "Suma::Vendor::ServiceCategory", :db do
     expect(p).to be_a(described_class)
   end
 
-  it "can add and remove services" do
+  it "can add and remove services and products" do
     cat = Suma::Fixtures.vendor_service_category.food.create
     vs = Suma::Fixtures.vendor_service.create
-    cat.add_service(vs)
-    expect(cat.services).to have_same_ids_as(vs)
+    pro = Suma::Fixtures.product.create
+    vs.add_category(cat)
+    pro.add_vendor_service_category(cat)
+    expect(vs.categories).to have_same_ids_as(cat)
+    expect(pro.vendor_service_categories).to have_same_ids_as(cat)
   end
 
   it "knows its ancestry and can tsort" do

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -128,18 +128,6 @@ function CheckoutPayment({
         <i className="bi bi-bank2 me-2" />
         Link bank account
       </Link>
-      <Form>
-        <Form.Group>
-          <Form.Check
-            id="savePayment"
-            name="savePayment"
-            label="Save for future orders"
-            onChange={(e) =>
-              onCheckoutChange({ savePaymentInstrument: e.target.checked })
-            }
-          ></Form.Check>
-        </Form.Group>
-      </Form>
     </>
   );
 
@@ -167,6 +155,18 @@ function CheckoutPayment({
                   onChange={() => onSelectedInstrumentChange(pi)}
                 />
               ))}
+            </Form.Group>
+          </Form>
+          <Form>
+            <Form.Group>
+              <Form.Check
+                id="savePayment"
+                name="savePayment"
+                label="Save for future orders"
+                onChange={(e) =>
+                  onCheckoutChange({ savePaymentInstrument: e.target.checked })
+                }
+              ></Form.Check>
             </Form.Group>
           </Form>
           <div>Or, link a new payment method to pay for this order.</div>
@@ -264,27 +264,33 @@ function OrderSummary({ checkout, chosenInstrument, onSubmit }) {
           className="text-success"
         />
         <hr className="ms-auto w-25 my-1" />
-        <SummaryLine label={`Total before tax`} price={checkout.taxableCost} />
-        <SummaryLine label={`Tax`} price={checkout.tax} />
+        <SummaryLine label="Total before tax" price={checkout.taxableCost} />
+        <SummaryLine label="Tax" price={checkout.tax} />
+        {checkout.existingFundsAvailable.map(({ amount, name }) => (
+          <SummaryLine key={name} label={name} price={amount} subtract />
+        ))}
         <hr className="mt-1 mb-2" />
         <SummaryLine
           label="Order total"
-          price={checkout.total}
+          price={checkout.chargeableTotal}
           className="text-success fw-bold fs-5"
         />
+        {chosenInstrument && (
+          <p className="small text-secondary mb-1">Charge to {chosenInstrument.name}.</p>
+        )}
+        <p className="small text-secondary mb-1">
+          By clicking &#34;place order&#34; you agree to suma&#39;s{" "}
+          <Link to="/terms">Terms of Use</Link>.
+        </p>
         <Button
           variant="success"
-          className="d-flex ms-auto mt-2"
+          className="w-100 mt-2"
           disabled={!canPlace}
           onClick={onSubmit}
         >
           Place order
         </Button>
       </div>
-      <p className="small text-secondary mt-2">
-        By clicking &#34;place order&#34; you are agreeing to suma&#39;s{" "}
-        <Link to="/TODO user agreement">Terms of Use</Link>.
-      </p>
     </Col>
   );
 }


### PR DESCRIPTION
Fixes #260 

Order checkout takes ledgers into account

Just like with mobility trips, we now look at the balances
of the member ledger to figure out how much to charge them.

This required an overhaul of how we find chargeable ledgers
to better control behavior around remainders.

Also restructure bootstrap task.

---


Ledgers should show a 'contribution text'

Rather than the name, like 'Cash' or 'Food',
we need a thing we can place in the UI when ledgers
contribute towards a payment ("Account Balance: $20" for example).

---

Automatically add subsidy when a member reigsters

Create an 'automation trigger' system
that does some of what the async job system does.

Add an implementation (and hook it up to bootstrap)
so we create a 'holiday 2022 ledger' when a user signs up,
and load it with $80 in credit.

Note this ledger can only be used for the holiday 2022 products
due to vendor service category constraints.

Fixes #241
Refs #257 which can be solved using this.

---

- Remove errant puts
- Fix flaky spec due to ledger names
