### PR TITLE
Add message preferences and order confirmation

### DIFF
--- a/data/messages/templates/offerings/2022-12-pilot-confirmation.en.sms.liquid
+++ b/data/messages/templates/offerings/2022-12-pilot-confirmation.en.sms.liquid
@@ -1,0 +1,1 @@
+Thanks for your order! We'll reach out by December 12 with information about pickup. Respond to this text or email apphelp@mysuma.org if you need help. - Suma

--- a/data/messages/templates/offerings/2022-12-pilot-confirmation.es.sms.liquid
+++ b/data/messages/templates/offerings/2022-12-pilot-confirmation.es.sms.liquid
@@ -1,0 +1,1 @@
+Gracias for your order! We'll reach out by December 12 with information about pickup. Respond to this text or email apphelp@mysuma.org if you need help. - Suma

--- a/data/messages/templates/specs/localized.fr.sms.liquid
+++ b/data/messages/templates/specs/localized.fr.sms.liquid
@@ -1,0 +1,1 @@
+french message

--- a/db/migrations/014_order_confirmation.rb
+++ b/db/migrations/014_order_confirmation.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:commerce_offerings) do
+      add_column :confirmation_template, :text, null: false, default: ""
+    end
+
+    create_table(:message_preferences) do
+      primary_key :id
+      timestamptz :created_at, null: false, default: Sequel.function(:now)
+      timestamptz :updated_at
+
+      foreign_key :member_id, :members, null: false, unique: true
+
+      text :preferred_language, null: false
+      boolean :sms_enabled, null: false
+      boolean :email_enabled, null: false
+    end
+
+    alter_table(:message_deliveries) do
+      add_column :template_language, :text, null: false, default: ""
+    end
+  end
+end

--- a/lib/suma/api/me.rb
+++ b/lib/suma/api/me.rb
@@ -56,6 +56,18 @@ class Suma::API::Me < Suma::API::V1
       status 200
       present member, with: CurrentMemberEntity, env:
     end
+
+    params do
+      requires :language, values: ["en", "es"]
+    end
+    post :language do
+      member = current_member
+      member.db.transaction do
+        member.message_preferences!.update(preferred_language: params[:language])
+      end
+      status 200
+      present member, with: CurrentMemberEntity, env:
+    end
   end
 
   class MemberDashboardEntity < BaseEntity

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -25,6 +25,7 @@ module Suma::Async
     "suma/async/ensure_default_member_ledgers_on_create",
     "suma/async/funding_transaction_processor",
     "suma/async/message_dispatched",
+    "suma/async/order_confirmation",
     "suma/async/plaid_update_institutions",
     "suma/async/reset_code_create_dispatch",
   ].freeze

--- a/lib/suma/async/order_confirmation.rb
+++ b/lib/suma/async/order_confirmation.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "amigo/job"
+require "suma/messages/order_confirmation"
+
+class Suma::Async::OrderConfirmation
+  extend Amigo::Job
+
+  on "suma.commerce.order.created"
+
+  def _perform(event)
+    o = self.lookup_model(Suma::Commerce::Order, event)
+    return if o.checkout.cart.offering.confirmation_template.blank?
+    Suma::Idempotency.once_ever.under_key("order-#{o.id}-confirmation") do
+      msg = Suma::Messages::OrderConfirmation.new(o)
+      o.checkout.cart.member.message_preferences!.dispatch(msg)
+    end
+  end
+
+  Amigo.register_job(self)
+end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -63,6 +63,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
   one_to_many :charges, class: "Suma::Charge", order: Sequel.desc([:id])
   many_to_one :legal_entity, class: "Suma::LegalEntity"
   one_to_many :message_deliveries, key: :recipient_id, class: "Suma::Message::Delivery"
+  one_to_one :message_preferences, class: "Suma::Message::Preferences"
   one_to_one :ongoing_trip, class: "Suma::Mobility::Trip", conditions: {ended_at: nil}
   one_to_one :payment_account, class: "Suma::Payment::Account"
   one_to_many :reset_codes, class: "Suma::Member::ResetCode", order: Sequel.desc([:created_at])
@@ -170,6 +171,10 @@ class Suma::Member < Suma::Postgres::Model(:members)
   # @return [Suma::Member::StripeAttributes]
   def stripe
     return @stripe ||= Suma::Member::StripeAttributes.new(self)
+  end
+
+  def message_preferences!
+    return self.message_preferences ||= Suma::Message::Preferences.find_or_create_or_find(member: self)
   end
 
   #

--- a/lib/suma/message.rb
+++ b/lib/suma/message.rb
@@ -47,6 +47,7 @@ module Suma::Message
     Suma::Message::Delivery.db.transaction do
       delivery = Suma::Message::Delivery.create(
         template: template.full_template_name,
+        template_language: template.language || "",
         transport_type: transport.type,
         transport_service: transport.service,
         to: recipient.to,
@@ -99,6 +100,8 @@ module Suma::Message
   class InvalidTransportError < StandardError; end
 
   class MissingTemplateError < StandardError; end
+
+  class LanguageNotSetError < StandardError; end
 
   # Presents a homogeneous interface for a given 'to' value (email vs. member, for example).
   # .to will always be a plain object, and .member will be a +Suma::Member+ if present.

--- a/lib/suma/message/preferences.rb
+++ b/lib/suma/message/preferences.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "suma/postgres"
+require "suma/message"
+
+class Suma::Message::Preferences < Suma::Postgres::Model(:message_preferences)
+  plugin :timestamps
+
+  many_to_one :member, class: Suma::Member
+
+  def initialize(*)
+    super
+    self[:sms_enabled] = true if self[:sms_enabled].nil?
+    self[:email_enabled] = false if self[:email_enabled].nil?
+    self[:preferred_language] = "en" if self[:preferred_language].nil?
+  end
+
+  def sms_enabled? = self.sms_enabled
+  def email_enabled? = self.email_enabled
+
+  def dispatch(message)
+    message.language = self.preferred_language
+    to = self.member
+    sent = []
+    sent << Suma::Message.dispatch(message, to, :sms) if self.sms_enabled?
+    sent << Suma::Message.dispatch(message, to, :email) if self.email_enabled?
+    return sent
+  end
+end

--- a/lib/suma/message/template.rb
+++ b/lib/suma/message/template.rb
@@ -21,6 +21,8 @@ class Suma::Message::Template
     return self.new
   end
 
+  attr_accessor :language
+
   def dispatch(to, transport: Suma::Message::DEFAULT_TRANSPORT)
     return Suma::Message.dispatch(self, to, transport)
   end
@@ -32,6 +34,10 @@ class Suma::Message::Template
   def dispatch_sms(to)
     return self.dispatch(to, transport: :sms)
   end
+
+  # Return true if the message templates support localization
+  # (different templates exist like basic.en.sms.liquid, etc).
+  def localized? = false
 
   # The folder containing this template. Templates in the root template directory should use nil.
   def template_folder
@@ -51,7 +57,12 @@ class Suma::Message::Template
   end
 
   def template_path(transport)
-    return Suma::Message::DATA_DIR + "templates/#{self.full_template_name}.#{transport}.liquid"
+    lang = ""
+    if self.localized?
+      raise Suma::Message::LanguageNotSetError if self.language.nil?
+      lang = "." + self.language
+    end
+    return Suma::Message::DATA_DIR + "templates/#{self.full_template_name}#{lang}.#{transport}.liquid"
   end
 
   # The layout for the template. See the 'layouts' folder in the message data directory.

--- a/lib/suma/messages/order_confirmation.rb
+++ b/lib/suma/messages/order_confirmation.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "suma/message/template"
+
+class Suma::Messages::OrderConfirmation < Suma::Message::Template
+  def self.fixtured(recipient)
+    cart = Suma::Fixtures.cart(member: recipient).with_any_product.create
+    co = Suma::Fixtures.checkout(cart:).populate_items.create
+    order = Suma::Fixtures.order(checkout: co).create
+    return self.new(order)
+  end
+
+  def initialize(order)
+    @order = order
+    super()
+  end
+
+  def template_name = @order.checkout.cart.offering.confirmation_template
+  def template_folder = "offerings"
+
+  def localized? = true
+end

--- a/lib/suma/messages/specs.rb
+++ b/lib/suma/messages/specs.rb
@@ -64,4 +64,8 @@ module Suma::Messages::Testers
       return "basic"
     end
   end
+
+  class Localized < Base
+    def localized? = true
+  end
 end

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -70,6 +70,7 @@ module Suma::Postgres
     "suma/market",
     "suma/message/body",
     "suma/message/delivery",
+    "suma/message/preferences",
     "suma/mobility/restricted_area",
     "suma/mobility/trip",
     "suma/mobility/vehicle",

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -195,6 +195,7 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
     offering = Suma::Commerce::Offering.new
     offering.period = 1.day.ago..Time.new(2022, 12, 16)
     offering.description = Suma::TranslatedText.create(en: "Holidays 2022", es: "Días festivos")
+    offering.confirmation_template = "2022-12-pilot-confirmation"
     offering.save_changes
 
     bytes = File.binread("spec/data/images/holiday-offering.jpeg")

--- a/spec/suma/api/me_spec.rb
+++ b/spec/suma/api/me_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe Suma::API::Me, :db do
     end
   end
 
+  describe "POST /v1/me/language" do
+    it "modifies message preferences language" do
+      post "/v1/me/language", language: "es"
+
+      expect(last_response).to have_status(200)
+      expect(member.refresh.message_preferences).to have_attributes(preferred_language: "es")
+    end
+  end
+
   describe "GET /v1/me/dashboard" do
     it "returns the dashboard" do
       cash_ledger = Suma::Fixtures.ledger.member(member).category(:cash).create

--- a/spec/suma/message/preferences_spec.rb
+++ b/spec/suma/message/preferences_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "suma/messages/specs"
+
+RSpec.describe "Suma::Message::Preferences", :db, :messaging do
+  let(:described_class) { Suma::Message::Preferences }
+
+  it "creates correct defaults" do
+    pref = Suma::Fixtures.member.create.message_preferences!
+    expect(pref).to have_attributes(
+      sms_enabled: true,
+      email_enabled: false,
+      preferred_language: "en",
+    )
+  end
+
+  it "dispatches correctly using configured settings" do
+    msg = Suma::Messages::Testers::Localized.new
+    deliveries = Suma::Fixtures.member.create.message_preferences!.update(preferred_language: "fr").dispatch(msg)
+    expect(deliveries).to contain_exactly(have_attributes(template: "specs/localized", template_language: "fr"))
+  end
+end

--- a/spec/suma/message_spec.rb
+++ b/spec/suma/message_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe "Suma::Message", :db, :messaging do
       expect(delivery.bodies).to have_length(1)
       expect(delivery.bodies.first).to have_attributes(content: match("test message to member@lithic.tech"))
     end
+
+    it "includes the language in the template name if template supports localization" do
+      tmpl = Suma::Messages::Testers::Localized.new
+      tmpl.language = "fr"
+      delivery = tmpl.dispatch("member@lithic.tech", transport: :sms)
+      expect(delivery).to have_attributes(template_language: "fr")
+      expect(delivery.bodies).to contain_exactly(have_attributes(content: match("french message")))
+    end
+
+    it "errors if no language is set and the template supports localization" do
+      tmpl = Suma::Messages::Testers::Localized.new
+      expect do
+        tmpl.dispatch("member@lithic.tech", transport: :sms)
+      end.to raise_error(Suma::Message::LanguageNotSetError)
+    end
   end
 
   describe "rendering" do

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -43,6 +43,7 @@ export default {
   del,
   getMe: (data) => get(`/api/v1/me`, data),
   updateMe: (data) => post(`/api/v1/me/update`, data),
+  changeLanguage: (data) => post(`/api/v1/me/language`, data),
   joinWaitlist: (data) => post(`/api/v1/me/waitlist`, data),
   getSupportedGeographies: (data) => get(`/api/v1/meta/supported_geographies`, data),
   getSupportedLocales: (data) => get(`/api/v1/meta/supported_locales`, data),

--- a/webapp/src/localization/useI18Next.js
+++ b/webapp/src/localization/useI18Next.js
@@ -1,8 +1,10 @@
+import api from "../api";
 import { localStorageCache } from "../shared/localStorageHelper";
 import { formatMoney } from "../shared/react/Money";
 import useLocalStorageState from "../shared/react/useLocalStorageState";
 import i18n from "i18next";
 import Backend from "i18next-http-backend";
+import _ from "lodash";
 import React from "react";
 
 export const I18NextContext = React.createContext();
@@ -22,6 +24,10 @@ export function I18NextProvider({ children }) {
 
   const changeLanguage = React.useCallback(
     (lang) => {
+      api
+        .changeLanguage({ language: lang })
+        .then(_.noop)
+        .catch((r) => console.error(r));
       setI18NextLoading(true);
       Promise.delayOr(
         500,


### PR DESCRIPTION
Fixes https://github.com/lithictech/suma/issues/256

Working backwards from end-user feature to capability, this change:

- Sends the user a confirmation email when the order is created (using the existing messaging system).
- It sends it in their preferred language.
- Preferred language is set when the user toggles language on the frontend.
- There's a new 'Message::Preferences' model which stores the preferred language, and eventually preferred transports (sms, email) for a user.
- The messaging system is updated to support localization. This was pretty simple- the template declares if localization is supported by the liquid templates, and if so, we look for localized template files (`x.en.sms.liquid`).
- Offerings need customized templates per-offering, since fulfillment and communication is very non-standard. Offerings have a new `confirmation_template` field to specify which confirmation message to send.
- Creates the localized template for pilot order confirmations. Eventually we may need to compose these and save them in the database, so new confirmation emails do not require code changes.
- Add the async job to send the order confirmation message.