### PR TITLE
Fix various ledger bugs (sorting, payments) and add multiple ledger view support

### DIFF
--- a/lib/suma/admin_api/funding_transactions.rb
+++ b/lib/suma/admin_api/funding_transactions.rb
@@ -45,6 +45,7 @@ class Suma::AdminAPI::FundingTransactions < Suma::AdminAPI::V1
         amount: params[:amount],
         vendor_service_category: Suma::Vendor::ServiceCategory.cash,
         instrument:,
+        apply_at: Time.now,
       )
       created_resource_headers(fx.id, fx.admin_link)
       status 200

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -115,6 +115,7 @@ module Suma::API::Entities
   class LedgerEntity < BaseEntity
     expose :id
     expose :name
+    expose_translated :contribution_text
     expose :balance, with: MoneyEntity
   end
 end

--- a/lib/suma/api/payments.rb
+++ b/lib/suma/api/payments.rb
@@ -24,6 +24,7 @@ class Suma::API::Payments < Suma::API::V1
         amount: params[:amount],
         instrument:,
         vendor_service_category: Suma::Vendor::ServiceCategory.cash,
+        apply_at: Time.now,
       )
       add_current_member_header
       status 200

--- a/lib/suma/commerce/checkout.rb
+++ b/lib/suma/commerce/checkout.rb
@@ -151,6 +151,7 @@ class Suma::Commerce::Checkout < Suma::Postgres::Model(:commerce_checkouts)
           amount: remainder_contribs.first.amount,
           vendor_service_category: Suma::Vendor::ServiceCategory.cash,
           instrument: self.payment_instrument,
+          apply_at: now,
         )
       end
 

--- a/lib/suma/commerce/checkout.rb
+++ b/lib/suma/commerce/checkout.rb
@@ -82,7 +82,7 @@ class Suma::Commerce::Checkout < Suma::Postgres::Model(:commerce_checkouts)
   def total = self.customer_cost + self.handling
 
   # Nonzero contributions made by existing customer ledgers against the order totals.
-  # @return [Array<Suma::Payment::Account::ChargeContribution]
+  # @return [Array<Suma::Payment::ChargeContribution]
   def usable_ledger_contributions
     return self.ledger_charge_contributions(now: Time.now, remainder_ledger: :ignore).
         delete_if { |c| c.amount.zero? }
@@ -134,9 +134,9 @@ class Suma::Commerce::Checkout < Suma::Postgres::Model(:commerce_checkouts)
         end
       end
 
-      # Create ledger debits for all contributions. This MAY bring our balance negative.
+      # Create ledger debits for all positive contributions. This MAY bring our balance negative.
       book_xactions = self.cart.member.payment_account.debit_contributions(
-        debit_contribs,
+        debit_contribs.select { |c| c.amount.positive? },
         memo: Suma::TranslatedText.create(
           en: "Suma Order %04d - %s" % [order.id, self.cart.offering.description.en],
           es: "Suma Pedido %04d - %s" % [order.id, self.cart.offering.description.es],
@@ -166,15 +166,19 @@ class Suma::Commerce::Checkout < Suma::Postgres::Model(:commerce_checkouts)
   # NOTE: Right now this is only product contributions; when we support tax and handling,
   # we'll need to modify this routine to factor those into the right (cash?) ledger.
   #
-  # @return [Array<Suma::Payment::Account::ChargeContribution]
+  # @return [Array<Suma::Payment::ChargeContribution]
   def ledger_charge_contributions(now:, remainder_ledger:)
+    ctx = Suma::Payment::CalculationContext.new
     product_contributions = self.items.map do |item|
-      self.cart.member.payment_account!.find_chargeable_ledgers(
+      contribs = self.cart.member.payment_account!.find_chargeable_ledgers(
         item.offering_product.product,
         item.customer_cost,
         now:,
         remainder_ledger:,
+        calculation_context: ctx,
       )
+      ctx.apply_all(contribs)
+      contribs
     end
     consolidated_contributions = product_contributions.
       flatten.
@@ -182,7 +186,7 @@ class Suma::Commerce::Checkout < Suma::Postgres::Model(:commerce_checkouts)
       values.
       map do |contribs|
       c = contribs.first
-      Suma::Payment::Account::ChargeContribution.new(
+      Suma::Payment::ChargeContribution.new(
         ledger: c.ledger,
         apply_at: c.apply_at,
         category: c.category,

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -79,6 +79,7 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
         self.vendor_service,
         result_cost,
         now:,
+        calculation_context: Suma::Payment::CalculationContext.new,
         # At this point, ride has been taken and finished so we need to accept it
         # and deal with a potential negative balance.
         remainder_ledger: :last,

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -49,7 +49,7 @@ module Suma::Payment
       ledger = payment_account.cash_ledger
       return ledger if ledger
       ledger = payment_account.add_ledger({currency: Suma.default_currency, name: "Cash"})
-      ledger.contribution_text.update(en: "Account Balance", es: "Saldo de la cuenta")
+      ledger.contribution_text.update(en: "General Balance", es: "Balance general")
       ledger.add_vendor_service_category(Suma::Vendor::ServiceCategory.cash)
       payment_account.associations.delete(:cash_ledger)
       return ledger

--- a/lib/suma/payment/book_transaction.rb
+++ b/lib/suma/payment/book_transaction.rb
@@ -57,6 +57,11 @@ class Suma::Payment::BookTransaction < Suma::Postgres::Model(:payment_book_trans
     return self.values.fetch(:_directed, false)
   end
 
+  def debug_description
+    return "BookTransaction[#{self.id}] for #{self.amount.format} from " \
+           "#{self.originating_ledger.admin_label} to #{self.receiving_ledger.admin_label}"
+  end
+
   UsageDetails = Struct.new(:code, :args)
 
   # @return [Array<UsageDetails>]

--- a/lib/suma/payment/calculation_context.rb
+++ b/lib/suma/payment/calculation_context.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# CalculationContexts are used when we have to work against the balance
+# of ledgers at the same time across time. For example,
+# we may be debiting one ledger for a product; then processing another product,
+# but don't want to re-debit that same ledger.
+# CalculationContext takes care of this by allowing the caller
+# to modify ledger balances in-memory.
+class Suma::Payment::CalculationContext
+  def initialize
+    @adjustments = {}
+  end
+
+  def balance(ledger)
+    balance = ledger.balance
+    if (adj = @adjustments[ledger.id])
+      balance -= adj
+    end
+    return balance
+  end
+
+  # @param contrib [Suma::Payment::ChargeContribution]
+  def apply(contrib)
+    return if contrib.remainder?
+    v = @adjustments[contrib.ledger.id]
+    v = v.nil? ? contrib.amount : (v + contrib.amount)
+    @adjustments[contrib.ledger.id] = v
+  end
+
+  def apply_all(contributions)
+    contributions.each { |c| self.apply(c) }
+  end
+end

--- a/lib/suma/payment/charge_contribution.rb
+++ b/lib/suma/payment/charge_contribution.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "suma/payment"
+
+class Suma::Payment::ChargeContribution < Suma::TypedStruct
+  attr_accessor :ledger, :apply_at, :amount, :category
+
+  def remainder? = self.ledger.nil?
+end

--- a/lib/suma/payment/funding_transaction.rb
+++ b/lib/suma/payment/funding_transaction.rb
@@ -119,12 +119,14 @@ class Suma::Payment::FundingTransaction < Suma::Postgres::Model(:payment_funding
 
     # Like +start_new+, but also creates a +BookTransaction+ that moves funds
     # from the platform ledger into the receiving ledger.
-    def start_and_transfer(receiving_ledger, amount:, vendor_service_category:, instrument: nil, strategy: nil)
+    def start_and_transfer(receiving_ledger,
+      amount:, vendor_service_category:, apply_at:,
+      instrument: nil, strategy: nil)
+
       self.db.transaction do
-        now = Time.now
         fx = Suma::Payment::FundingTransaction.start_new(receiving_ledger.account, amount:, instrument:, strategy:)
         originated_book_transaction = Suma::Payment::BookTransaction.create(
-          apply_at: now,
+          apply_at:,
           amount: fx.amount,
           originating_ledger: fx.platform_ledger,
           receiving_ledger:,

--- a/spec/suma/payment/funding_transaction_spec.rb
+++ b/spec/suma/payment/funding_transaction_spec.rb
@@ -88,17 +88,19 @@ RSpec.describe "Suma::Payment::FundingTransaction", :db do
     let(:category) { Suma::Vendor::ServiceCategory.find_or_create(name: "Cash") }
 
     it "creates a new funding and book transaction" do
+      now = Time.now
       fx = described_class.start_and_transfer(
         ledger,
         amount: Money.new(500, "USD"),
         vendor_service_category: category,
         instrument: bank_account,
         strategy: Suma::Payment::FakeStrategy.create.not_ready,
+        apply_at: now,
       )
       expect(fx).to have_attributes(status: "created")
       expect(member.payment_account.originated_funding_transactions).to contain_exactly(be === fx)
       expect(member.payment_account.cash_ledger.received_book_transactions).to contain_exactly(
-        have_attributes(amount: cost("$5")),
+        have_attributes(amount: cost("$5"), apply_at: match_time(now)),
       )
       expect(member.payment_account).to have_attributes(total_balance: cost("$5"))
     end

--- a/spec/suma/payment/ledger_spec.rb
+++ b/spec/suma/payment/ledger_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe "Suma::Payment::Ledger", :db do
       # Test custom eager loader
       expect(ledger.account.ledgers.first.combined_book_transactions).to have_same_ids_as(orig1, orig2, recip1, recip2)
     end
+
+    it "sorts combined transactions to have credits first" do
+      now = Time.now
+      debit1 = Suma::Fixtures.book_transaction.from(ledger).create(apply_at: now)
+      debit2 = Suma::Fixtures.book_transaction.from(ledger).create(apply_at: now)
+      credit1 = Suma::Fixtures.book_transaction.to(ledger).create(apply_at: now)
+      credit2 = Suma::Fixtures.book_transaction.to(ledger).create(apply_at: now)
+      expect(ledger.combined_book_transactions).to have_same_ids_as(debit1, debit2, credit1, credit2).ordered
+      eager_ledger = ledger.account.ledgers.first
+      expect(eager_ledger.combined_book_transactions).to have_same_ids_as(debit1, debit2, credit1, credit2).ordered
+    end
   end
 
   describe "balance" do

--- a/webapp/src/assets/styles/custom.scss
+++ b/webapp/src/assets/styles/custom.scss
@@ -90,3 +90,18 @@
     width: 100%;
     object-fit: cover;
 }
+
+/* Use this to hide the dropdown toggle */
+.dropdown-toggle-hide::after {
+    display: none !important;
+}
+
+/* Render a dropdown caret in a div */
+.dropdown-toggle-manual {
+    margin-left: $caret-spacing;
+    vertical-align: $caret-vertical-align;
+    border-top: $caret-width solid;
+    border-right: $caret-width solid transparent;
+    border-bottom: 0;
+    border-left: $caret-width solid transparent;
+}

--- a/webapp/src/shared/react/useListQueryControls.js
+++ b/webapp/src/shared/react/useListQueryControls.js
@@ -8,7 +8,7 @@ export default function useListQueryControls() {
   const search = params.get("search");
   const order = params.get("order");
   const orderBy = params.get("orderby");
-  function setListQueryParams(arg) {
+  function setListQueryParams(arg, more) {
     const sp = new URLSearchParams(params);
     _.each(urlKeysAndProps, (attr, key) => {
       if (_.has(arg, attr)) {
@@ -19,9 +19,11 @@ export default function useListQueryControls() {
         }
       }
     });
+    _.each(more, (val, key) => sp.set(key, val));
     setParams(sp);
   }
   return {
+    params,
     page,
     perPage,
     search,


### PR DESCRIPTION
Fix bug with charging multiple ledgers

When we calculate how we are paying for a product,
we figure out each ledger's contribution by looking at its balance.
However, once the ledger 'pays' for a product, it should deduct
from its balance (but we're not ready to add a book transaction).

We now have a 'calculation context' that allows us to build up
changes to a ledger balance as we process all the products.

---

Ledgers overview works with multiple ledgers

Fixes https://github.com/lithictech/suma/issues/269

We only supported one ledger; we now support multiple.

---

Improve sorting of book transactions

For xactions at the same moment,
credits go before debits so it looks like
money is added to the account before it's removed.