### PR TITLE
Order confirmation and history pages

### DIFF
--- a/db/migrations/015_associated_funding.rb
+++ b/db/migrations/015_associated_funding.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_join_table(
+      {charge_id: :charges, funding_transaction_id: :payment_funding_transactions},
+      name: :charges_associated_funding_transactions,
+    )
+  end
+end

--- a/lib/suma/charge.rb
+++ b/lib/suma/charge.rb
@@ -14,6 +14,17 @@ class Suma::Charge < Suma::Postgres::Model(:charges)
                join_table: :charges_payment_book_transactions,
                left_key: :charge_id,
                right_key: :book_transaction_id
+  # Keep track of any synchronous funding transactions
+  # that were caused due to this charge. There is NOT a direct linkage
+  # in ledgering terms- this is rather modeling the user experience
+  # of when a charge and funding event happen one after the other
+  # (ie, paying for an order during checkout, charges a card
+  # to cover the difference).
+  many_to_many :associated_funding_transactions,
+               class: "Suma::Payment::FundingTransaction",
+               join_table: :charges_associated_funding_transactions,
+               left_key: :charge_id,
+               right_key: :funding_transaction_id
 
   def initialize(*)
     super

--- a/lib/suma/fixtures/checkouts.rb
+++ b/lib/suma/fixtures/checkouts.rb
@@ -28,4 +28,8 @@ module Suma::Fixtures::Checkouts
   decorator :completed do |t=Time.now|
     self.complete(t)
   end
+
+  decorator :with_payment_instrument, presave: true do
+    self.payment_instrument ||= Suma::Fixtures.send([:card, :bank_account].sample).member(self.cart.member).create
+  end
 end

--- a/lib/suma/fixtures/orders.rb
+++ b/lib/suma/fixtures/orders.rb
@@ -15,4 +15,9 @@ module Suma::Fixtures::Orders
     instance.checkout ||= Suma::Fixtures.checkout.create
     instance
   end
+
+  decorator :as_purchased_by do |member|
+    cart = Suma::Fixtures.cart(member:).with_any_product.create
+    self.checkout = Suma::Fixtures.checkout(cart:).with_payment_instrument.populate_items.create
+  end
 end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -51,7 +51,8 @@ class Suma::Member < Suma::Postgres::Model(:members)
                     ],
                     class: "Suma::Payment::BankAccount",
                     left_primary_key: :legal_entity_id,
-                    order: [:created_at, :id]
+                    order: [:created_at, :id],
+                    read_only: true
   many_through_many :cards,
                     [
                       [:legal_entities, :id, :id],
@@ -59,12 +60,23 @@ class Suma::Member < Suma::Postgres::Model(:members)
                     ],
                     class: "Suma::Payment::Card",
                     left_primary_key: :legal_entity_id,
-                    order: [:created_at, :id]
+                    order: [:created_at, :id],
+                    read_only: true
   one_to_many :charges, class: "Suma::Charge", order: Sequel.desc([:id])
   many_to_one :legal_entity, class: "Suma::LegalEntity"
   one_to_many :message_deliveries, key: :recipient_id, class: "Suma::Message::Delivery"
   one_to_one :message_preferences, class: "Suma::Message::Preferences"
   one_to_one :ongoing_trip, class: "Suma::Mobility::Trip", conditions: {ended_at: nil}
+  many_through_many :orders,
+                    [
+                      [:commerce_carts, :member_id, :id],
+                      [:commerce_checkouts, :cart_id, :id],
+                    ],
+                    class: "Suma::Commerce::Order",
+                    left_primary_key: :id,
+                    right_primary_key: :checkout_id,
+                    order: Sequel.desc(:created_at),
+                    read_only: true
   one_to_one :payment_account, class: "Suma::Payment::Account"
   one_to_many :reset_codes, class: "Suma::Member::ResetCode", order: Sequel.desc([:created_at])
   many_to_many :roles, class: "Suma::Role", join_table: :roles_members

--- a/lib/suma/payment/bank_account.rb
+++ b/lib/suma/payment/bank_account.rb
@@ -66,6 +66,8 @@ class Suma::Payment::BankAccount < Suma::Postgres::Model(:payment_bank_accounts)
     return "#{self.name} x-#{self.last4}"
   end
 
+  def simple_label = self.name_with_last4
+
   def rel_admin_link = "/bank-account/#{self.id}"
 
   def institution

--- a/lib/suma/payment/card.rb
+++ b/lib/suma/payment/card.rb
@@ -53,6 +53,8 @@ class Suma::Payment::Card < Suma::Postgres::Model(:payment_cards)
   def brand  = self.stripe_json.fetch("brand")
   def name = "#{self.brand} x-#{self.last4}"
 
+  def simple_label = self.name
+
   def stripe_card
     return @stripe_card ||= Stripe::Card.construct_from(stripe_json.deep_symbolize_keys)
   end

--- a/lib/suma/payment/instrument.rb
+++ b/lib/suma/payment/instrument.rb
@@ -31,7 +31,7 @@ module Suma::Payment::Instrument
   end
 
   def simple_label
-    return "#{self.name} x-#{self.last4}"
+    raise NotImplementedError
   end
 
   def search_label

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -82,9 +82,12 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
 
     it "creates a funding transaction for the chargeable amount" do
       Suma::Fixtures.book_transaction(amount: money("$5")).to(member_ledger).create
-      checkout.create_order
+      order = checkout.create_order
       expect(member.payment_account.originated_funding_transactions).to contain_exactly(
         have_attributes(amount: cost("$35"), status: "created"),
+      )
+      expect(order.charges.first.associated_funding_transactions).to contain_exactly(
+        be === member.payment_account.originated_funding_transactions.first,
       )
     end
 

--- a/spec/suma/commerce/order_spec.rb
+++ b/spec/suma/commerce/order_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::Commerce::Order", :db do
+  let(:described_class) { Suma::Commerce::Order }
+
+  it "can make a serial number" do
+    o = Suma::Fixtures.order.create
+    o.id = 12
+    expect(o.serial).to eq("0012")
+  end
+
+  it "knows how much was paid" do
+    charge = Suma::Fixtures.charge.create
+    bx = Suma::Fixtures.book_transaction.create(amount: money("$12.50"))
+    charge.add_book_transaction(bx)
+    o = Suma::Fixtures.order.create
+    expect(o.paid_amount).to cost("$0")
+    o.add_charge(charge)
+    expect(o.paid_amount).to cost("$12.50")
+  end
+
+  it "knows how much was synchronously funded" do
+    charge = Suma::Fixtures.charge.create
+    fx = Suma::Fixtures.funding_transaction.with_fake_strategy.create(amount: money("$12.50"))
+    charge.add_associated_funding_transaction(fx)
+    o = Suma::Fixtures.order.create
+    expect(o.funded_amount).to cost("$0")
+    o.add_charge(charge)
+    expect(o.funded_amount).to cost("$12.50")
+  end
+end

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe "Suma::Member", :db do
       t.end_trip(lat: 1, lng: 2)
       expect(c.refresh.ongoing_trip).to be_nil
     end
+
+    it "has an orders association" do
+      o = Suma::Fixtures.order.create
+      member = o.checkout.cart.member
+
+      expect(member.orders).to contain_exactly(be === o)
+    end
   end
 
   describe "greeting" do

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -27,6 +27,8 @@ import Onboarding from "./pages/Onboarding";
 import OnboardingFinish from "./pages/OnboardingFinish";
 import OnboardingSignup from "./pages/OnboardingSignup";
 import OneTimePassword from "./pages/OneTimePassword";
+import OrderHistoryDetail from "./pages/OrderHistoryDetail";
+import OrderHistoryList from "./pages/OrderHistoryList";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import Start from "./pages/Start";
 import Styleguide from "./pages/Styleguide";
@@ -328,6 +330,30 @@ function AppRoutes() {
             withMetatags({ title: t("titles:ledgers_overview") }),
             withLayout(),
             LedgersOverview
+          )}
+        />
+        <Route
+          path="/order-history"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:ledgers_overview") }), // TODO
+            withLayout(),
+            OrderHistoryList
+          )}
+        />
+        <Route
+          path="/order/:id"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:ledgers_overview") }), // TODO
+            withLayout(),
+            OrderHistoryDetail
           )}
         />
         <Route path="/styleguide" exact element={<Styleguide />} />

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -241,7 +241,7 @@ function AppRoutes() {
             redirectIfUnboarded,
             withScreenLoaderMount(),
             withMetatags({ title: t("food:checkout") }),
-            withLayout({ appNav: true, gutters: true, top: true }),
+            withLayout({ appNav: true, gutters: false }),
             FoodCheckoutConfirmation
           )}
         />

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -4,7 +4,7 @@ import apiBase from "./shared/apiBase";
 
 const instance = apiBase.create(config.apiHost, {
   debug: config.debug,
-  chaos: config.chaos,
+  chaos: false,
 });
 
 instance.interceptors.request.use(
@@ -72,6 +72,8 @@ export default {
     post(`/api/v1/commerce/checkouts/${id}/complete`, data),
   getCheckoutConfirmation: ({ id, ...data }) =>
     get(`/api/v1/commerce/checkouts/${id}/confirmation`, data),
+  getOrderHistory: (data) => get(`/api/v1/commerce/orders`, data),
+  getOrderDetails: ({ id, ...data }) => get(`/api/v1/commerce/orders/${id}`, data),
 
   createBankAccount: (data) =>
     post(`/api/v1/payment_instruments/bank_accounts/create`, data),

--- a/webapp/src/assets/styles/custom.scss
+++ b/webapp/src/assets/styles/custom.scss
@@ -91,6 +91,11 @@
     object-fit: cover;
 }
 
+.responsive-wide-image {
+    width: 100%;
+    object-fit: cover;
+}
+
 /* Use this to hide the dropdown toggle */
 .dropdown-toggle-hide::after {
     display: none !important;

--- a/webapp/src/components/AppNav.js
+++ b/webapp/src/components/AppNav.js
@@ -10,20 +10,26 @@ export default function AppNav() {
     <div ref={setAppNav} className="app-nav d-flex flex-row">
       <AppLink to="/dashboard" label={t("titles:home")} className="border-end-0" />
       <AppLink to="/mobility" label={t("titles:mobility")} className="border-end-0" />
-      <AppLink to="/food" label={t("food:title")} className="border-end-0" />
+      <AppLink
+        to="/food"
+        label={t("food:title")}
+        className="border-end-0"
+        prefixes={["/checkout"]}
+      />
       <AppLink to="/utilities" label={t("utilities:title")} />
     </div>
   );
 }
 
-const AppLink = ({ to, label, className }) => {
+const AppLink = ({ to, label, prefixes, className }) => {
   const location = useLocation();
+  const active = [...(prefixes || []), to].some((x) => location.pathname.startsWith(x));
   return (
     <Link
       to={to}
       className={clsx(
         "btn btn-outline-primary app-link",
-        location.pathname.startsWith(to) && "app-link-active",
+        active && "app-link-active",
         className
       )}
     >

--- a/webapp/src/pages/Food.js
+++ b/webapp/src/pages/Food.js
@@ -15,6 +15,7 @@ import { Stack } from "react-bootstrap";
 import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
+import { Link } from "react-router-dom";
 
 export default function Food() {
   const {
@@ -52,6 +53,13 @@ export default function Food() {
         {_.isEmpty(foodOfferings?.items) && !offeringsLoading && (
           <p>{t("food:no_offerings")}</p>
         )}
+        <hr />
+        <h4 className="mb-3">
+          <Link to="/order-history" className="text-decoration-none">
+            <span className="text-dark">Previous Orders </span>
+            <i className="bi-arrow-right"></i>
+          </Link>
+        </h4>
       </LayoutContainer>
     </>
   );

--- a/webapp/src/pages/FoodCheckoutConfirmation.js
+++ b/webapp/src/pages/FoodCheckoutConfirmation.js
@@ -1,10 +1,14 @@
 import api from "../api";
 import ErrorScreen from "../components/ErrorScreen";
 import PageLoader from "../components/PageLoader";
+import SumaImage from "../components/SumaImage";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import { LayoutContainer } from "../state/withLayout";
-import _ from "lodash";
 import React from "react";
+import { Alert } from "react-bootstrap";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Stack from "react-bootstrap/Stack";
 import { useLocation, useParams } from "react-router-dom";
 
 export default function FoodCheckoutConfirmation() {
@@ -32,9 +36,59 @@ export default function FoodCheckoutConfirmation() {
       </LayoutContainer>
     );
   }
-  if (loading || _.isEmpty(checkout)) {
+  if (loading) {
     return <PageLoader />;
   }
+  const { fulfillmentOption, items } = checkout;
+  return (
+    <>
+      <div className="bg-success text-white p-3">
+        <Alert.Heading>Order placed successfully!</Alert.Heading>
+        <p className="mb-0">
+          You will get a message soon with details about how to get your order.
+        </p>
+      </div>
+      <LayoutContainer top>
+        <h4 className="mb-3">What you&rsquo;re getting</h4>
+        {items.map((p, idx) => (
+          <Item key={idx} item={p} />
+        ))}
+        <hr />
+        <h4 className="mb-3">How you&rsquo;re getting it</h4>
+        <p>{fulfillmentOption.description}</p>
+        <hr />
+        <p>
+          Respond to your confirmation message or reach out if you have any questions.
+        </p>
+        <Stack className="mt-2">
+          <Button variant="outline-success" href="/dashboard">
+            Take me home!
+          </Button>
+        </Stack>
+      </LayoutContainer>
+    </>
+  );
+}
 
-  return <div>Checkout confirmation for {checkout.id}</div>;
+function Item({ item }) {
+  const { product, quantity } = item;
+  return (
+    <>
+      <Col xs={12} className="mb-3">
+        <Stack direction="horizontal" gap={3} className="align-items-start">
+          <SumaImage
+            image={product.images[0]}
+            alt={product.name}
+            className="rounded"
+            w={90}
+            h={90}
+          />
+          <Stack>
+            <p className="mb-0 lead">{product.name}</p>
+            <p className="text-secondary">Quantity: {quantity}</p>
+          </Stack>
+        </Stack>
+      </Col>
+    </>
+  );
 }

--- a/webapp/src/pages/OrderHistoryDetail.js
+++ b/webapp/src/pages/OrderHistoryDetail.js
@@ -1,0 +1,91 @@
+import api from "../api";
+import ErrorScreen from "../components/ErrorScreen";
+import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
+import PageLoader from "../components/PageLoader";
+import SumaImage from "../components/SumaImage";
+import { dayjs } from "../modules/dayConfig";
+import Money from "../shared/react/Money";
+import useAsyncFetch from "../shared/react/useAsyncFetch";
+import { LayoutContainer } from "../state/withLayout";
+import React from "react";
+import { Stack } from "react-bootstrap";
+import Card from "react-bootstrap/Card";
+import { useLocation, useParams } from "react-router-dom";
+
+export default function OrderHistoryDetail() {
+  const { id } = useParams();
+  const location = useLocation();
+  const getOrderDetails = React.useCallback(() => api.getOrderDetails({ id }), [id]);
+  const { state, loading, error } = useAsyncFetch(getOrderDetails, {
+    default: {},
+    pickData: true,
+    pullFromState: "order",
+    location,
+  });
+  if (error) {
+    return (
+      <LayoutContainer top>
+        <ErrorScreen />
+      </LayoutContainer>
+    );
+  }
+  if (loading) {
+    return <PageLoader />;
+  }
+  return (
+    <>
+      <LayoutContainer top gutters>
+        <LinearBreadcrumbs back="/order-history" />
+      </LayoutContainer>
+      <LayoutContainer gutters>
+        <Stack gap={3}>
+          <div>
+            <h2 className="mb-1">Order {state.serial}</h2>
+            {dayjs(state.createdAt).format("lll")}
+          </div>
+          <p className="mb-0">
+            Price: <Money>{state.customerCost}</Money>
+            <Money as="del" className="text-secondary ms-2">
+              {state.undiscountedCost}
+            </Money>
+            <br />
+            Fees <Money>{state.handling}</Money>, Tax <Money>{state.tax}</Money>
+            <br />
+            Total: <Money>{state.total}</Money>
+            {state.fundingTransactions.map(({ label, amount }) => (
+              <React.Fragment key={label}>
+                <br />
+                {label}: <Money>{amount}</Money>
+              </React.Fragment>
+            ))}
+            <br />
+            <span>{state.fulfillmentOption.description}</span>
+          </p>
+          <SumaImage
+            image={state.image}
+            w={350}
+            height={150}
+            className="rounded responsive-wide-image"
+          />
+          <hr className="my-0" />
+          <Stack>
+            <Card.Text className="h4">Items</Card.Text>
+            {state.items.map(({ name, description, customerPrice }, i) => (
+              <Stack
+                direction="horizontal"
+                key={`${name}-${i}`}
+                className="justify-content-between align-items-start"
+              >
+                <div>
+                  <div className="lead">{name}</div>
+                  <div className="text-secondary">{description}</div>
+                </div>
+                <Money className="ms-2 lead">{customerPrice}</Money>
+              </Stack>
+            ))}
+          </Stack>
+        </Stack>
+      </LayoutContainer>
+    </>
+  );
+}

--- a/webapp/src/pages/OrderHistoryList.js
+++ b/webapp/src/pages/OrderHistoryList.js
@@ -1,0 +1,100 @@
+import api from "../api";
+import ErrorScreen from "../components/ErrorScreen";
+import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
+import PageLoader from "../components/PageLoader";
+import RLink from "../components/RLink";
+import SumaImage from "../components/SumaImage";
+import { dayjs } from "../modules/dayConfig";
+import Money from "../shared/react/Money";
+import useAsyncFetch from "../shared/react/useAsyncFetch";
+import { LayoutContainer } from "../state/withLayout";
+import _ from "lodash";
+import React from "react";
+import { Stack } from "react-bootstrap";
+import Card from "react-bootstrap/Card";
+import { Link, useNavigate } from "react-router-dom";
+
+export default function OrderHistoryList() {
+  const {
+    state: orderHistory,
+    loading,
+    error,
+  } = useAsyncFetch(api.getOrderHistory, {
+    default: {},
+    pickData: true,
+  });
+  const navigate = useNavigate();
+  if (error) {
+    return (
+      <LayoutContainer top>
+        <ErrorScreen />
+      </LayoutContainer>
+    );
+  }
+  if (loading) {
+    return <PageLoader />;
+  }
+
+  function handleNavigate(e, order) {
+    const detailed = _.find(orderHistory.detailedOrders, { id: order.id });
+    if (!detailed) {
+      return;
+    }
+    e.preventDefault();
+    navigate(`/order/${order.id}`, { state: { order: detailed } });
+  }
+  return (
+    <>
+      <LayoutContainer top gutters>
+        <LinearBreadcrumbs back="/food" />
+        <h2>Order History</h2>
+      </LayoutContainer>
+      <LayoutContainer gutters>
+        {!_.isEmpty(orderHistory?.items) && (
+          <Stack gap={4} className="mt-4">
+            {orderHistory?.items.map((o) => (
+              <Order key={o.id} {...o} onNavigate={(e) => handleNavigate(e, o)} />
+            ))}
+          </Stack>
+        )}
+        {_.isEmpty(orderHistory?.items) && (
+          <>
+            <p>You haven&rsquo;t place any orders yet.</p>
+            <p>
+              <Link to="/food">
+                Check out what&rsquo;s available. <i className="bi bi-arrow-right"></i>
+              </Link>
+            </p>
+          </>
+        )}
+      </LayoutContainer>
+    </>
+  );
+}
+
+function Order({ id, createdAt, total, image, serial, onNavigate }) {
+  return (
+    <Card>
+      <Card.Body>
+        <Stack direction="horizontal" gap={3}>
+          <SumaImage image={image} width={80} h={80} className="border rounded" />
+          <div>
+            <Card.Link
+              as={RLink}
+              href={`/order/${id}`}
+              className="h5"
+              onClick={onNavigate}
+            >
+              Order {serial}
+            </Card.Link>
+            <Card.Text className="text-secondary mt-1">
+              Placed {dayjs(createdAt).format("ll")}
+              <br />
+              <Money>{total}</Money>
+            </Card.Text>
+          </div>
+        </Stack>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/webapp/src/shared/react/Money.js
+++ b/webapp/src/shared/react/Money.js
@@ -22,7 +22,7 @@ const defaultFormatters = {
 };
 defaultFormatters.default = defaultFormatters.USD;
 
-export default function Money({ value, children, className, accounting, ...rest }) {
+export default function Money({ value, children, className, accounting, as, ...rest }) {
   let entity = value || children;
   if (!entity) {
     return null;
@@ -33,7 +33,8 @@ export default function Money({ value, children, className, accounting, ...rest 
   } else {
     ch = formatMoney(entity, rest);
   }
-  return <span className={className}>{ch}</span>;
+  const As = as || "span";
+  return <As className={className}>{ch}</As>;
 }
 
 Money.propTypes = {


### PR DESCRIPTION
AppNav is more flexible with active paths

Checkout confirmation was not showing as active under food.

---

Implement order history support

Fixes https://github.com/lithictech/suma/issues/261

- Add order history list, reachable from the offerings page
- Add order history detail page.
- Order history comes from the backend including the last 2
  most recent detailed orders, to avoid API calls for the common case.
- We need to show what instrument was used to fund the order
  (ie the $10 card charge). Because we use a ledgering system,
  we weren't keeping track of that (ie, a charge is not connected
  to an order- a charge just funds a ledger and the ledger
  is debited). We now keep track of what funding transactions
  are created as part of an order.
- Add association so a member can find its orders.
- Tweak some display information on instrument labels.

---

Overhaul checkout confirmation page

Fixes https://github.com/lithictech/suma/issues/258

---

![Screen Shot 2022-11-19 at 09 39 02](https://user-images.githubusercontent.com/1643233/202864311-aaa20c68-be3f-409c-87d3-dc399522be1b.png)

![Screen Shot 2022-11-19 at 09 29 55](https://user-images.githubusercontent.com/1643233/202864314-ce9f8b40-fdf7-45c7-85eb-ae9e38306c41.png)

![Screen Shot 2022-11-19 at 09 29 45](https://user-images.githubusercontent.com/1643233/202864319-44dee912-3fab-4363-8e32-14e7ea726019.png)
