### PR TITLE
Payment methods are enabled/disabled via config

### DIFF
--- a/lib/suma/api/meta.rb
+++ b/lib/suma/api/meta.rb
@@ -35,5 +35,10 @@ class Suma::API::Meta < Suma::API::V1
       use_http_expires_caching 2.days
       present_collection Suma::I18n::SUPPORTED_LOCALES.values, with: LocaleEntity
     end
+
+    get :supported_payment_methods do
+      use_http_expires_caching 2.days
+      present_collection Suma::Payment.supported_methods
+    end
   end
 end

--- a/lib/suma/api/payment_instruments.rb
+++ b/lib/suma/api/payment_instruments.rb
@@ -15,6 +15,9 @@ class Suma::API::PaymentInstruments < Suma::API::V1
       end
       post :create do
         c = current_member
+        merror!(402, "Bank account creation not supported", code: "forbidden") unless
+          Suma::Payment.method_supported?("bank_account")
+
         account_number = params.delete(:account_number)
         routing_number = params.delete(:routing_number)
         identity = Suma::Payment::BankAccount.identity(c.legal_entity_id, routing_number, account_number)
@@ -70,6 +73,8 @@ class Suma::API::PaymentInstruments < Suma::API::V1
       end
       post :create_stripe do
         me = current_member
+        merror!(402, "Card creation not supported", code: "forbidden") unless
+          Suma::Payment.method_supported?("card")
         card = me.db.transaction do
           me.stripe.ensure_registered_as_customer
           begin

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -165,14 +165,12 @@ class Suma::Member < Suma::Postgres::Model(:members)
 
   def usable_payment_instruments
     ord = [Sequel.desc(:created_at), :id]
-    bank_accounts = self.
-      legal_entity.
-      bank_accounts_dataset.
-      usable.
-      order(*ord).
-      all
-    cards = self.legal_entity.cards_dataset.usable.order(*ord).all
-    return bank_accounts + cards
+    result = []
+    result.concat(self.legal_entity.bank_accounts_dataset.usable.order(*ord).all) if
+      Suma::Payment.method_supported?("bank_account")
+    result.concat(self.legal_entity.cards_dataset.usable.order(*ord).all) if
+      Suma::Payment.method_supported?("card")
+    return result
   end
 
   def default_payment_instrument

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -17,9 +17,12 @@ module Suma::Payment
     end
   end
 
+  class UnsupportedMethod < Error; end
+
   configurable(:payments) do
     setting :autoverify_account_numbers, [], convert: ->(s) { s.split }
     setting :minimum_funding_amount_cents, 500
+    setting :supported_methods, ["bank_account", "card"], convert: ->(s) { s.split }
   end
 
   APPROXIMATE_ACH_SCHEDULE = Biz::Schedule.new do |config|
@@ -33,6 +36,24 @@ module Suma::Payment
     config.time_zone = "America/New_York"
     config.holidays = Holidays.between(Date.new(2022, 7, 1), 1.year.from_now, :us, :observed).
       map { |h| h[:date] }
+  end
+
+  # Certain Suma deployments may only support certain payment instruments-
+  # for example, it may be easy to get set up with cards but difficult to
+  # start using bank accounts, or perhaps this is an entirely unbanked instance
+  # that only uses script. When a payment method is not enabled:
+  #
+  # - Funding transactions using those instruments is disabled.
+  # - Adding those instruments is disabled.
+  # - They do not show up in a member's 'usable instruments'.
+  # - They do not show in the UI.
+  #
+  # Removing support for an instrument on an established instance is not
+  # considered a 'safe' operation since a disabled instrument
+  # may be linked to active checkouts, etc. If this is needed in the future,
+  # we need to add better support for it.
+  def self.method_supported?(x)
+    return self.supported_methods.include?(x.to_s)
   end
 
   # Every member should have a 'cash' ledger that is used for almost every service

--- a/lib/suma/payment/funding_transaction.rb
+++ b/lib/suma/payment/funding_transaction.rb
@@ -89,7 +89,10 @@ class Suma::Payment::FundingTransaction < Suma::Postgres::Model(:payment_funding
       self.db.transaction do
         platform_ledger = Suma::Payment.ensure_cash_ledger(Suma::Payment::Account.lookup_platform_account)
         if strategy.nil?
-          strategy = case instrument&.payment_method_type
+          raise ArgumentError, ":instrument must be provided if :strategy is not" if instrument.nil?
+          pmt = instrument.payment_method_type
+          raise Suma::Payment::UnsupportedMethod, "#{pmt} is not supported" unless Suma::Payment.method_supported?(pmt)
+          strategy = case pmt
             when "bank_account"
               IncreaseAchStrategy.create(originating_bank_account: instrument)
             when "card"

--- a/spec/suma/api/meta_spec.rb
+++ b/spec/suma/api/meta_spec.rb
@@ -79,4 +79,15 @@ RSpec.describe Suma::API::Meta, :db do
       )
     end
   end
+
+  describe "GET /v1/meta/supported_payment_methods" do
+    it "returns supported methods" do
+      get "/v1/meta/supported_payment_methods"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        items: ["bank_account", "card"],
+      )
+    end
+  end
 end

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -205,6 +205,10 @@ RSpec.describe "Suma::Member", :db do
     let(:bank_fac) { Suma::Fixtures.bank_account.member(member) }
     let(:card_fac) { Suma::Fixtures.card.member(member) }
 
+    after(:each) do
+      Suma::Payment.reset_configuration
+    end
+
     it "returns undeleted bank accounts and cards" do
       deleted_ba = bank_fac.create
       deleted_ba.soft_delete
@@ -217,6 +221,15 @@ RSpec.describe "Suma::Member", :db do
       c2 = card_fac.create
 
       expect(member.usable_payment_instruments).to have_same_ids_as(ba1, ba2, c2, c1).ordered
+    end
+
+    it "excludes unsupported payment methods" do
+      c1 = card_fac.create
+      ba1 = bank_fac.create
+
+      expect(member.usable_payment_instruments).to have_same_ids_as(ba1, c1)
+      Suma::Payment.supported_methods = ["card"]
+      expect(member.usable_payment_instruments).to have_same_ids_as(c1)
     end
   end
 

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -48,6 +48,8 @@ export default {
   getSupportedGeographies: (data) => get(`/api/v1/meta/supported_geographies`, data),
   getSupportedLocales: (data) => get(`/api/v1/meta/supported_locales`, data),
   getSupportedCurrencies: (data) => get(`/api/v1/meta/supported_currencies`, data),
+  getSupportedPaymentMethods: (data) =>
+    get(`/api/v1/meta/supported_payment_methods`, data),
   dashboard: (data) => get("/api/v1/me/dashboard", data),
   getLedgersOverview: (data) => get("/api/v1/ledgers/overview", data),
   getLedgerLines: ({ id, ...data }) => get(`/api/v1/ledgers/${id}/lines`, data),

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -6,6 +6,7 @@ import SumaImage from "../components/SumaImage";
 import { t } from "../localization";
 import Money from "../shared/react/Money";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
+import { useBackendGlobals } from "../state/useBackendGlobals";
 import { useOffering } from "../state/useOffering";
 import { useScreenLoader } from "../state/useScreenLoader";
 import { LayoutContainer } from "../state/withLayout";
@@ -118,16 +119,21 @@ function CheckoutPayment({
   onSelectedInstrumentChange,
   onCheckoutChange,
 }) {
+  const { isPaymentMethodSupported } = useBackendGlobals();
   const addPaymentLinks = (
     <>
-      <Link to={`/add-card?returnTo=/checkout/${checkout.id}`}>
-        <i className="bi bi-credit-card me-2" />
-        Add debit/credit card
-      </Link>
-      <Link to={`/link-bank-account?returnTo=/checkout/${checkout.id}`}>
-        <i className="bi bi-bank2 me-2" />
-        Link bank account
-      </Link>
+      {isPaymentMethodSupported("card") && (
+        <Link to={`/add-card?returnTo=/checkout/${checkout.id}`}>
+          <i className="bi bi-credit-card me-2" />
+          Add debit/credit card
+        </Link>
+      )}
+      {isPaymentMethodSupported("bank_account") && (
+        <Link to={`/link-bank-account?returnTo=/checkout/${checkout.id}`}>
+          <i className="bi bi-bank2 me-2" />
+          Link bank account
+        </Link>
+      )}
     </>
   );
 

--- a/webapp/src/pages/Funding.js
+++ b/webapp/src/pages/Funding.js
@@ -7,6 +7,7 @@ import RLink from "../components/RLink";
 import { md, t } from "../localization";
 import externalLinks from "../modules/externalLinks";
 import useToggle from "../shared/react/useToggle";
+import { useBackendGlobals } from "../state/useBackendGlobals";
 import { extractErrorCode, useError } from "../state/useError";
 import { useScreenLoader } from "../state/useScreenLoader";
 import { useUser } from "../state/useUser";
@@ -19,14 +20,19 @@ import Modal from "react-bootstrap/Modal";
 
 export default function Funding() {
   const { user } = useUser();
+  const { isPaymentMethodSupported } = useBackendGlobals();
   return (
     <>
       <LinearBreadcrumbs back />
       <h2 className="page-header">{t("payments:payment_title")}</h2>
       <p>{md("payments:payment_intro.intro_md")}</p>
       <p id="some">{md("payments:payment_intro.privacy_statement_md")}</p>
-      <BankAccountsCard instruments={user.usablePaymentInstruments} />
-      <CardsCard instruments={user.usablePaymentInstruments} />
+      {isPaymentMethodSupported("bank_account") && (
+        <BankAccountsCard instruments={user.usablePaymentInstruments} />
+      )}
+      {isPaymentMethodSupported("card") && (
+        <CardsCard instruments={user.usablePaymentInstruments} />
+      )}
       <AdditionalSourcesCard />
     </>
   );

--- a/webapp/src/state/useBackendGlobals.js
+++ b/webapp/src/state/useBackendGlobals.js
@@ -10,11 +10,25 @@ export function BackendGlobalsProvider({ children }) {
     default: { items: [] },
     pickData: true,
   });
+  const { state: supportedPaymentMethods } = useAsyncFetch(
+    api.getSupportedPaymentMethods,
+    {
+      default: { items: [] },
+      pickData: true,
+    }
+  );
+
+  const isPaymentMethodSupported = React.useCallback(
+    (pm) => supportedPaymentMethods.items.includes(pm),
+    [supportedPaymentMethods]
+  );
 
   return (
     <BackendGlobalsContext.Provider
       value={{
         supportedLocales,
+        supportedPaymentMethods,
+        isPaymentMethodSupported,
       }}
     >
       {children}


### PR DESCRIPTION
Certain Suma deployments may only support certain payment instruments- for example, it may be easy to get set up with cards but difficult to start using bank accounts, or perhaps this is an entirely unbanked instance that only uses script. When a payment method is not enabled:

- Funding transactions using those instruments is disabled.
- Adding those instruments is disabled.
- They do not show up in a member's 'usable instruments'.
- They do not show in the UI.

Removing support for an instrument on an established instance is not considered a 'safe' operation since a disabled instrument may be linked to active checkouts, etc. If this is needed in the future, we need to add better support for it.

Fixes https://github.com/lithictech/suma/issues/235