### PR TITLE
Createand add errorToast context provider in necessary pages

### DIFF
--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -27,7 +27,8 @@
     "view_all": "View all",
     "waitlisted": "Great! You are on the waiting list and we'll let you know when it's available.",
     "welcome_to_suma": "Welcome to Suma!",
-    "whats_this": "What's this?"
+    "whats_this": "What's this?",
+    "error": "Error"
   },
   "dashboard": {
     "check_ongoing_trip": "You have an ongoing trip. Please make sure you end it when you are finished with your ride!",

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -52,23 +52,23 @@ window.Promise = bluejay.Promise;
 
 export default function App() {
   return (
-    <BackendGlobalsProvider>
-      <I18NextProvider>
-        <ScreenLoaderProvider>
-          <HelmetProvider>
-            <UserProvider>
-              <GlobalViewStateProvider>
-                <OfferingProvider>
-                  <ErrorToastProvider>
+    <GlobalViewStateProvider>
+      <ErrorToastProvider>
+        <BackendGlobalsProvider>
+          <I18NextProvider>
+            <ScreenLoaderProvider>
+              <HelmetProvider>
+                <UserProvider>
+                  <OfferingProvider>
                     <InnerApp />
-                  </ErrorToastProvider>
-                </OfferingProvider>
-              </GlobalViewStateProvider>
-            </UserProvider>
-          </HelmetProvider>
-        </ScreenLoaderProvider>
-      </I18NextProvider>
-    </BackendGlobalsProvider>
+                  </OfferingProvider>
+                </UserProvider>
+              </HelmetProvider>
+            </ScreenLoaderProvider>
+          </I18NextProvider>
+        </BackendGlobalsProvider>
+      </ErrorToastProvider>
+    </GlobalViewStateProvider>
   );
 }
 

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -37,6 +37,7 @@ import bluejay from "./shared/bluejay";
 import Redirect from "./shared/react/Redirect";
 import renderComponent from "./shared/react/renderComponent";
 import { BackendGlobalsProvider } from "./state/useBackendGlobals";
+import { ErrorToastProvider } from "./state/useErrorToast";
 import { GlobalViewStateProvider } from "./state/useGlobalViewState";
 import { OfferingProvider } from "./state/useOffering";
 import { ScreenLoaderProvider, withScreenLoaderMount } from "./state/useScreenLoader";
@@ -58,7 +59,9 @@ export default function App() {
             <UserProvider>
               <GlobalViewStateProvider>
                 <OfferingProvider>
-                  <InnerApp />
+                  <ErrorToastProvider>
+                    <InnerApp />
+                  </ErrorToastProvider>
                 </OfferingProvider>
               </GlobalViewStateProvider>
             </UserProvider>
@@ -326,7 +329,7 @@ function AppRoutes() {
             redirectIfUnauthed,
             redirectIfUnboarded,
             withScreenLoaderMount(),
-            withMetatags({ title: t("titles:ledgers_overview") }), // TODO
+            withMetatags({ title: t("titles:ledgers_overview") }),
             withLayout(),
             OrderHistoryList
           )}
@@ -338,7 +341,7 @@ function AppRoutes() {
             redirectIfUnauthed,
             redirectIfUnboarded,
             withScreenLoaderMount(),
-            withMetatags({ title: t("titles:ledgers_overview") }), // TODO
+            withMetatags({ title: t("titles:ledgers_overview") }),
             withLayout(),
             OrderHistoryDetail
           )}

--- a/webapp/src/assets/styles/_theme.scss
+++ b/webapp/src/assets/styles/_theme.scss
@@ -74,6 +74,7 @@ $input-placeholder-color: $gray-500;
 @import "~bootstrap/scss/_navbar";
 @import "~bootstrap/scss/_pagination";
 @import "~bootstrap/scss/_tables";
+@import "~bootstrap/scss/_toasts";
 @import "~bootstrap/scss/_transitions";
 // @import "~bootstrap/scss/_breadcrumb";
 // @import "~bootstrap/scss/_list-group";
@@ -81,7 +82,6 @@ $input-placeholder-color: $gray-500;
 // @import "~bootstrap/scss/_progress";
 // @import "~bootstrap/scss/_popover";
 // @import "~bootstrap/scss/_spinners";
-// @import "~bootstrap/scss/_toasts";
 // @import "~bootstrap/scss/_tooltip";
 @import "~bootstrap/scss/_type";
 

--- a/webapp/src/components/FoodCartWidget.js
+++ b/webapp/src/components/FoodCartWidget.js
@@ -2,6 +2,8 @@ import api from "../api";
 import addIcon from "../assets/images/food-widget-add.svg";
 import subtractIcon from "../assets/images/food-widget-subtract.svg";
 import { t } from "../localization";
+import { extractErrorCode } from "../state/useError";
+import { useErrorToast } from "../state/useErrorToast";
 import { useOffering } from "../state/useOffering";
 import clsx from "clsx";
 import _ from "lodash";
@@ -14,6 +16,7 @@ export default function FoodCartWidget({ product, size }) {
   size = size || "sm";
   const btnClasses = sizeClasses[size];
   const { offering, cart, setCart } = useOffering();
+  const { setErrorToast } = useErrorToast();
 
   const changePromise = React.useRef(null);
 
@@ -36,8 +39,7 @@ export default function FoodCartWidget({ product, size }) {
         setCart(resp.data);
       })
       .catch((e) => {
-        // TODO: Add an error toast when this fails
-        console.error(e);
+        setErrorToast(extractErrorCode(e));
       });
   };
 

--- a/webapp/src/components/FoodCartWidget.js
+++ b/webapp/src/components/FoodCartWidget.js
@@ -2,7 +2,6 @@ import api from "../api";
 import addIcon from "../assets/images/food-widget-add.svg";
 import subtractIcon from "../assets/images/food-widget-subtract.svg";
 import { t } from "../localization";
-import { extractErrorCode } from "../state/useError";
 import { useErrorToast } from "../state/useErrorToast";
 import { useOffering } from "../state/useOffering";
 import clsx from "clsx";
@@ -16,7 +15,7 @@ export default function FoodCartWidget({ product, size }) {
   size = size || "sm";
   const btnClasses = sizeClasses[size];
   const { offering, cart, setCart } = useOffering();
-  const { setErrorToast } = useErrorToast();
+  const { showErrorToast } = useErrorToast();
 
   const changePromise = React.useRef(null);
 
@@ -38,9 +37,7 @@ export default function FoodCartWidget({ product, size }) {
       .then((resp) => {
         setCart(resp.data);
       })
-      .catch((e) => {
-        setErrorToast(extractErrorCode(e));
-      });
+      .catch((e) => showErrorToast(e, { extract: true }));
   };
 
   // TODO: once we have basic inventory it should control the max quantity

--- a/webapp/src/pages/FoodCart.js
+++ b/webapp/src/pages/FoodCart.js
@@ -6,7 +6,6 @@ import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
 import { md, mdp, t } from "../localization";
 import Money from "../shared/react/Money";
-import { extractErrorCode } from "../state/useError";
 import { useErrorToast } from "../state/useErrorToast";
 import { useOffering } from "../state/useOffering";
 import { LayoutContainer } from "../state/withLayout";
@@ -24,7 +23,7 @@ export default function FoodCart() {
   const { id: offeringId } = useParams();
   const navigate = useNavigate();
   const { cart, products, vendors, error, loading, initializeToOffering } = useOffering();
-  const { setErrorToast } = useErrorToast();
+  const { showErrorToast } = useErrorToast();
 
   React.useEffect(() => {
     initializeToOffering(offeringId);
@@ -46,9 +45,7 @@ export default function FoodCart() {
       .startCheckout({ offeringId })
       .then(api.pickData)
       .then((d) => navigate(`/checkout/${d.id}`, { state: { checkout: d } }))
-      .catch((e) => {
-        setErrorToast(extractErrorCode(e));
-      });
+      .catch((e) => showErrorToast(e, { extract: true }));
   }
   const productsById = Object.fromEntries(products.map((p) => [p.productId, p]));
   const vendorsById = Object.fromEntries(vendors.map((v) => [v.id, v]));

--- a/webapp/src/pages/FoodCart.js
+++ b/webapp/src/pages/FoodCart.js
@@ -6,6 +6,8 @@ import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
 import { md, mdp, t } from "../localization";
 import Money from "../shared/react/Money";
+import { extractErrorCode } from "../state/useError";
+import { useErrorToast } from "../state/useErrorToast";
 import { useOffering } from "../state/useOffering";
 import { LayoutContainer } from "../state/withLayout";
 import clsx from "clsx";
@@ -22,6 +24,7 @@ export default function FoodCart() {
   const { id: offeringId } = useParams();
   const navigate = useNavigate();
   const { cart, products, vendors, error, loading, initializeToOffering } = useOffering();
+  const { setErrorToast } = useErrorToast();
 
   React.useEffect(() => {
     initializeToOffering(offeringId);
@@ -44,8 +47,7 @@ export default function FoodCart() {
       .then(api.pickData)
       .then((d) => navigate(`/checkout/${d.id}`, { state: { checkout: d } }))
       .catch((e) => {
-        // TODO: Add error toast
-        console.error(e);
+        setErrorToast(extractErrorCode(e));
       });
   }
   const productsById = Object.fromEntries(products.map((p) => [p.productId, p]));

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -7,7 +7,6 @@ import { md, t } from "../localization";
 import Money from "../shared/react/Money";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import { useBackendGlobals } from "../state/useBackendGlobals";
-import { extractErrorCode } from "../state/useError";
 import { useErrorToast } from "../state/useErrorToast";
 import { useOffering } from "../state/useOffering";
 import { useScreenLoader } from "../state/useScreenLoader";
@@ -30,7 +29,7 @@ import {
 
 export default function FoodCheckout() {
   const { id } = useParams();
-  const { setErrorToast } = useErrorToast();
+  const { showErrorToast } = useErrorToast();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const screenLoader = useScreenLoader();
@@ -83,7 +82,7 @@ export default function FoodCheckout() {
       })
       .catch((e) => {
         screenLoader.turnOff();
-        setErrorToast(extractErrorCode(e));
+        showErrorToast(e, { extract: true });
       });
   }
   return (

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -7,6 +7,8 @@ import { md, t } from "../localization";
 import Money from "../shared/react/Money";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import { useBackendGlobals } from "../state/useBackendGlobals";
+import { extractErrorCode } from "../state/useError";
+import { useErrorToast } from "../state/useErrorToast";
 import { useOffering } from "../state/useOffering";
 import { useScreenLoader } from "../state/useScreenLoader";
 import { LayoutContainer } from "../state/withLayout";
@@ -28,6 +30,7 @@ import {
 
 export default function FoodCheckout() {
   const { id } = useParams();
+  const { setErrorToast } = useErrorToast();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const screenLoader = useScreenLoader();
@@ -80,8 +83,7 @@ export default function FoodCheckout() {
       })
       .catch((e) => {
         screenLoader.turnOff();
-        console.error(e);
-        // TODO: toast error
+        setErrorToast(extractErrorCode(e));
       });
   }
   return (

--- a/webapp/src/state/useErrorToast.js
+++ b/webapp/src/state/useErrorToast.js
@@ -1,33 +1,65 @@
 import { t } from "../localization";
-import { useError } from "./useError";
+import { extractErrorCode } from "./useError";
 import { useGlobalViewState } from "./useGlobalViewState";
-import React from "react";
+import React, { useState } from "react";
 import Toast from "react-bootstrap/Toast";
 import ToastContainer from "react-bootstrap/ToastContainer";
 
 export const ErrorToastContext = React.createContext();
+
+/**
+ * @typedef ErrorToastState
+ * @property {function(*, object=)} showErrorToast Given a string,
+ *   popup an error toast using `t(errors:<value>)`.
+ *   Given a React element, render it as the toast message verbatim.
+ *   Pass showErrorToast(e, {extract: true}) to use `extractErrorCode(e)` as the code.
+ */
+
+/**
+ * @returns {ErrorToastState}
+ */
 export const useErrorToast = () => React.useContext(ErrorToastContext);
+
 export function ErrorToastProvider({ children }) {
-  const [errorToast, setErrorToast] = useError("");
+  const [state, setState] = useState(null);
   const { appNav, topNav } = useGlobalViewState();
   const navsHeight = (topNav?.clientHeight || 0) + (appNav?.clientHeight || 0);
+
+  React.useEffect(() => {
+    const callback = () => {
+      setState(null);
+    };
+    window.addEventListener("popstate", callback);
+    return () => window.removeEventListener("popstate", callback);
+  }, []);
+
+  const showErrorToast = React.useCallback(
+    (e, opts) => {
+      if (opts?.extract) {
+        e = extractErrorCode(e);
+      }
+      setState(React.isValidElement(e) ? e : t("errors:" + e));
+    },
+    [setState]
+  );
+
   return (
-    <ErrorToastContext.Provider value={{ setErrorToast }}>
+    <ErrorToastContext.Provider value={{ showErrorToast }}>
       <ToastContainer
         className="d-flex justify-content-center position-fixed p-2 w-100"
         style={{ zIndex: "1021", top: `${navsHeight}px`, left: 0 }}
       >
         <Toast
-          show={Boolean(errorToast)}
+          show={Boolean(state)}
           autohide={true}
-          onClose={() => setErrorToast("")}
+          onClose={() => setState("")}
           bg="light"
         >
           <Toast.Header className="text-danger">
             <i className="bi bi-exclamation-triangle-fill me-2"></i>
             <strong className="me-auto">{t("common:error")}</strong>
           </Toast.Header>
-          <Toast.Body>{errorToast}</Toast.Body>
+          <Toast.Body>{state}</Toast.Body>
         </Toast>
       </ToastContainer>
       {children}

--- a/webapp/src/state/useErrorToast.js
+++ b/webapp/src/state/useErrorToast.js
@@ -1,0 +1,36 @@
+import { t } from "../localization";
+import { useError } from "./useError";
+import { useGlobalViewState } from "./useGlobalViewState";
+import React from "react";
+import Toast from "react-bootstrap/Toast";
+import ToastContainer from "react-bootstrap/ToastContainer";
+
+export const ErrorToastContext = React.createContext();
+export const useErrorToast = () => React.useContext(ErrorToastContext);
+export function ErrorToastProvider({ children }) {
+  const [errorToast, setErrorToast] = useError("");
+  const { appNav, topNav } = useGlobalViewState();
+  const navsHeight = (topNav?.clientHeight || 0) + (appNav?.clientHeight || 0);
+  return (
+    <ErrorToastContext.Provider value={{ setErrorToast }}>
+      <ToastContainer
+        className="d-flex justify-content-center position-fixed p-2 w-100"
+        style={{ zIndex: "1021", top: `${navsHeight}px`, left: 0 }}
+      >
+        <Toast
+          show={Boolean(errorToast)}
+          autohide={true}
+          onClose={() => setErrorToast("")}
+          bg="light"
+        >
+          <Toast.Header className="text-danger">
+            <i className="bi bi-exclamation-triangle-fill me-2"></i>
+            <strong className="me-auto">{t("common:error")}</strong>
+          </Toast.Header>
+          <Toast.Body>{errorToast}</Toast.Body>
+        </Toast>
+      </ToastContainer>
+      {children}
+    </ErrorToastContext.Provider>
+  );
+}


### PR DESCRIPTION
Fixes #255 
- Create `useErrorToast` context provider for commerce pages (can be used in the future where necessary)
- Use method to display errors when cart modifications/API fails
- Localize & format
- Remove unnecessary "TODO" comments