### PR TITLE
Add max quantity behavior for products

### DIFF
--- a/db/migrations/016_inventory.rb
+++ b/db/migrations/016_inventory.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:commerce_products) do
+      add_column :max_quantity_per_order, :integer, null: true
+      add_constraint(
+        :positive_quantity_per_order,
+        Sequel[max_quantity_per_order: nil] | Sequel.expr { max_quantity_per_order > 0 },
+      )
+      add_column :max_quantity_per_offering, :integer, null: true
+      add_constraint(
+        :positive_quantity_per_offering,
+        Sequel[max_quantity_per_offering: nil] | Sequel.expr { max_quantity_per_offering > 0 },
+      )
+    end
+  end
+end

--- a/lib/suma/commerce/order.rb
+++ b/lib/suma/commerce/order.rb
@@ -12,7 +12,7 @@ class Suma::Commerce::Order < Suma::Postgres::Model(:commerce_orders)
   one_to_many :charges, class: "Suma::Charge", key: :commerce_order_id
 
   state_machine :order_status, initial: :open do
-    state :open
+    state :open, :completed, :canceled
 
     after_transition(&:commit_audit_log)
     after_failure(&:commit_audit_log)

--- a/lib/suma/payment/funding_transaction.rb
+++ b/lib/suma/payment/funding_transaction.rb
@@ -85,7 +85,9 @@ class Suma::Payment::FundingTransaction < Suma::Postgres::Model(:payment_funding
     #   When using a FakeStrategy, pass it in this way.
     # @return [Suma::Payment::FundingTransaction]
     def start_new(payment_account, amount:, instrument: nil, originating_ip: nil, strategy: nil)
-      strategy ||= @fake_strategy
+      if strategy.nil?
+        strategy = @fake_strategy.respond_to?(:call) ? @fake_strategy.call : @fake_strategy
+      end
       self.db.transaction do
         platform_ledger = Suma::Payment.ensure_cash_ledger(Suma::Payment::Account.lookup_platform_account)
         if strategy.nil?

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -250,13 +250,15 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
     suma_org = Suma::Organization.find_or_create(name: "suma")
     offering = Suma::Commerce::Offering.first
     products.each do |ps|
-      product = Suma::Commerce::Product.new
-      product.name = Suma::TranslatedText.create(en: ps[:en], es: ps[:es] || "")
-      product.description_string = "Includes stuffing, mashed potatoes, green beans, " \
-                                   "dinner rolls, gravy, cranberry, and pie for dessert."
-      product.vendor = Suma::Vendor.find_or_create(name: "Sheridan's Market", organization: suma_org)
-      product.our_cost = Money.new(90_00)
-      product.save_changes
+      product = Suma::Commerce::Product.create(
+        name: Suma::TranslatedText.create(en: ps[:en], es: ps[:es] || ""),
+        description_string: "Includes stuffing, mashed potatoes, green beans, " \
+                            "dinner rolls, gravy, cranberry, and pie for dessert.",
+        vendor: Suma::Vendor.find_or_create(name: "Sheridan's Market", organization: suma_org),
+        our_cost: Money.new(90_00),
+        max_quantity_per_order: 1,
+        max_quantity_per_offering: 1,
+      )
       product.add_vendor_service_category(holidays_category)
       bytes = File.binread("spec/data/images/#{ps[:image]}")
       uf = Suma::UploadedFile.create_with_blob(bytes:, content_type: "image/jpeg", filename: ps[:image])

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     let!(:platform_ledger) { Suma::Fixtures::Ledgers.ensure_platform_cash }
 
     around(:each) do |ex|
-      Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.not_ready) do
+      Suma::Payment::FundingTransaction.force_fake(proc { Suma::Payment::FakeStrategy.create.not_ready }) do
         ex.run
       end
     end
@@ -196,6 +196,28 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
           have_attributes(originating_ledger: be === cash_ledger, amount: cost("$40")),
           have_attributes(receiving_ledger: be === cash_ledger, amount: cost("$40")),
         )
+      end
+    end
+
+    describe "inventory constraints" do
+      it "errors if the order quantity exceeds the max quantity per order" do
+        product.update(max_quantity_per_order: 1)
+        expect { checkout.create_order }.to raise_error(described_class::MaxQuantityExceeded)
+      end
+
+      it "errors if the order quantity exceeds the max quantity per offering" do
+        product.update(max_quantity_per_order: 2, max_quantity_per_offering: 2)
+
+        cancel_order = Suma::Fixtures.checkout(cart:, card:).populate_items.create.create_order
+        cancel_order.update(order_status: "canceled")
+
+        cart.add_item(product:, quantity: 2, timestamp: 0)
+        co1 = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+        expect { co1.create_order }.to_not raise_error
+
+        cart.add_item(product:, quantity: 2, timestamp: 0)
+        co2 = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+        expect { co2.create_order }.to raise_error(described_class::MaxQuantityExceeded)
       end
     end
   end

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -55,6 +55,7 @@
     "forbidden": "You are forbidden from accessing these resources.",
     "impossible_phone_number": "That doesn't look like a real phone number.",
     "invalid_credentials": "Sorry, that information is not correct.",
+    "invalid_order_quantity": "Sorry, one or more of the items in your order are unavailable because you have purchased too many already. Please go back to your cart and try again.",
     "invalid_otp": "That token is not valid. Enter it again, or request a new code.",
     "invalid_permissions": "You are not allowed to do that.",
     "network_error": "There was a network error. Connect to the internet and try again.",

--- a/webapp/src/components/FoodCartWidget.js
+++ b/webapp/src/components/FoodCartWidget.js
@@ -40,9 +40,6 @@ export default function FoodCartWidget({ product, size }) {
       .catch((e) => showErrorToast(e, { extract: true }));
   };
 
-  // TODO: once we have basic inventory it should control the max quantity
-  const maxQuantity = 10;
-
   return (
     <ButtonGroup aria-label="add-to-cart" className="shadow">
       {quantity > 0 && (
@@ -69,7 +66,10 @@ export default function FoodCartWidget({ product, size }) {
               {quantity}
             </Dropdown.Toggle>
             <Dropdown.Menu className="food-widget-dropdown-menu" renderOnMount={true}>
-              <DropdownQuantities maxQuantity={maxQuantity} selectedQuantity={quantity} />
+              <DropdownQuantities
+                maxQuantity={product.maxQuantity}
+                selectedQuantity={quantity}
+              />
             </Dropdown.Menu>
           </Dropdown>
         </>
@@ -77,7 +77,7 @@ export default function FoodCartWidget({ product, size }) {
       <Button
         variant="success"
         onClick={() => handleQuantityChange(quantity + 1)}
-        className={clsx(btnClasses, quantity === maxQuantity && "disabled")}
+        className={clsx(btnClasses, quantity === product.maxQuantity && "disabled")}
         title={t("food:add_to_cart")}
       >
         <img src={addIcon} alt={t("food:add_to_cart")} width="32px" />


### PR DESCRIPTION
Fixes https://github.com/lithictech/suma/issues/254

Add new maximums for how much can be ordered
cumulatively for an offering, and individually
for an order.

Error when creating the order if this gets violated.