### PR TITLE
Display item count and quantity in order history details

### DIFF
--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -130,7 +130,7 @@
     "shop": "Shop",
     "subtotal_items_md": "Subtotal ({{totalItems}} items): **{{customerCost, sumaCurrency}}**",
     "terms_of_use_agreement_md": "By clicking &#34;place order&#34; you agree to suma&#39;s [Terms of Use](/terms).",
-    "price_times_quantity_md": "{{price, sumaCurrency}}\n\nx {{quantity}}",
+    "price_times_quantity_md": "{{price, sumaCurrency}} x {{quantity}}",
     "title": "Food",
     "total": "{{total, sumaCurrency}}"
   },

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -130,6 +130,7 @@
     "shop": "Shop",
     "subtotal_items_md": "Subtotal ({{totalItems}} items): **{{customerCost, sumaCurrency}}**",
     "terms_of_use_agreement_md": "By clicking &#34;place order&#34; you agree to suma&#39;s [Terms of Use](/terms).",
+    "price_times_quantity_md": "{{price, sumaCurrency}}\n\nx {{quantity}}",
     "title": "Food",
     "total": "{{total, sumaCurrency}}"
   },

--- a/webapp/src/pages/OrderHistoryDetail.js
+++ b/webapp/src/pages/OrderHistoryDetail.js
@@ -3,7 +3,7 @@ import ErrorScreen from "../components/ErrorScreen";
 import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
 import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
-import { t } from "../localization";
+import { md, t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import Money from "../shared/react/Money";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
@@ -70,8 +70,10 @@ export default function OrderHistoryDetail() {
           />
           <hr className="my-0" />
           <Stack>
-            <Card.Text className="h4">{t("food:items_title")}</Card.Text>
-            {state.items.map(({ name, description, customerPrice }, i) => (
+            <Card.Text className="h4">
+              {t("food:labels:items_count", { itemCount: state.items.length })}
+            </Card.Text>
+            {state.items.map(({ name, description, customerPrice, quantity }, i) => (
               <Stack
                 direction="horizontal"
                 key={i}
@@ -81,7 +83,9 @@ export default function OrderHistoryDetail() {
                   <div className="lead">{name}</div>
                   <div className="text-secondary">{description}</div>
                 </div>
-                <Money className="ms-2 lead">{customerPrice}</Money>
+                <span className="ms-2 lead text-end">
+                  {md("food:price_times_quantity_md", { price: customerPrice, quantity })}
+                </span>
               </Stack>
             ))}
           </Stack>

--- a/webapp/src/pages/OrderHistoryDetail.js
+++ b/webapp/src/pages/OrderHistoryDetail.js
@@ -79,13 +79,16 @@ export default function OrderHistoryDetail() {
                 key={i}
                 className="justify-content-between align-items-start"
               >
-                <div>
+                <Stack gap={1}>
                   <div className="lead">{name}</div>
+                  <div>
+                    {md("food:price_times_quantity_md", {
+                      price: customerPrice,
+                      quantity,
+                    })}
+                  </div>
                   <div className="text-secondary">{description}</div>
-                </div>
-                <span className="ms-2 lead text-end">
-                  {md("food:price_times_quantity_md", { price: customerPrice, quantity })}
-                </span>
+                </Stack>
               </Stack>
             ))}
           </Stack>


### PR DESCRIPTION
Fixes #275 
- display items count and item quantity in the `OrderHistoryDetails` page
- localize