### PR TITLE
Fix image and stream caching

### DIFF
--- a/lib/suma/api/images.rb
+++ b/lib/suma/api/images.rb
@@ -25,6 +25,7 @@ class Suma::API::Images < Suma::API::V1
         optional :q, type: Integer, values: 1..100
       end
       get do
+        use_http_expires_caching 1.year
         if params[:opaque_id] == "missing"
           uf = Suma::UploadedFile::NoImageAvailable.new
         else

--- a/lib/suma/service.rb
+++ b/lib/suma/service.rb
@@ -19,6 +19,7 @@ class Suma::Service < Grape::API
   include Appydays::Configurable
   include Appydays::Loggable
 
+  require "suma/service/grape_patches"
   require "suma/service/auth"
   require "suma/service/middleware"
   require "suma/service/types"

--- a/lib/suma/service/grape_patches.rb
+++ b/lib/suma/service/grape_patches.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Grape::DSL::InsideRoute
+  # Grape #stream sets cache-control explicitly, so stomp it if needed.
+  # I believe it's a bug, and used Rails as inspiration,
+  # which also had a bug: https://github.com/rails/rails/pull/35400
+  alias _original_stream stream
+
+  def stream(value=nil)
+    orig = header["Cache-Control"]
+    r = _original_stream(value)
+    header "Cache-Control", orig unless orig.nil?
+    return r
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/lithictech/suma/issues/286

There was a bug with caching and `stream`.
We also weren't using caching on the images endpoint.