### PR TITLE
Various fixes from demo

### DIFF
--- a/lib/suma/payment/card.rb
+++ b/lib/suma/payment/card.rb
@@ -42,7 +42,7 @@ class Suma::Payment::Card < Suma::Postgres::Model(:payment_cards)
     inst = INSTITUTIONS[self.brand]
     inst ||= Institution.new(
       name: self.brand,
-      logo: DEFAULT_INSTITUTION.logo,
+      logo: DEFAULT_INSTITUTION.logo_src,
       color: DEFAULT_INSTITUTION.color,
     )
     return inst

--- a/spec/suma/payment/bank_account_spec.rb
+++ b/spec/suma/payment/bank_account_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Suma::Payment::BankAccount", :db do
       expect(ba).to have_attributes(
         institution: have_attributes(
           name: "Unknown",
-          logo: "",
+          logo_src: "",
           color: "#000000",
         ),
         name: "Checking",
@@ -59,7 +59,7 @@ RSpec.describe "Suma::Payment::BankAccount", :db do
       expect(ba).to have_attributes(
         institution: have_attributes(
           name: "Chase",
-          logo: "xyz",
+          logo_src: "xyz",
           color: "red",
         ),
         name: "Checking",

--- a/spec/suma/payment/card_spec.rb
+++ b/spec/suma/payment/card_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Suma::Payment::Card", :db do
       expect(Suma::Fixtures.card.visa.create.institution).to have_attributes(
         name: "Visa",
         color: "#1A1F71",
-        logo: end_with("5ErkJggg=="),
+        logo_src: end_with("5ErkJggg=="),
       )
     end
 
@@ -22,7 +22,7 @@ RSpec.describe "Suma::Payment::Card", :db do
       expect(Suma::Fixtures.card.with_stripe({"brand" => "foo"}).create.institution).to have_attributes(
         name: "foo",
         color: "#AAAAAA",
-        logo: end_with("ElFTkSuQmCC"),
+        logo_src: end_with("ElFTkSuQmCC"),
       )
     end
   end

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -33,4 +33,5 @@ start-network: check-version network-code
 network-code:
 	@echo $(LOCAL_NETWORK_ADDR) | node node_modules/.bin/qrcode --small
 	@echo "Go to $(LOCAL_NETWORK_ADDR) on your device or scan the above code, then press Enter."
+	@echo "Reload the browser after the server starts up."
 	@read

--- a/webapp/src/components/FormButtons.js
+++ b/webapp/src/components/FormButtons.js
@@ -1,9 +1,8 @@
 import { t } from "../localization";
 import clsx from "clsx";
 import React from "react";
+import { Stack } from "react-bootstrap";
 import Button from "react-bootstrap/Button";
-import Col from "react-bootstrap/Col";
-import Row from "react-bootstrap/Row";
 
 const FormButtons = React.forwardRef(
   ({ primaryProps, secondaryProps, variant, back, className, style }, ref) => {
@@ -13,30 +12,32 @@ const FormButtons = React.forwardRef(
         onClick: () => window.history.back(),
       };
     }
+    // Each button should be at least 1/3 of the width, leading some nice room to the sides,
+    // or allowing wide button content to grow. We could move this to justify-end in some cases
+    // if it looks nicer.
+    const btnStyle = { minWidth: "33%" };
     variant = variant || "outline-primary";
     return (
-      <div ref={ref} className={clsx("mt-4 mx-4", className)} style={style}>
-        <Row>
-          <Col>
-            {secondaryProps && (
-              <Button
-                variant="outline-secondary"
-                className="w-100 h-100"
-                {...secondaryProps}
-              />
-            )}
-          </Col>
-          <Col>
-            {primaryProps && (
-              <Button
-                variant={variant}
-                className="w-100 h-100"
-                type="submit"
-                {...primaryProps}
-              />
-            )}
-          </Col>
-        </Row>
+      <div ref={ref} className={clsx("mt-4", className)} style={style}>
+        <Stack gap={2} direction="horizontal" className="justify-content-center">
+          {secondaryProps && (
+            <Button
+              variant="outline-secondary"
+              className="h-100"
+              style={btnStyle}
+              {...secondaryProps}
+            />
+          )}
+          {primaryProps && (
+            <Button
+              variant={variant}
+              className="h-100"
+              style={btnStyle}
+              type="submit"
+              {...primaryProps}
+            />
+          )}
+        </Stack>
       </div>
     );
   }

--- a/webapp/src/localization/useI18Next.js
+++ b/webapp/src/localization/useI18Next.js
@@ -72,9 +72,10 @@ export function I18NextProvider({ children }) {
     });
   });
 
-  return (
-    <I18NextContext.Provider value={{ i18nextLoading, language, changeLanguage }}>
-      {children}
-    </I18NextContext.Provider>
+  const value = React.useMemo(
+    () => ({ i18nextLoading, language, changeLanguage }),
+    [changeLanguage, i18nextLoading, language]
   );
+
+  return <I18NextContext.Provider value={value}>{children}</I18NextContext.Provider>;
 }

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -202,11 +202,11 @@ function PaymentLabel({ institution, last4, name }) {
   name = institution.name.toLowerCase() === "unknown" ? name : institution.name;
   return (
     <>
-      {!_.isEmpty(institution.logo) && (
+      {!_.isEmpty(institution.logoSrc) && (
         <img
           className="me-2"
           style={{ width: "28px" }}
-          src={`data://${institution.logo}`}
+          src={`${institution.logoSrc}`}
           alt={institution.name}
         />
       )}

--- a/webapp/src/pages/Funding.js
+++ b/webapp/src/pages/Funding.js
@@ -214,7 +214,7 @@ function CardLine({ card }) {
             <img
               className="me-2"
               width="28px"
-              src={`data://${card.institution.logo}`}
+              src={`${card.institution.logoSrc}`}
               alt={card.institution.name}
             />
             {card.name}

--- a/webapp/src/pages/FundingAddCard.js
+++ b/webapp/src/pages/FundingAddCard.js
@@ -15,27 +15,30 @@ import { useSearchParams } from "react-router-dom";
 export default function FundingAddCard() {
   const [params] = useSearchParams();
   const returnTo = params.get("returnTo");
-  const [submitSuccessful, setSubmitSuccessful] = React.useState(false);
-  const { user, setUser, handleUpdateCurrentMember } = useUser();
+  const [submitSuccessful, setSubmitSuccessful] = React.useState(null);
+  const { handleUpdateCurrentMember } = useUser();
   const screenLoader = useScreenLoader();
   const [error, setError] = useError();
 
-  function handleCardSuccess(stripeToken) {
-    screenLoader.turnOn();
-    setError("");
-    api
-      .createCardStripe({ token: stripeToken })
-      .tap(handleUpdateCurrentMember)
-      .then((r) => {
-        setUser({ ...user, usablePaymentInstruments: r.data.allPaymentInstruments });
-        setSubmitSuccessful({
-          instrumentId: r.data.id,
-          instrumentType: r.data.paymentMethodType,
-        });
-      })
-      .catch((e) => setError(extractErrorCode(e)))
-      .finally(screenLoader.turnOff);
-  }
+  const handleCardSuccess = React.useCallback(
+    (stripeToken) => {
+      screenLoader.turnOn();
+      setError("");
+      api
+        .createCardStripe({ token: stripeToken })
+        .tap(handleUpdateCurrentMember)
+        .then((r) => {
+          setSubmitSuccessful({
+            instrumentId: r.data.id,
+            instrumentType: r.data.paymentMethodType,
+          });
+        })
+        .catch((e) => setError(extractErrorCode(e)))
+        .finally(screenLoader.turnOff);
+    },
+    [handleUpdateCurrentMember, screenLoader, setError]
+  );
+
   return (
     <>
       {!_.isEmpty(submitSuccessful) ? (

--- a/webapp/src/pages/OneTimePassword.js
+++ b/webapp/src/pages/OneTimePassword.js
@@ -105,7 +105,7 @@ const OneTimePassword = () => {
           <div id="otpContainer" className="d-flex justify-content-center mt-4">
             {otp.map((data, index) => (
               <input
-                className="otp-field mb-2"
+                className="otp-field mb-2 p-1"
                 type="text"
                 name="otp"
                 maxLength="1"

--- a/webapp/src/state/useErrorToast.js
+++ b/webapp/src/state/useErrorToast.js
@@ -43,8 +43,10 @@ export function ErrorToastProvider({ children }) {
     [setState]
   );
 
+  const value = React.useMemo(() => ({ showErrorToast }), [showErrorToast]);
+
   return (
-    <ErrorToastContext.Provider value={{ showErrorToast }}>
+    <ErrorToastContext.Provider value={value}>
       <ToastContainer
         className="d-flex justify-content-center position-fixed p-2 w-100"
         style={{ zIndex: "1021", top: `${navsHeight}px`, left: 0 }}

--- a/webapp/src/state/useGlobalViewState.js
+++ b/webapp/src/state/useGlobalViewState.js
@@ -20,7 +20,10 @@ export const useGlobalViewState = () => React.useContext(GlobalViewStateContext)
 export function GlobalViewStateProvider({ children }) {
   const [topNav, setTopNav] = React.useState(null);
   const [appNav, setAppNav] = React.useState(null);
-  const value = { topNav, setTopNav, appNav, setAppNav };
+  const value = React.useMemo(
+    () => ({ topNav, setTopNav, appNav, setAppNav }),
+    [appNav, topNav]
+  );
   return (
     <GlobalViewStateContext.Provider value={value}>
       {children}

--- a/webapp/src/state/useOffering.js
+++ b/webapp/src/state/useOffering.js
@@ -57,21 +57,20 @@ export function OfferingProvider({ children }) {
     [asyncFetch, setCartInner]
   );
 
-  return (
-    <OfferingContext.Provider
-      value={{
-        initializeToOffering,
-        offering,
-        vendors,
-        products,
-        cart,
-        setCart: setCartInner,
-        loading,
-        error,
-        reset,
-      }}
-    >
-      {children}
-    </OfferingContext.Provider>
+  const value = React.useMemo(
+    () => ({
+      initializeToOffering,
+      offering,
+      vendors,
+      products,
+      cart,
+      setCart: setCartInner,
+      loading,
+      error,
+      reset,
+    }),
+    [cart, error, initializeToOffering, loading, offering, products, reset, vendors]
   );
+
+  return <OfferingContext.Provider value={value}>{children}</OfferingContext.Provider>;
 }

--- a/webapp/src/state/useUser.js
+++ b/webapp/src/state/useUser.js
@@ -66,21 +66,20 @@ export function UserProvider({ children }) {
     [setUser]
   );
 
-  return (
-    <UserContext.Provider
-      value={{
-        user,
-        setUser,
-        userLoading,
-        userError,
-        userAuthed: Boolean(user),
-        userUnauthed: !userLoading && !user,
-        handleUpdateCurrentMember,
-      }}
-    >
-      {children}
-    </UserContext.Provider>
+  const value = React.useMemo(
+    () => ({
+      user,
+      setUser,
+      userLoading,
+      userError,
+      userAuthed: Boolean(user),
+      userUnauthed: !userLoading && !user,
+      handleUpdateCurrentMember,
+    }),
+    [handleUpdateCurrentMember, setUser, user, userError, userLoading]
   );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 }
 
 const STORAGE_KEY = "sumauser";

--- a/webapp/tools/networkip.js
+++ b/webapp/tools/networkip.js
@@ -14,8 +14,11 @@ for (const [name, nets] of Object.entries(networkInterfaces())) {
     }
   }
 }
+
+const first = (x) => (x && x.length > 0 ? x[0] : null);
+
 const message =
-  results["en0"] ||
-  results["eth0"] ||
+  first(results["en0"]) ||
+  first(results["eth0"]) ||
   `<could not locate en0 or eth0 in interfaces: ${Object.keys(results)}>`;
 console.log(message);


### PR DESCRIPTION
Fix busted images

We weren't handling data urls consistently,
and added a `data:` prefix to to a data url.
This was handled by Chrome but not on Safari.
Be more precise about how we handle institution
logo urls (they are base64 bytes from Plaid,
but already data urls for the ones we load).

---

Must useMemo in contexts

The `value` was changing, causing massive re-renders.
Have to `useMemo` to avoid them in most cases.

Also clean up some payment instrument handlers in adding a card.
Will clean up the rest as part of
https://github.com/lithictech/suma/issues/312

---

OTP has explicit padding

Was not set, so browser defaults were different

---

Better FormButtons layout

Stacking on smaller screens looked bad

---

Fix networkip output

Fixes #311 and #310 and other issues that have not been reported.

