### PR TITLE
Show non-cash contributions for products

### DIFF
--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -188,6 +188,7 @@ class Suma::API::Commerce < Suma::API::V1
   class CartEntity < BaseEntity
     expose :items, with: CartItemEntity
     expose :customer_cost, with: Suma::Service::Entities::Money
+    expose :noncash_ledger_contribution_amount, with: Suma::Service::Entities::Money
   end
 
   class OfferingEntity < BaseEntity
@@ -206,6 +207,9 @@ class Suma::API::Commerce < Suma::API::V1
 
     expose :max_quantity do |inst, opts|
       opts.fetch(:cart).max_quantity_for(inst)
+    end
+    expose :noncash_ledger_contribution_amount, with: Suma::Service::Entities::Money do |inst, opts|
+      opts.fetch(:cart).product_noncash_ledger_contribution_amount(inst)
     end
 
     expose :is_discounted, &self.delegate_to(:discounted?, safe_with_default: false)

--- a/lib/suma/commerce.rb
+++ b/lib/suma/commerce.rb
@@ -2,3 +2,5 @@
 
 module Suma::Commerce
 end
+
+require "suma/commerce/priced_item"

--- a/lib/suma/commerce/cart_item.rb
+++ b/lib/suma/commerce/cart_item.rb
@@ -4,6 +4,8 @@ require "suma/commerce"
 require "suma/postgres/model"
 
 class Suma::Commerce::CartItem < Suma::Postgres::Model(:commerce_cart_items)
+  include Suma::Commerce::PricedItem
+
   plugin :timestamps
 
   many_to_one :cart, class: "Suma::Commerce::Cart"

--- a/lib/suma/commerce/checkout_item.rb
+++ b/lib/suma/commerce/checkout_item.rb
@@ -4,6 +4,8 @@ require "suma/commerce"
 require "suma/postgres/model"
 
 class Suma::Commerce::CheckoutItem < Suma::Postgres::Model(:commerce_checkout_items)
+  include Suma::Commerce::PricedItem
+
   plugin :timestamps
 
   many_to_one :checkout, class: "Suma::Commerce::Checkout"
@@ -11,10 +13,6 @@ class Suma::Commerce::CheckoutItem < Suma::Postgres::Model(:commerce_checkout_it
   many_to_one :offering_product, class: "Suma::Commerce::OfferingProduct"
   # Point to the cart item, rather than copying the quantity.
   many_to_one :cart_item, class: "Suma::Commerce::CartItem"
-
-  def undiscounted_cost = self.quantity * self.offering_product.undiscounted_price
-  def customer_cost = self.quantity * self.offering_product.customer_price
-  def savings = self.undiscounted_cost - self.customer_cost
 
   def quantity
     return self.immutable_quantity || self.cart_item.quantity

--- a/lib/suma/commerce/priced_item.rb
+++ b/lib/suma/commerce/priced_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Adds some price helpers.
+# Requires :quantity and :offering_product
+module Suma::Commerce::PricedItem
+  def undiscounted_cost = self.quantity * self.offering_product.undiscounted_price
+  def customer_cost = self.quantity * self.offering_product.customer_price
+  def savings = self.undiscounted_cost - self.customer_cost
+end

--- a/lib/suma/payment/ledger.rb
+++ b/lib/suma/payment/ledger.rb
@@ -80,19 +80,31 @@ class Suma::Payment::Ledger < Suma::Postgres::Model(:payment_ledgers)
   # only vendor services with 'organic' assigned could be used.
   #
   # Note that ledgers and services can have multiple service categories.
-  def can_be_used_to_purchase?(has_vnd_svc_categories)
-    match = self.category_used_to_purchase(has_vnd_svc_categories)
+  #
+  # @param has_vnd_svc_categories [Suma::Vendor::HasServiceCategories]
+  # @param exclude [Enumerable<Suma::Vendor::ServiceCategory>]
+  #   Any categories in exclude are removed from consideration on the receiving ledger.
+  #   Ledgers look at 'child' categories when considering if they can be used to purchase,
+  #   and these exclusions apply verbatim, they do NOT apply recursively.
+  #   So if this ledger has category 'x', and category 'x' has a chain x->y->z,
+  #   excluding 'y' would only exclude 'y' and NOT 'z'
+  #   (so a product/service that has category 'z' can be still be purchased by this ledger).
+  #   Using exclude is pretty rare; generally it's only useful to exclude the 'cash' or top-level ledgers
+  #   to figure out how much will be contributed from other ledgers.
+  def can_be_used_to_purchase?(has_vnd_svc_categories, exclude: [])
+    match = self.category_used_to_purchase(has_vnd_svc_categories, exclude:)
     return !match.nil?
   end
 
   # See can_be_used_to_purchase?. Returns the first matching category
   # which qualifies this ledger to pay for the vendor service.
-  # We may need to refind this search algorithm in the future
+  # We may need to refine this search algorithm in the future
   # if we find it doesn't select the right category.
-  def category_used_to_purchase(has_vnd_svc_categories)
+  def category_used_to_purchase(has_vnd_svc_categories, exclude: [])
     service_cat_ids = has_vnd_svc_categories.vendor_service_categories.map(&:id)
+    exclude_ids = exclude.map(&:id)
     return self.vendor_service_categories.find do |c|
-      chain_ids = c.tsort.map(&:id)
+      chain_ids = c.tsort.map(&:id) - exclude_ids
       !(service_cat_ids & chain_ids).empty?
     end
   end

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -291,11 +291,11 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
       name: "Holidays 2022 Promo",
       topic: "suma.payment.account.created",
       active_during_begin: Time.now,
-      active_during_end: Time.parse("2022-12-12T23:00:00-0800"),
+      active_during_end: Time.parse("2022-12-08T23:00:00-0800"),
       klass_name: "Suma::AutomationTrigger::CreateAndSubsidizeLedger",
       parameter: {
         ledger_name: "Holidays2022Promo",
-        contribution_text: {en: "Holidays 2022 Gift", es: "Regalo de Vacaciones 2022"},
+        contribution_text: {en: "Holiday 2022 Subsidy", es: "Subsidio Vacaciones 2022"},
         category_name: "Holiday 2022 Promo",
         amount_cents: 80_00,
         amount_currency: "USD",

--- a/lib/suma/vendor/service_category.rb
+++ b/lib/suma/vendor/service_category.rb
@@ -41,6 +41,16 @@ class Suma::Vendor::ServiceCategory < Suma::Postgres::Model(:vendor_service_cate
     return d
   end
 
+  def hierarchy_up
+    it = self
+    arr = [self]
+    while (parent = it.parent)
+      arr << parent
+      it = parent
+    end
+    return arr
+  end
+
   def full_label
     if (prefix = self.parent&.full_label)
       return "#{prefix} - #{self.name}"

--- a/spec/suma/payment/ledger_spec.rb
+++ b/spec/suma/payment/ledger_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe "Suma::Payment::Ledger", :db do
 
   describe "can_be_used_to_purchase?" do
     it "is true if the service has a category in the ledger category chain" do
-      food = Suma::Fixtures.vendor_service_category.create(name: 'food')
-      grocery = Suma::Fixtures.vendor_service_category.create(name: 'grocery', parent: food)
-      restaurant = Suma::Fixtures.vendor_service_category.create(name: 'restaurant', parent: food)
-      organic = Suma::Fixtures.vendor_service_category.create(name: 'organic', parent: grocery)
-      packaged = Suma::Fixtures.vendor_service_category.create(name: 'packaged', parent: grocery)
+      food = Suma::Fixtures.vendor_service_category.create
+      grocery = Suma::Fixtures.vendor_service_category.create(parent: food)
+      restaurant = Suma::Fixtures.vendor_service_category.create(parent: food)
+      organic = Suma::Fixtures.vendor_service_category.create(parent: grocery)
+      packaged = Suma::Fixtures.vendor_service_category.create(parent: grocery)
 
-      mobility = Suma::Fixtures.vendor_service_category.create(name: 'mobility')
-      scooters = Suma::Fixtures.vendor_service_category.create(name: 'scooter', parent: mobility)
+      mobility = Suma::Fixtures.vendor_service_category.create
+      scooters = Suma::Fixtures.vendor_service_category.create(parent: mobility)
 
       food_ledger = Suma::Fixtures.ledger.with_categories(food).create
       grocery_ledger = Suma::Fixtures.ledger.with_categories(grocery).create
@@ -87,46 +87,7 @@ RSpec.describe "Suma::Payment::Ledger", :db do
       expect(food_ledger.category_used_to_purchase(restaurant_service)).to be === food
       expect(grocery_ledger.category_used_to_purchase(grocery_service)).to be === grocery
       expect(grocery_ledger.category_used_to_purchase(organic_service)).to be === grocery
-    end
-
-    it "can exclude categories from consideration" do
-      cash = Suma::Fixtures.vendor_service_category.create(name: 'cash')
-      food = Suma::Fixtures.vendor_service_category.create(name: 'food', parent: cash)
-      promo = Suma::Fixtures.vendor_service_category.create(name: 'promo', parent: food)
-      promo2 = Suma::Fixtures.vendor_service_category.create(name: 'promo2')
-
-      cash_ledger = Suma::Fixtures.ledger.with_categories(cash).create
-      promo_ledger = Suma::Fixtures.ledger.with_categories(promo).create
-      promo_x2_ledger = Suma::Fixtures.ledger.with_categories(promo, promo2).create
-
-      pcash_only = Suma::Fixtures.product.with_categories(cash).create
-      ppromo_only = Suma::Fixtures.product.with_categories(promo).create
-      pcash_and_promo = Suma::Fixtures.product.with_categories(cash, promo).create
-      pcash_and_promo2 = Suma::Fixtures.product.with_categories(cash, promo2).create
-      ppromo2 = Suma::Fixtures.product.with_categories(promo2).create
-
-      expect(cash_ledger).to be_can_be_used_to_purchase(pcash_only)
-      expect(cash_ledger).to be_can_be_used_to_purchase(pcash_and_promo)
-      expect(cash_ledger).to be_can_be_used_to_purchase(ppromo_only)
-      expect(cash_ledger).to be_can_be_used_to_purchase(pcash_and_promo2)
-      expect(cash_ledger).to_not be_can_be_used_to_purchase(ppromo2)
-
-      expect(cash_ledger).to_not be_can_be_used_to_purchase(pcash_only, exclude: [cash])
-      expect(cash_ledger).to be_can_be_used_to_purchase(pcash_and_promo, exclude: [cash])
-      expect(cash_ledger).to_not be_can_be_used_to_purchase(pcash_and_promo2, exclude: [cash])
-      expect(cash_ledger).to_not be_can_be_used_to_purchase(ppromo2, exclude: [cash])
-
-      expect(promo_ledger).to_not be_can_be_used_to_purchase(pcash_only)
-      expect(promo_ledger).to be_can_be_used_to_purchase(pcash_and_promo)
-      expect(promo_ledger).to be_can_be_used_to_purchase(ppromo_only)
-      expect(promo_ledger).to_not be_can_be_used_to_purchase(pcash_and_promo2)
-      expect(promo_ledger).to_not be_can_be_used_to_purchase(ppromo2)
-
-      expect(promo_ledger).to_not be_can_be_used_to_purchase(pcash_only, exclude: [cash])
-      expect(promo_ledger).to be_can_be_used_to_purchase(pcash_and_promo, exclude: [cash])
-      expect(promo_ledger).to be_can_be_used_to_purchase(ppromo_only, exclude: [cash])
-      expect(promo_ledger).to_not be_can_be_used_to_purchase(pcash_and_promo2, exclude: [cash])
-      expect(promo_ledger).to_not be_can_be_used_to_purchase(ppromo2, exclude: [cash])
+      expect(organic_ledger.category_used_to_purchase(organic_service)).to be === organic
     end
   end
 

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -218,7 +218,7 @@
     "enter_code": "Enter code ",
     "enter_code_sent_to": "Enter the code that we sent to",
     "send_new_code": "Send a new code",
-    "terms": "By creating an account or signing in, you accept and agree to our [Terms of Use](/terms-of-use).",
+    "terms": "By creating an account or signing in, you accept and agree to our [Terms of Use](/terms-of-use) and [Privacy Policy](/privacy-policy).",
     "verify": "Verify",
     "verify_code": "Verify Code"
   },

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -79,7 +79,9 @@
   "food": {
     "add_card": "Add debit/credit card",
     "add_to_cart": "Add to cart",
+    "additional_credit_at_checkout": "-{{amount, sumaCurrency}} credit",
     "available_until": "Until",
+    "cart_available_credit": "Available Credit: **{{amount, sumaCurrency}}**",
     "cart_title": "Shopping Cart",
     "change_quantities": "Change item quantities",
     "charge_to": "Charge to {{instrumentName}}",
@@ -116,6 +118,7 @@
     "no_offerings": "There are no food offerings currently available, please check back later.",
     "no_orders": "You haven’t place any orders yet.",
     "no_products": "There were no products found, this offering might be closed. [Click here to view available offerings](/food '$t(strings:food:title)').",
+    "noncash_ledger_contribution_available": "Eligible for {{amount, sumaCurrency}} of the existing balance in your account. Applied at checkout.",
     "order_button": "Place order",
     "order_date": "Placed {{date}}",
     "order_history_title": "Order History",

--- a/webapp/src/components/FoodCartWidget.js
+++ b/webapp/src/components/FoodCartWidget.js
@@ -77,7 +77,11 @@ export default function FoodCartWidget({ product, size }) {
       <Button
         variant="success"
         onClick={() => handleQuantityChange(quantity + 1)}
-        className={clsx(btnClasses, quantity === product.maxQuantity && "disabled")}
+        className={clsx(
+          btnClasses,
+          quantity === product.maxQuantity && "disabled",
+          "nowrap"
+        )}
         title={t("food:add_to_cart")}
       >
         <img src={addIcon} alt={t("food:add_to_cart")} width="32px" />

--- a/webapp/src/components/FoodPrice.js
+++ b/webapp/src/components/FoodPrice.js
@@ -1,0 +1,31 @@
+import Money from "../shared/react/Money";
+import clsx from "clsx";
+import React from "react";
+import { Stack } from "react-bootstrap";
+
+export default function FoodPrice({
+  customerPrice,
+  isDiscounted,
+  undiscountedPrice,
+  fs,
+  bold,
+  className,
+}) {
+  return (
+    <Stack className={clsx(className)}>
+      <Stack
+        direction="horizontal"
+        className={clsx(bold && `fw-semibold`, fs && `fs-${fs}`)}
+      >
+        <Money className={clsx("me-2", isDiscounted && "text-success")}>
+          {customerPrice}
+        </Money>
+        {isDiscounted && (
+          <strike>
+            <Money>{undiscountedPrice}</Money>
+          </strike>
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/webapp/src/localization/index.js
+++ b/webapp/src/localization/index.js
@@ -59,15 +59,15 @@ export class Lookup {
       });
     }
     const overrides = { a: { component: MdLink } };
-    return <Markdown options={{ overrides }}>{str}</Markdown>;
+    return <Markdown options={{ overrides, ...mdoptions }}>{str}</Markdown>;
   };
 
   md = (key, options = {}) => {
-    return this.mdx(key, { forceInline: true, forceWrapper: true }, options);
+    return this.mdx(key, { forceWrapper: true, wrapper: React.Fragment }, options);
   };
 
   mdp = (key, options = {}) => {
-    return this.mdx(key, {}, options);
+    return this.mdx(key, { forceBlock: true }, options);
   };
 
   t = (key, options = {}) => {

--- a/webapp/src/pages/FoodCart.js
+++ b/webapp/src/pages/FoodCart.js
@@ -1,20 +1,19 @@
 import api from "../api";
 import ErrorScreen from "../components/ErrorScreen";
 import FoodCartWidget from "../components/FoodCartWidget";
+import FoodPrice from "../components/FoodPrice";
 import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
 import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
-import { md, mdp, t } from "../localization";
-import Money from "../shared/react/Money";
+import { md, t } from "../localization";
+import { anyMoney } from "../shared/react/Money";
 import { useErrorToast } from "../state/useErrorToast";
 import { useOffering } from "../state/useOffering";
 import { LayoutContainer } from "../state/withLayout";
-import clsx from "clsx";
 import _ from "lodash";
 import React from "react";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
-import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Stack from "react-bootstrap/Stack";
 import { Link, useNavigate, useParams } from "react-router-dom";
@@ -72,15 +71,24 @@ export default function FoodCart() {
                 />
               );
             })}
-            <Container className="d-flex align-items-end flex-column fs-6">
-              {mdp("food:subtotal_items", {
-                totalItems: cart.items.length,
-                customerCost: cart.customerCost,
-              })}
+            <Stack gap={2} className="align-items-end">
+              <div>
+                {md("food:subtotal_items", {
+                  totalItems: cart.items.length,
+                  customerCost: cart.customerCost,
+                })}
+              </div>
+              {anyMoney(cart.noncashLedgerContributionAmount) && (
+                <div>
+                  {md("food:cart_available_credit", {
+                    amount: cart.noncashLedgerContributionAmount,
+                  })}
+                </div>
+              )}
               <Button onClick={handleCheckout} variant="success">
                 {t("food:continue_to_checkout")}
               </Button>
-            </Container>
+            </Stack>
           </Row>
         )}
       </LayoutContainer>
@@ -107,9 +115,9 @@ function CartItem({ offeringId, product, vendor }) {
           </Link>
           <div>
             <Link to={`/product/${offeringId}-${productId}`}>
-              <h6 className="mb-0">{name}</h6>
+              <h6 className="mb-2">{name}</h6>
             </Link>
-            <p className="text-secondary mb-1 small">
+            <p className="text-secondary mb-2 small">
               {product.isDiscounted
                 ? t("food:from_vendor_with_discount", {
                     vendorName: vendor.name,
@@ -119,16 +127,13 @@ function CartItem({ offeringId, product, vendor }) {
             </p>
             <FoodCartWidget product={product} />
           </div>
-          <p className="ms-auto fs-6">
-            <Money className={clsx("me-2", isDiscounted && "text-success")}>
-              {customerPrice}
-            </Money>
-            {isDiscounted && (
-              <strike>
-                <Money>{undiscountedPrice}</Money>
-              </strike>
-            )}
-          </p>
+          <FoodPrice
+            customerPrice={customerPrice}
+            isDiscounted={isDiscounted}
+            undiscountedPrice={undiscountedPrice}
+            fs={6}
+            bold={false}
+          />
         </Stack>
       </Col>
       <hr className="mb-3 mt-0" />

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -1,5 +1,6 @@
 import api from "../api";
 import ErrorScreen from "../components/ErrorScreen";
+import FoodPrice from "../components/FoodPrice";
 import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
 import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
@@ -294,7 +295,7 @@ function OrderSummary({ checkout, chosenInstrument, onSubmit }) {
             {t("food:charge_to", { instrumentName: chosenInstrument.name })}.
           </p>
         )}
-        <p className="small text-secondary mb-1">{md("food:terms_of_use_agreement")}</p>
+        <p className="small text-secondary mt-2">{md("food:terms_of_use_agreement")}</p>
         <Button
           variant="success"
           className="w-100 mt-2"
@@ -346,16 +347,11 @@ function CheckoutItem({ item }) {
             <small>{t("food:quantity", { quantity: quantity })}</small>
           </div>
         </Stack>
-        <p className="ms-auto fs-6">
-          <Money className={clsx("me-2", product.isDiscounted && "text-success")}>
-            {product.customerPrice}
-          </Money>
-          {product.isDiscounted && (
-            <strike>
-              <Money>{product.undiscountedPrice}</Money>
-            </strike>
-          )}
-        </p>
+        <FoodPrice
+          undiscountedPrice={product.undiscountedPrice}
+          isDiscounted={product.isDiscounted}
+          customerPrice={product.customerPrice}
+        />
       </Stack>
     </Col>
   );

--- a/webapp/src/pages/FoodCheckoutConfirmation.js
+++ b/webapp/src/pages/FoodCheckoutConfirmation.js
@@ -2,7 +2,7 @@ import api from "../api";
 import ErrorScreen from "../components/ErrorScreen";
 import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
-import { md, mdp, t } from "../localization";
+import { mdp, t } from "../localization";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import { LayoutContainer } from "../state/withLayout";
 import React from "react";

--- a/webapp/src/pages/FoodDetails.js
+++ b/webapp/src/pages/FoodDetails.js
@@ -1,12 +1,13 @@
 import ErrorScreen from "../components/ErrorScreen";
 import FoodCartWidget from "../components/FoodCartWidget";
 import FoodNav from "../components/FoodNav";
+import FoodPrice from "../components/FoodPrice";
 import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
 import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
-import { mdp, t } from "../localization";
+import { t } from "../localization";
 import makeTitle from "../modules/makeTitle";
-import Money from "../shared/react/Money";
+import { anyMoney } from "../shared/react/Money";
 import { useOffering } from "../state/useOffering";
 import { LayoutContainer } from "../state/withLayout";
 import clsx from "clsx";
@@ -60,18 +61,9 @@ export default function FoodDetails() {
       />
       <LayoutContainer top>
         <h3 className="mb-2">{product.name}</h3>
-        <Stack direction="horizontal">
+        <Stack direction="horizontal" gap={3}>
           <div>
-            <p className="mb-0 fs-4">
-              <Money className={clsx("me-2", product.isDiscounted && "text-success")}>
-                {product.customerPrice}
-              </Money>
-              {product.isDiscounted && (
-                <strike>
-                  <Money>{product.undiscountedPrice}</Money>
-                </strike>
-              )}
-            </p>
+            <FoodPrice {...product} fs={4} className="mb-2" />
             <p>
               {product.isDiscounted
                 ? t("food:from_vendor_with_discount", {
@@ -80,6 +72,13 @@ export default function FoodDetails() {
                   })
                 : t("food:from_vendor", { vendorName: vendor.name })}
             </p>
+            {anyMoney(product.noncashLedgerContributionAmount) && (
+              <div className={clsx("mt-2")}>
+                {t("food:noncash_ledger_contribution_available", {
+                  amount: product.noncashLedgerContributionAmount,
+                })}
+              </div>
+            )}
           </div>
           <div className="ms-auto">
             <FoodCartWidget product={product} size="lg" />

--- a/webapp/src/pages/FoodList.js
+++ b/webapp/src/pages/FoodList.js
@@ -1,17 +1,17 @@
 import ErrorScreen from "../components/ErrorScreen";
-import FoodCartWidget from "../components/FoodCartWidget";
 import FoodNav from "../components/FoodNav";
+import FoodPrice from "../components/FoodPrice";
 import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
 import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
 import { t, mdp } from "../localization";
 import makeTitle from "../modules/makeTitle";
-import Money from "../shared/react/Money";
+import { anyMoney } from "../shared/react/Money";
 import { useOffering } from "../state/useOffering";
 import { LayoutContainer } from "../state/withLayout";
-import clsx from "clsx";
 import _ from "lodash";
 import React from "react";
+import { Stack } from "react-bootstrap";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import { Helmet } from "react-helmet-async";
@@ -41,22 +41,26 @@ export default function FoodList() {
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <FoodNav
-        offeringId={offeringId}
-        cart={cart}
-        startElement={<h5 className="m-0">{offering.description}</h5>}
-      />
       {offering.image && (
         <SumaImage image={offering.image} w={500} h={140} className="thin-header-image" />
       )}
-      <LayoutContainer className="pt-2">
+      <FoodNav
+        offeringId={offeringId}
+        cart={cart}
+        startElement={
+          <Stack gap={2}>
+            <LinearBreadcrumbs back="/food" noBottom />
+            <h3 className="m-0">{offering.description}</h3>
+          </Stack>
+        }
+      />
+      <LayoutContainer className="pt-4">
         {loading && <PageLoader />}
         {!loading && (
           <>
             {_.isEmpty(products) && mdp("food:no_products")}
             {!_.isEmpty(products) && (
               <Row>
-                <LinearBreadcrumbs back="/food" />
                 {products.map((p) => (
                   <Product key={p.productId} offeringId={offeringId} product={p} />
                 ))}
@@ -70,26 +74,33 @@ export default function FoodList() {
 }
 
 function Product({ product, offeringId }) {
-  const { productId, name, isDiscounted, undiscountedPrice, customerPrice, images } =
-    product;
+  const {
+    productId,
+    name,
+    isDiscounted,
+    undiscountedPrice,
+    customerPrice,
+    images,
+    noncashLedgerContributionAmount,
+  } = product;
   return (
-    <Col xs={6} className="mb-2">
+    <Col xs={6} className="mb-4">
       <div className="position-relative">
         <SumaImage image={images[0]} alt={name} className="w-100" w={225} h={150} />
-        <div className="food-widget-container position-absolute">
-          <FoodCartWidget product={product} />
-        </div>
-        <h6 className="mb-0 mt-2">{name}</h6>
-        <p className="mb-0 fs-5 fw-semibold">
-          <Money className={clsx("me-2", isDiscounted && "text-success")}>
-            {customerPrice}
-          </Money>
-          {isDiscounted && (
-            <strike>
-              <Money>{undiscountedPrice}</Money>
-            </strike>
-          )}
-        </p>
+        <h5 className="mb-2 mt-2">{name}</h5>
+        <FoodPrice
+          fs={5}
+          customerPrice={customerPrice}
+          isDiscounted={isDiscounted}
+          undiscountedPrice={undiscountedPrice}
+        />
+        {anyMoney(noncashLedgerContributionAmount) && (
+          <p className="mb-0">
+            {t("food:additional_credit_at_checkout", {
+              amount: noncashLedgerContributionAmount,
+            })}
+          </p>
+        )}
         <Link to={`/product/${offeringId}-${productId}`} className="stretched-link" />
       </div>
     </Col>

--- a/webapp/src/shared/react/Money.js
+++ b/webapp/src/shared/react/Money.js
@@ -101,3 +101,11 @@ export function addMoney(m1, m2) {
 export function subtractMoney(m1, m2) {
   return mathMoney(m1, m2, (x, y) => x - y);
 }
+
+export function anyMoney(m) {
+  if (!m) {
+    return false;
+  }
+  const cents = m.cents;
+  return cents > 0 || cents < 0;
+}


### PR DESCRIPTION
Fixes https://github.com/lithictech/suma/issues/317

The team was worried that folks would see $180/$90 and get confused
since it should only cost $10.

This adds a method to calculate charge contributions per-product,
or for the whole cart, based on all the existing charge contribution
work done before. We now accept an 'exclude up' which excludes
ledgers from consideration that only can handle categories
we are excluding.

Return this new exclusion data, and show it on the frontend.
The wording may need some tweaking.


![Screen Shot 2022-11-29 at 00 20 09](https://user-images.githubusercontent.com/1643233/204477648-9d248470-cc28-427e-96c3-7570a19dec64.png)
![Screen Shot 2022-11-29 at 00 20 15](https://user-images.githubusercontent.com/1643233/204477660-216b4c95-0f7f-4171-b8a9-864f944ac61a.png)
![Screen Shot 2022-11-29 at 00 20 23](https://user-images.githubusercontent.com/1643233/204477664-cb1acea9-db08-41e9-9ee4-e522ea6c6210.png)

