### PR TITLE
Focus CVC input and fix expiry format

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -13,5 +13,5 @@ PORT=22001
 REDIS_URL=redis://localhost:22007/0
 SERVICE_DEVMODE=true
 SERVICE_ENFORCE_SSL=false
-STRIPE_API_KEY=sk_test_51KlS9cAqRmWQecss6nLE3r4UpbBvlhxn6yP2drmcCBabYI4nBpB1M3yznqIao22YVQYdLWv64Dr7g4iVGP6hp2nL00UArnAbB7
+STRIPE_API_KEY=get-this-from-https://dashboard.stripe.com/test/apikeys
 SUMA_LOG_FORMAT=color

--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_DEV_CARD_DETAILS={"name":"Your Name Here","number":"4242424242424242","expiry":"01/25","cvc":"123"}
+REACT_APP_DEV_CARD_DETAILS={"name":"Your Name Here","number":"4242424242424242","expiry":"01 / 25","cvc":"123"}
 REACT_APP_DEV_BANK_ACCOUNT_DETAILS={"name":"Test Account","routing":"111222333","account":"9123"}

--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -1,2 +1,2 @@
-REACT_APP_DEV_CARD_DETAILS={"name":"Your Name Here","number":"4242424242424242","expiry":"01 / 25","cvc":"123"}
+REACT_APP_DEV_CARD_DETAILS={"name":"Your Name Here","number":"4242424242424242","expiry":"01/25","cvc":"123"}
 REACT_APP_DEV_BANK_ACCOUNT_DETAILS={"name":"Test Account","routing":"111222333","account":"9123"}

--- a/webapp/src/components/AddCreditCard.js
+++ b/webapp/src/components/AddCreditCard.js
@@ -94,8 +94,9 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
 
   const handleExpiryChange = (e) => {
     let { name, value } = e.target;
+    value = paymentLibSafeExpiry(value);
     runSetter(name, setExpiry, value);
-    const digits = _.filter(value, (c) => /\d/.test(c)).length;
+    const digits = keepDigits(value).length;
     if (digits === 4) {
       cvcRef.current.focus();
     }
@@ -184,7 +185,7 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
           style={{ transform: `translateY(${expOffset}px)` }}
         >
           <FormControlGroup
-            inputRef={(r) => r && Payment.formatCardExpiry(r)}
+            // Do NOT use Payment here, it has bugs.
             as={Col}
             required
             type="text"
@@ -253,7 +254,7 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
           <Col>
             <ReactCreditCards
               cvc={cvc}
-              expiry={expiry}
+              expiry={reactCardSafeExpiry(expiry)}
               focused={focus}
               name={name}
               number={number}
@@ -263,4 +264,25 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
       </Form>
     </>
   );
+}
+
+function reactCardSafeExpiry(s) {
+  // It doesn't work with 00 / 00, only 00/00
+  const digits = keepDigits(s);
+  if (digits.length < 2) {
+    return digits;
+  } else if (digits.length === 2) {
+    return digits + "/";
+  } else {
+    return digits.slice(0, 2) + "/" + digits.slice(2);
+  }
+}
+
+function paymentLibSafeExpiry(s) {
+  const digits = keepDigits(s);
+  if (digits.length < 3) {
+    return digits;
+  } else {
+    return digits.slice(0, 2) + " / " + digits.slice(2);
+  }
 }

--- a/webapp/src/components/AddCreditCard.js
+++ b/webapp/src/components/AddCreditCard.js
@@ -214,7 +214,6 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
             as={Col}
             required
             type="text"
-            maxLength="3"
             pattern="\d*"
             inputMode="numeric"
             name="cvc"

--- a/webapp/src/components/AddCreditCard.js
+++ b/webapp/src/components/AddCreditCard.js
@@ -31,6 +31,7 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
   const screenLoader = useScreenLoader();
   const numberRowRef = React.useRef(null);
   const expiryRowRef = React.useRef(null);
+  const cvcRef = React.useRef(null);
   const errorRowRef = React.useRef(null);
   const buttonRowRef = React.useRef(null);
   const cardRowRef = React.useRef(null);
@@ -93,16 +94,10 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
 
   const handleExpiryChange = (e) => {
     let { name, value } = e.target;
-    // Fallback expiry formatter since Payment formatter does not remove whitespace
-    // This caused issues with ReactCreditCard expiry display
-    value = value && name === "expiry" ? value.match(/(\d{1,2})/g).join("/") : value;
     runSetter(name, setExpiry, value);
-
-    // Focus CVC input element
-    const cvcElement = document.getElementsByName("cvc")[0];
-    const expiryMaxLength = 5;
-    if (value.length === expiryMaxLength) {
-      cvcElement.focus();
+    const digits = _.filter(value, (c) => /\d/.test(c)).length;
+    if (digits === 4) {
+      cvcRef.current.focus();
     }
   };
 
@@ -189,17 +184,17 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
           style={{ transform: `translateY(${expOffset}px)` }}
         >
           <FormControlGroup
+            inputRef={(r) => r && Payment.formatCardExpiry(r)}
             as={Col}
             required
             type="text"
-            maxLength="7"
             pattern="\d*"
             inputMode="numeric"
             name="expiry"
             autoComplete="cc-exp"
             autoCorrect="off"
             spellCheck="false"
-            label={"MM/YY"}
+            label={"MM / YY"}
             value={expiry}
             errors={errors}
             register={register}
@@ -210,7 +205,10 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
             onBlur={handleBlur}
           />
           <FormControlGroup
-            inputRef={(r) => r && Payment.formatCardCVC(r)}
+            inputRef={(r) => {
+              cvcRef.current = r;
+              r && Payment.formatCardCVC(r);
+            }}
             as={Col}
             required
             type="text"

--- a/webapp/src/components/AddCreditCard.js
+++ b/webapp/src/components/AddCreditCard.js
@@ -44,9 +44,6 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
 
   const runSetter = React.useCallback(
     (name, set, value) => {
-      // Fallback expiry formatter since Payment formatter does not remove whitespace
-      // This caused issues with ReactCreditCard expiry display
-      value = value && name === "expiry" ? value.match(/(\d{1,2})/g).join("/") : value;
       clearErrors(name);
       setValue(name, value);
       set(value);
@@ -95,11 +92,16 @@ export default function AddCreditCard({ onSuccess, error, setError }) {
   const handleBlur = () => setFocus("");
 
   const handleExpiryChange = (e) => {
-    runSetter(e.target.name, setExpiry, e.target.value);
+    let { name, value } = e.target;
+    // Fallback expiry formatter since Payment formatter does not remove whitespace
+    // This caused issues with ReactCreditCard expiry display
+    value = value && name === "expiry" ? value.match(/(\d{1,2})/g).join("/") : value;
+    runSetter(name, setExpiry, value);
+
     // Focus CVC input element
     const cvcElement = document.getElementsByName("cvc")[0];
     const expiryMaxLength = 5;
-    if (e.target.value.length === expiryMaxLength) {
+    if (value.length === expiryMaxLength) {
       cvcElement.focus();
     }
   };

--- a/webapp/src/components/FormControlGroup.js
+++ b/webapp/src/components/FormControlGroup.js
@@ -83,6 +83,8 @@ export default function FormControlGroup({
       }}
       {...registerRest}
       name={name}
+      maxLength={maxLength}
+      minLength={minLength}
       isInvalid={!!message}
       placeholder={_.isString(label) ? label : null}
       className={inputClass}


### PR DESCRIPTION
Fixes #325 

Add expiry input change handler to:
- Add fallback expiry formatter due to Payment plugin inability to remove whitespace (was causing ReactCreditCard plugin to display date incorrectly)
- Focus CVC input sibling when expiry date is typed

Additionally
- Fix `FormControlGroup.js` - was not applying maxLength and minLength attributes/props to the inputs
- Update React credit card 'expiry' environment variable