### PR TITLE
Set dynamic config at startup

### DIFF
--- a/bin/build-webapp
+++ b/bin/build-webapp
@@ -6,7 +6,4 @@ npm install --production=false
 export PUBLIC_URL="/app/"
 export BUILD_PATH="../build-webapp"
 export NODE_ENV=${RACK_ENV}
-export REACT_APP_API_HOST="/"
-export REACT_APP_SENTRY_DSN=${SENTRY_DSN}
-export REACT_APP_STRIPE_PUBLIC_KEY=${STRIPE_PUBLIC_KEY}
 npm run build

--- a/lib/rack/dynamic_config_writer.rb
+++ b/lib/rack/dynamic_config_writer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rack"
+require "nokogiri"
+
+# Allow dynamic configuration of a SPA.
+# When the app starts up, it should run #emplace.
+# This will 1) copy the index.html to a 'backup' location
+# if it does not exist, 2) replace a placeholder string
+# in the index.html with the given keys and values
+# (use .pick_env_vars to pull everything like 'REACT_APP_'),
+# and write it out to index.html.
+class Rack::DynamicConfigWriter
+  GLOBAL_ASSIGN = "window.rackDynamicConfig"
+  BACKUP_SUFFIX = ".original"
+
+  def initialize(
+    index_html_path,
+    global_assign: GLOBAL_ASSIGN,
+    backup_suffix: BACKUP_SUFFIX
+  )
+    @index_html_path = index_html_path
+    @global_assign = global_assign
+    @index_html_backup = index_html_path + backup_suffix
+  end
+
+  def emplace(keys_and_values)
+    self.prepare
+    json = Yajl::Encoder.encode(keys_and_values)
+    script = "#{@global_assign}=#{json}"
+    File.open(@index_html_backup) do |f|
+      doc = Nokogiri::HTML5(f)
+      doc.at("head").prepend_child("<script>#{script}</script>")
+      File.write(@index_html_path, doc.serialize)
+    end
+  end
+
+  protected def prepare
+    return if File.exist?(@index_html_backup)
+    FileUtils.move(@index_html_path, @index_html_backup)
+  end
+
+  def self.pick_env(regex_or_prefix)
+    return ENV.to_a.select { |(k, _v)| k.start_with?(regex_or_prefix) }.to_h if regex_or_prefix.is_a?(String)
+    return ENV.to_a.select { |(k, _v)| regex_or_prefix.match?(k) }.to_h
+  end
+end

--- a/lib/suma/tasks/frontend.rb
+++ b/lib/suma/tasks/frontend.rb
@@ -9,9 +9,6 @@ class Suma::Tasks::Frontend < Rake::TaskLib
     super()
     namespace :frontend do
       task :build_webapp do
-        release = "sumaweb@"
-        release += Suma::RELEASE.include?("unknown") ? Suma::VERSION : Suma::RELEASE
-        ENV["REACT_APP_RELEASE"] = release
         puts `bin/build-webapp`
       end
     end

--- a/spec/rack/dynamic_config_writer_spec.rb
+++ b/spec/rack/dynamic_config_writer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rack/dynamic_config_writer"
+
+RSpec.describe Rack::DynamicConfigWriter do
+  include_context "uses temp dir"
+
+  let(:index) { (temp_dir_path + "index.html").to_s }
+
+  it "sets the config using default parameters" do
+    File.write(index, "<html><head></head></html>")
+    described_class.new(index).emplace({"x" => "1"})
+    html = "<html><head><script>window.rackDynamicConfig={\"x\":\"1\"}</script></head><body></body></html>"
+    expect(File.read(index)).to eq(html)
+  end
+
+  it "sets the config using passed parameters" do
+    File.write(index, "<html><head>\n<meta />\n\n</head></html>")
+    described_class.new(index, global_assign: "globals.x").emplace({"x" => "1"})
+    expect(File.read(index)).to eq(
+      "<html><head><script>globals.x={\"x\":\"1\"}</script>\n<meta>\n\n</head><body></body></html>",
+    )
+  end
+
+  it "can run multiple times, using new parameters each time" do
+    File.write(index, "<html><head></head></html>")
+    dcw = described_class.new(index, global_assign: "globals.x")
+    dcw.emplace({"x" => "1"})
+    dcw.emplace({"x" => "2"})
+    dcw.emplace({"x" => "3"})
+    expect(File.read(index)).to eq("<html><head><script>globals.x={\"x\":\"3\"}</script></head><body></body></html>")
+  end
+
+  it "handles an empty document" do
+    File.write(index, "")
+    dcw = described_class.new(index, global_assign: "globals.x")
+    dcw.emplace({"x" => "1"})
+    dcw.emplace({"x" => "2"})
+    dcw.emplace({"x" => "3"})
+    expect(File.read(index)).to eq("<html><head><script>globals.x={\"x\":\"3\"}</script></head><body></body></html>")
+  end
+
+  it "handles a document with no head" do
+    File.write(index, "<html><body></body></html>")
+    dcw = described_class.new(index, global_assign: "globals.x")
+    dcw.emplace({"x" => "1"})
+    dcw.emplace({"x" => "2"})
+    dcw.emplace({"x" => "3"})
+    expect(File.read(index)).to eq("<html><head><script>globals.x={\"x\":\"3\"}</script></head><body></body></html>")
+  end
+end

--- a/webapp/src/config.js
+++ b/webapp/src/config.js
@@ -1,10 +1,13 @@
+import { initSentry } from "./shared/sentry";
+
+// sumaDynamicEnv is set by Rack::DynamicConfigWriter
+const env = { ...process.env, ...(window.sumaDynamicEnv || {}) };
+
 // If the API host is configured, use that.
 // If it's '/', assume we mean 'the same server',
 // and use an empty string. Otherwise, fall back to local dev,
 // which is usually a different server to the React dev server.
-import { initSentry } from "./shared/sentry";
-
-let apiHost = process.env.REACT_APP_API_HOST;
+let apiHost = env.REACT_APP_API_HOST;
 if (apiHost === "/") {
   apiHost = "";
 } else if (!apiHost) {
@@ -12,7 +15,7 @@ if (apiHost === "/") {
 }
 
 function parseIfSet(key) {
-  const s = process.env[key];
+  const s = env[key];
   if (!s) {
     return {};
   }
@@ -26,13 +29,13 @@ function parseIfSet(key) {
 
 const config = {
   apiHost: apiHost,
-  chaos: process.env.REACT_APP_CHAOS,
-  debug: process.env.REACT_APP_DEBUG,
-  environment: process.env.NODE_ENV,
-  release: process.env.REACT_APP_RELEASE || "app.mysuma@localdev",
-  sentryDsn: process.env.REACT_APP_SENTRY_DSN,
+  chaos: env.REACT_APP_CHAOS,
+  debug: env.REACT_APP_DEBUG,
+  environment: env.NODE_ENV,
+  release: env.REACT_APP_RELEASE || "app.mysuma@localdev",
+  sentryDsn: env.REACT_APP_SENTRY_DSN,
   stripePublicKey:
-    process.env.REACT_APP_STRIPE_PUBLIC_KEY ||
+    env.REACT_APP_STRIPE_PUBLIC_KEY ||
     "pk_test_51LxdhVLelvCURGkUPdGCTS68je1xL8wWi0faS8hiDHbxxEPhmfcAX7EBDzMFTkb3N1Y0tB5vziqtsifKp6PQ4roM005GI4h8T3",
   devCardDetails: parseIfSet("REACT_APP_DEV_CARD_DETAILS"),
   devBankAccountDetails: parseIfSet("REACT_APP_DEV_BANK_ACCOUNT_DETAILS"),


### PR DESCRIPTION
In #294 and 8aa3ace96a3cafdcd154271d7275c029c6c56f70 changes were made to the build system to allow production configuration. Because config is templated at build time, however, it means we cannot 'promote' a build from one environment to another.

This adds a dynamic configuration writing system
so env vars are written to index.html at server boot, ensuring whatever is being served has the current server config, rather than depending on what we built.

This means we can go back to pipeline promotions in Heroku. Fixes https://github.com/lithictech/suma/issues/349