### PR TITLE
Update webapp leaflet and fix CSS sizing issue

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -22,7 +22,7 @@
         "humps": "^2.0.1",
         "i18next": "^21.6.14",
         "i18next-http-backend": "^1.4.0",
-        "leaflet": "1.7.1",
+        "leaflet": "^1.9.3",
         "leaflet.animatedmarker": "^1.0.0",
         "leaflet.markercluster": "^1.5.3",
         "lodash": "^4.17.21",
@@ -9610,9 +9610,9 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
-      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
     },
     "node_modules/leaflet.animatedmarker": {
       "version": "1.0.0",
@@ -22257,9 +22257,9 @@
       }
     },
     "leaflet": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
-      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
+      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
     },
     "leaflet.animatedmarker": {
       "version": "1.0.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -17,7 +17,7 @@
     "humps": "^2.0.1",
     "i18next": "^21.6.14",
     "i18next-http-backend": "^1.4.0",
-    "leaflet": "1.7.1",
+    "leaflet": "^1.9.3",
     "leaflet.animatedmarker": "^1.0.0",
     "leaflet.markercluster": "^1.5.3",
     "lodash": "^4.17.21",

--- a/webapp/src/assets/styles/mobility.scss
+++ b/webapp/src/assets/styles/mobility.scss
@@ -71,7 +71,7 @@
 }
 
 .mobility-map-icon-img {
-  width: 90%;
+  width: 90%!important;
   top: 50%;
   position: absolute;
   left: 50%;


### PR DESCRIPTION
Fixes #362 (Partly)
- Upgrade `leaflet` to the latest version (1.9.3) and fix icon CSS issue