### PR TITLE
Fix dynamic variable configuration during build time

### DIFF
--- a/adminapp/src/config.js
+++ b/adminapp/src/config.js
@@ -1,5 +1,5 @@
-// sumaDynamicEnv is set by Rack::DynamicConfigWriter
-const env = { ...process.env, ...(window.sumaDynamicEnv || {}) };
+// See webapp config.js for explanation.
+const env = window.sumaDynamicEnv || process.env;
 
 // If the API host is configured, use that.
 // If it's '/', assume we mean 'the same server',

--- a/adminapp/src/shared/bluejay.js
+++ b/adminapp/src/shared/bluejay.js
@@ -1,3 +1,4 @@
+import config from "../config";
 import Promise from "bluebird";
 
 Promise.delayOr = function delayOr(durationMs, otherPromise, options) {
@@ -26,8 +27,8 @@ Promise.prototype.tapTap = function tapTap(f) {
 
 Promise.config({
   cancellation: true,
-  longStackTraces: process.env.REACT_APP_DEBUG,
-  warnings: process.env.REACT_APP_DEBUG,
+  longStackTraces: config.debug,
+  warnings: config.debug,
 });
 
 export default Promise;

--- a/webapp/src/config.js
+++ b/webapp/src/config.js
@@ -1,7 +1,12 @@
 import { initSentry } from "./shared/sentry";
 
-// sumaDynamicEnv is set by Rack::DynamicConfigWriter
-const env = { ...process.env, ...(window.sumaDynamicEnv || {}) };
+// When we are serving from the Ruby backend, only use the config it provides.
+// Otherwise we could accidentally template in values at build time (on staging)
+// and carry them forward to runtime in a different env (on prod).
+// We won't have sumaDynamicEnv set (by Rack::DynamicConfigWriter) when running
+// the development server of React during local dev,
+// or if this app is built and deployed separately as a static app.
+const env = window.sumaDynamicEnv || process.env;
 
 // If the API host is configured, use that.
 // If it's '/', assume we mean 'the same server',

--- a/webapp/src/shared/bluejay.js
+++ b/webapp/src/shared/bluejay.js
@@ -1,3 +1,4 @@
+import config from "../config";
 import Promise from "bluebird";
 
 Promise.delayOr = function delayOr(durationMs, otherPromise, options) {
@@ -26,8 +27,8 @@ Promise.prototype.tapTap = function tapTap(f) {
 
 Promise.config({
   cancellation: true,
-  longStackTraces: process.env.REACT_APP_DEBUG,
-  warnings: process.env.REACT_APP_DEBUG,
+  longStackTraces: config.debug,
+  warnings: config.debug,
 });
 
 export default Promise;


### PR DESCRIPTION
Prevents accidental template in values at build time (on staging) and carry them forward to runtime in a different env (on prod). We either use `process.env` (used to set vars by React) or `window.sumaDynamicEnv` when available in build time so that variables aren't overwritten.