### PR TITLE
Fixed pattern regex for frontapp async upsert

### DIFF
--- a/lib/suma/async/upsert_frontapp_contact.rb
+++ b/lib/suma/async/upsert_frontapp_contact.rb
@@ -5,7 +5,7 @@ require "amigo/job"
 class Suma::Async::UpsertFrontappContact
   extend Amigo::Job
 
-  on(/suma\.member\.+(created|updated)$/)
+  on(/suma\.member+(\.created|\.updated)$/)
 
   def _perform(event)
     member = self.lookup_model(Suma::Member, event)

--- a/lib/suma/async/upsert_frontapp_contact.rb
+++ b/lib/suma/async/upsert_frontapp_contact.rb
@@ -5,7 +5,7 @@ require "amigo/job"
 class Suma::Async::UpsertFrontappContact
   extend Amigo::Job
 
-  on(/suma\.member+(\.created|\.updated)$/)
+  on(/^suma\.member\.(created|updated)$/)
 
   def _perform(event)
     member = self.lookup_model(Suma::Member, event)


### PR DESCRIPTION
Lingering bug happening in Frontapp upsert async func where the pattern was still matching sub-resources e.g. suma.member.session.created. We want it to match suma.member.('created' or 'updated').

This was fixed by changing to the appropriate regex pattern.