### PR TITLE
Improve site security in headers

### DIFF
--- a/lib/suma/api/me.rb
+++ b/lib/suma/api/me.rb
@@ -16,6 +16,10 @@ class Suma::API::Me < Suma::API::V1
         # Add this as a way to backfill sessions for users that last authed before we had them.
         member.add_session(**Suma::Member::Session.params_for_request(request))
       end
+      # Expect JS to store this response, rather than the browser.
+      # If the browser stores it, we can end up requesting stale auth info
+      # out of the local cache even once we're signed out.
+      header "Cache-Control", "no-store"
       present member, with: CurrentMemberEntity, env:
     end
 

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -88,6 +88,8 @@ module Suma::Service::Helpers
 
     # Rack sends a cookie with an empty session, but let's tell the browser to actually delete the cookie.
     cookies.delete(Suma::Service::SESSION_COOKIE, domain: options[:domain], path: options[:path])
+    # Set this header to tell the client to delete everything.
+    header "Clear-Site-Data", "*"
   end
 
   def set_member(member)

--- a/spec/suma/api/auth_spec.rb
+++ b/spec/suma/api/auth_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe Suma::API::Auth, :db do
 
       expect(last_response).to have_status(204)
       expect(last_response["Set-Cookie"]).to include("=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00")
+      expect(last_response["Clear-Site-Data"]).to eq("*")
     end
   end
 end

--- a/spec/suma/api/me_spec.rb
+++ b/spec/suma/api/me_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Suma::API::Me, :db do
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.
         that_includes(email: member.email, ongoing_trip: nil)
+      expect(last_response.headers).to include("Cache-Control" => "no-store")
     end
 
     it "errors if the member is soft deleted" do


### PR DESCRIPTION
- Use `Clear-Site-Data: *` when logging out
- Use `Cache-Control: no-store` hitting `/v1/me`, so we never end up re-using a response from the browser cache.

Fixes https://github.com/lithictech/suma/issues/389, except for the 'Vary' header, which would have required big changes (to pass in the suma member id to all API methods).