### PR TITLE
Add CSV exporter to members list, fix referrals

### DIFF
--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -88,4 +88,18 @@ export default {
   searchPaymentInstruments: (data) =>
     get(`/adminapi/v1/search/payment_instruments`, data),
   searchLedgers: (data) => get(`/adminapi/v1/search/ledgers`, data),
+
+  /**
+   * Return an API url.
+   * @param tail {string}
+   * @param params {object}
+   * @return {URL}
+   */
+  makeUrl: (tail, params) => {
+    const u = new URL(config.apiHost + tail);
+    Object.entries(params).forEach(
+      ([k, v]) => v !== null && v !== undefined && u.searchParams.set(k, "" + v)
+    );
+    return u;
+  },
 };

--- a/adminapp/src/components/ResourceTable.js
+++ b/adminapp/src/components/ResourceTable.js
@@ -1,3 +1,4 @@
+import DownloadIcon from "@mui/icons-material/Download";
 import {
   CircularProgress,
   Paper,
@@ -14,6 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
 import { makeStyles } from "@mui/styles";
 import { visuallyHidden } from "@mui/utils";
 import React from "react";
@@ -31,6 +33,7 @@ import React from "react";
  * @param title
  * @param tableProps
  * @param disableSearch
+ * @param downloadUrl
  * @param {Array<{label: string, id: string, align: any, sortable: boolean, render: function}>} columns
  */
 export default function ResourceTable({
@@ -46,6 +49,7 @@ export default function ResourceTable({
   columns,
   tableProps,
   disableSearch,
+  downloadUrl,
 }) {
   const classes = useStyles();
   function handleSearchKeyDown(e) {
@@ -133,15 +137,22 @@ export default function ResourceTable({
         </Table>
       </TableContainer>
       {!listLoading && (
-        <TablePagination
-          component="div"
-          count={listResponse.totalCount || 0}
-          page={page}
-          onPageChange={(_e, page) => onParamsChange({ page })}
-          rowsPerPage={perPage}
-          onRowsPerPageChange={(e) => onParamsChange({ perPage: e.target.value })}
-          rowsPerPageOptions={[20, 50, 100]}
-        />
+        <div className={classes.pageControls}>
+          {downloadUrl && (
+            <IconButton href={downloadUrl}>
+              <DownloadIcon />
+            </IconButton>
+          )}
+          <TablePagination
+            component="div"
+            count={listResponse.totalCount || 0}
+            page={page}
+            onPageChange={(_e, page) => onParamsChange({ page })}
+            rowsPerPage={perPage}
+            onRowsPerPageChange={(e) => onParamsChange({ perPage: e.target.value })}
+            rowsPerPageOptions={[20, 50, 100]}
+          />
+        </div>
       )}
     </>
   );
@@ -164,5 +175,10 @@ const useStyles = makeStyles(() => ({
     "&:first-child": {
       paddingLeft: 0,
     },
+  },
+  pageControls: {
+    alignItems: "center",
+    display: "flex",
+    justifyContent: "flex-end",
   },
 }));

--- a/adminapp/src/pages/MemberListPage.js
+++ b/adminapp/src/pages/MemberListPage.js
@@ -37,6 +37,12 @@ export default function MemberListPage() {
       listResponse={listResponse}
       listLoading={listLoading}
       tableProps={{ sx: { minWidth: 650 }, size: "small" }}
+      downloadUrl={api.makeUrl("/adminapi/v1/members", {
+        order,
+        orderBy,
+        search,
+        download: "csv",
+      })}
       onParamsChange={setListQueryParams}
       columns={[
         {

--- a/db/migrations/022_unique_referrals.rb
+++ b/db/migrations/022_unique_referrals.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:member_referral) do
+      drop_index :member_id
+    end
+
+    rename_table(:member_referral, :member_referrals)
+
+    alter_table(:member_referrals) do
+      add_index :member_id, unique: true
+    end
+  end
+
+  down do
+    alter_table(:member_referrals) do
+      drop_index :member_id
+    end
+
+    rename_table(:member_referrals, :member_referral)
+
+    alter_table(:member_referral) do
+      add_index :member_id
+    end
+  end
+end

--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -108,8 +108,11 @@ class Suma::API::Auth < Suma::API::V1
             timezone: params[:timezone],
           )
           save_or_error!(member)
-          Suma::Member::Referral.create(member_id: member.id, channel: params[:channel],
-                                        event_name: params[:event_name] || "",)
+          Suma::Member::Referral.create(
+            member:,
+            channel: params[:channel],
+            event_name: params[:event_name] || "",
+          )
           member.add_activity(
             message_name: "registered",
             summary: "Created from referral API",

--- a/lib/suma/fixtures/referrals.rb
+++ b/lib/suma/fixtures/referrals.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "suma/fixtures"
+
+module Suma::Fixtures::Referrals
+  extend Suma::Fixtures
+
+  fixtured_class Suma::Member::Referral
+
+  base :referral do
+    self.channel ||= Faker::Lorem.word
+    self.event_name ||= ["", Faker::Lorem.word].sample
+  end
+
+  before_saving do |instance|
+    instance.member ||= Suma::Fixtures.member.create
+    instance
+  end
+end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -78,6 +78,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
                     order: Sequel.desc(:created_at),
                     read_only: true
   one_to_one :payment_account, class: "Suma::Payment::Account"
+  one_to_one :referral, class: "Suma::Member::Referral"
   one_to_many :reset_codes, class: "Suma::Member::ResetCode", order: Sequel.desc([:created_at])
   many_to_many :roles, class: "Suma::Role", join_table: :roles_members
   one_to_many :sessions, class: "Suma::Member::Session", order: Sequel.desc([:created_at, :id])
@@ -301,6 +302,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
   end
 end
 
+require "suma/member/exporter"
 require "suma/member/frontapp_attributes"
 require "suma/member/stripe_attributes"
 

--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Suma::Member::Exporter
+  def initialize(dataset)
+    @dataset = dataset
+  end
+
+  HEADERS = [
+    ["Id", ->(m) { m.id }],
+    ["Name", ->(m) { m.name }],
+    ["Lang", ->(m) { m.message_preferences&.preferred_language }],
+    ["Channel", ->(m) { m.referral&.channel }],
+    ["Event", ->(m) { m.referral&.event_name }],
+    ["Phone", ->(m) { Suma::PhoneNumber::US.format(m.phone) }],
+    ["IntlPhone", ->(m) { m.phone }],
+    ["Email", ->(m) { m.email }],
+    ["Address1", ->(m) { m.legal_entity.address&.address1 }],
+    ["Address2", ->(m) { m.legal_entity.address&.address2 }],
+    ["City", ->(m) { m.legal_entity.address&.city }],
+    ["State", ->(m) { m.legal_entity.address&.state_or_province }],
+    ["Zip", ->(m) { m.legal_entity.address&.postal_code }],
+    ["Country", ->(m) { m.legal_entity.address&.country }],
+    ["Verified", ->(m) { m.onboarding_verified_at ? true : false }],
+    ["Deleted", ->(m) { m.soft_deleted_at ? true : false }],
+    ["Timezone", ->(m) { m.timezone }],
+  ].freeze
+
+  def to_csv
+    coercers = HEADERS.map(&:second)
+    got = CSV.generate do |csv|
+      csv << HEADERS.map(&:first)
+      @dataset.paged_each do |m|
+        row = coercers.map { |c| c[m] }
+        csv << row
+      end
+    end
+    return got
+  end
+end

--- a/lib/suma/member/referral.rb
+++ b/lib/suma/member/referral.rb
@@ -3,8 +3,8 @@
 require "suma/postgres"
 require "suma/member"
 
-class Suma::Member::Referral < Suma::Postgres::Model(:member_referral)
+class Suma::Member::Referral < Suma::Postgres::Model(:member_referrals)
   plugin :timestamps
 
-  one_to_one :member, class: Suma::Member
+  many_to_one :member, class: Suma::Member
 end

--- a/lib/suma/phone_number.rb
+++ b/lib/suma/phone_number.rb
@@ -18,6 +18,11 @@ module Suma::PhoneNumber
     def self.valid_normalized?(s)
       return REGEXP.match?(s)
     end
+
+    def self.format(s)
+      raise ArgumentError, "#{s} must be a normalized to #{REGEXP}" unless self.valid_normalized?(s)
+      return "(#{s[1..3]}) #{s[4..6]}-#{s[7..]}"
+    end
   end
 
   def self.faked_unreachable_phone

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -83,6 +83,18 @@ RSpec.describe Suma::AdminAPI::Members, :db do
         return Suma::Fixtures.member.create(created_at: Time.now + rand(1..100).days, note: i.to_s)
       end
     end
+
+    it "can download as csv" do
+      match = Suma::Fixtures.member(phone: "12223334444").create
+      nomatch = Suma::Fixtures.member(phone: "12225554444").create
+
+      get "/v1/members", search: "22333444", download: "csv"
+
+      expect(last_response).to have_status(200)
+      expect(last_response.body.lines).to have_length(2)
+      expect(last_response.body).to include(match.name)
+      expect(last_response.body).to_not include(nomatch.name)
+    end
   end
 
   describe "GET /v1/members/:id" do

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Suma::Member::Exporter, :db do
+  it "exports to csv" do
+    allfields = Suma::Fixtures.member.create(
+      name: "ABC", phone: "12223334444", email: "a@b.c", onboarding_verified_at: Time.now,
+    )
+    Suma::Fixtures.referral.create(member: allfields, event_name: "ev", channel: "chan")
+    address = Suma::Fixtures.address.create(
+      address1: "123 Main", address2: "", city: "Portland", state_or_province: "Oregon", postal_code: "97214",
+    )
+    allfields.legal_entity.update(address:)
+    allfields.message_preferences!
+
+    plain = Suma::Fixtures.member.create(name: "XYZ", phone: "12223339999", email: "x@y.z", soft_deleted_at: Time.at(5))
+
+    csv = described_class.new(Suma::Member.dataset).to_csv
+    lines = <<~LINES
+      Id,Name,Lang,Channel,Event,Phone,IntlPhone,Email,Address1,Address2,City,State,Zip,Country,Verified,Deleted,Timezone
+      #{allfields.id},ABC,en,chan,ev,(222) 333-4444,12223334444,a@b.c,123 Main,"",Portland,Oregon,97214,US,true,false,America/Los_Angeles
+      #{plain.id},XYZ,,,,(222) 333-9999,12223339999,x@y.z,,,,,,,false,true,America/Los_Angeles
+    LINES
+    expect(csv).to eq(lines)
+  end
+end

--- a/spec/suma/phone_number_spec.rb
+++ b/spec/suma/phone_number_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Suma::PhoneNumber do
+  describe Suma::PhoneNumber::US do
+    it "can format a normalized number as US" do
+      expect(described_class.format("13334445555")).to eq("(333) 444-5555")
+    end
+
+    it "errors if the number is not normalized" do
+      expect { described_class.format("3334445555") }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
The `/admin/v1/members` endpoint takes a `download` param to allow it to download.

Adds an optional `downloadUrl` to admin `ResourceTable` which adds a download icon.

Fix some bugs with referral relations
(unique index required; fix associations)