### PR TITLE
Fix dayjs language configuration bug

### DIFF
--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -1,5 +1,5 @@
 import config from "./config";
-import { getCurrentLanguage } from "./localization/useI18Next";
+import { getCurrentLanguage } from "./localization/currentLanguage";
 import apiBase from "./shared/apiBase";
 
 const instance = apiBase.create(config.apiHost, {

--- a/webapp/src/localization/currentLanguage.js
+++ b/webapp/src/localization/currentLanguage.js
@@ -1,0 +1,17 @@
+import { localStorageCache } from "../shared/localStorageHelper";
+import useLocalStorageState from "../shared/react/useLocalStorageState";
+
+let cachedLanguage = localStorageCache.getItem("language", "en");
+
+export function getCurrentLanguage() {
+  return cachedLanguage;
+}
+
+export function setCurrentLanguage(value) {
+  cachedLanguage = value;
+}
+
+export function useCurrentLanguage() {
+  const [language, setLanguage] = useLocalStorageState("language", "en");
+  return [language, setLanguage];
+}

--- a/webapp/src/localization/currentLanguage.js
+++ b/webapp/src/localization/currentLanguage.js
@@ -1,8 +1,13 @@
 import { localStorageCache } from "../shared/localStorageHelper";
 import useLocalStorageState from "../shared/react/useLocalStorageState";
+import React from "react";
 
 let cachedLanguage = localStorageCache.getItem("language", "en");
 
+/**
+ * Return the current language. Use only when outside of React;
+ * inside of React use the useCurrentLanguage hook.
+ */
 export function getCurrentLanguage() {
   return cachedLanguage;
 }
@@ -12,6 +17,13 @@ export function setCurrentLanguage(value) {
 }
 
 export function useCurrentLanguage() {
-  const [language, setLanguage] = useLocalStorageState("language", "en");
+  const [language, setLanguageInner] = useLocalStorageState("language", cachedLanguage);
+  const setLanguage = React.useCallback(
+    (value) => {
+      cachedLanguage = value;
+      setLanguageInner(value);
+    },
+    [setLanguageInner]
+  );
   return [language, setLanguage];
 }

--- a/webapp/src/localization/useI18Next.js
+++ b/webapp/src/localization/useI18Next.js
@@ -1,12 +1,11 @@
 import api from "../api";
 import { dayjs } from "../modules/dayConfig";
 import doOnce from "../shared/doOnce";
-import { localStorageCache } from "../shared/localStorageHelper";
 import { Logger } from "../shared/logger";
 import { formatMoney } from "../shared/react/Money";
-import useLocalStorageState from "../shared/react/useLocalStorageState";
 import useMountEffect from "../shared/react/useMountEffect";
 import { useUser } from "../state/useUser";
+import { setCurrentLanguage, useCurrentLanguage } from "./currentLanguage";
 import i18n from "i18next";
 import Backend from "i18next-http-backend";
 import noop from "lodash/noop";
@@ -19,15 +18,9 @@ export const I18NextContext = React.createContext();
 export const useI18Next = () => React.useContext(I18NextContext);
 export default useI18Next;
 
-let memoryCache = localStorageCache.getItem("language", "en");
-
-export function getCurrentLanguage() {
-  return memoryCache;
-}
-
 export function I18NextProvider({ children }) {
   const [i18nextLoading, setI18NextLoading] = React.useState(true);
-  const [language, setLanguage] = useLocalStorageState("language", "en");
+  const [language, setLanguage] = useCurrentLanguage();
   const { userAuthed } = useUser();
 
   const changeLanguage = React.useCallback(
@@ -43,7 +36,7 @@ export function I18NextProvider({ children }) {
         i18n.changeLanguage(lang).then(() => {
           setLanguage(lang);
           dayjs.locale(lang);
-          memoryCache = lang;
+          setCurrentLanguage(lang);
         })
       ).then(() => {
         setI18NextLoading(false);

--- a/webapp/src/modules/dayConfig.js
+++ b/webapp/src/modules/dayConfig.js
@@ -1,7 +1,7 @@
 // This module allows extension of plugins with dayjs globally,
 // preventing the redundancy of extending any plugin in different
 // pages, uncomment any plugin you wish to extend/utilize
-import { getCurrentLanguage } from "../localization/useI18Next";
+import { getCurrentLanguage } from "../localization/currentLanguage";
 import dayjs from "dayjs";
 // import advancedFormat from 'dayjs/plugin/advancedFormat';
 // import customParseFormat from 'dayjs/plugin/customParseFormat';


### PR DESCRIPTION
Configured module `dayjs` had a lingering bug where daysjs was not setting the current app language due to an uninitialized language variable.
- also eliminates a circular dependency between `dayConfig` and `useI18Next`