### PR TITLE
Fix contact list language buttons

### DIFF
--- a/webapp/src/pages/ContactListHome.js
+++ b/webapp/src/pages/ContactListHome.js
@@ -6,7 +6,7 @@ import { useBackendGlobals } from "../state/useBackendGlobals";
 import React from "react";
 import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 export default function ContactListHome() {
   const [params] = useSearchParams();
@@ -24,18 +24,25 @@ export default function ContactListHome() {
 }
 
 function LanguageButtons({ eventName }) {
+  const navigate = useNavigate();
   const { supportedLocales } = useBackendGlobals();
   const { changeLanguage } = useI18Next();
   if (!supportedLocales.items) {
     return null;
   }
+  const handleClick = (e, code) => {
+    e.preventDefault();
+    changeLanguage(code);
+    navigate(
+      eventName ? `/contact-list/add?eventName=${eventName}` : "/contact-list/add"
+    );
+  };
   return supportedLocales.items.map(({ code, native }) => (
     <Button
-      href={eventName ? `/contact-list/add?eventName=${eventName}` : "/contact-list/add"}
       key={code}
       variant="outline-secondary"
       className="btn-outline-secondary mt-2 w-75"
-      onClick={() => changeLanguage(code)}
+      onClick={(e) => handleClick(e, code)}
     >
       {native}
     </Button>


### PR DESCRIPTION
Fixes bug happening in `ContactListHome` page where eventName in the URL params is not persistent.

I suspect the reason is because the language buttons have an `onClick` and `href` properties. onClick executes first to change language but does not persist the href properties (eventName) when href is executed.