### PR TITLE
Add `as={RLink}` to `Button` elements with `href`

### DIFF
--- a/webapp/src/pages/ContactListHome.js
+++ b/webapp/src/pages/ContactListHome.js
@@ -1,5 +1,6 @@
 import sumaLogo from "../assets/images/suma-logo-word-512.png";
 import ContactListTags from "../components/ContactListTags";
+import RLink from "../components/RLink";
 import { t } from "../localization";
 import useI18Next from "../localization/useI18Next";
 import { useBackendGlobals } from "../state/useBackendGlobals";
@@ -31,10 +32,11 @@ function LanguageButtons({ eventName }) {
   }
   return supportedLocales.items.map(({ code, native }) => (
     <Button
-      href={eventName ? `/contact-list/add?eventName=${eventName}` : "/contact-list/add"}
       key={code}
-      variant="outline-secondary"
+      as={RLink}
       className="btn-outline-secondary mt-2 w-75"
+      href={eventName ? `/contact-list/add?eventName=${eventName}` : "/contact-list/add"}
+      variant="outline-secondary"
       onClick={() => changeLanguage(code)}
     >
       {native}

--- a/webapp/src/pages/FoodCheckoutConfirmation.js
+++ b/webapp/src/pages/FoodCheckoutConfirmation.js
@@ -1,6 +1,7 @@
 import api from "../api";
 import ErrorScreen from "../components/ErrorScreen";
 import PageLoader from "../components/PageLoader";
+import RLink from "../components/RLink";
 import SumaImage from "../components/SumaImage";
 import { mdp, t } from "../localization";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
@@ -58,7 +59,7 @@ export default function FoodCheckoutConfirmation() {
         <hr />
         {mdp("food:confirmation_message", { check: false })}
         <Stack className="mt-2">
-          <Button variant="outline-success" href="/dashboard">
+          <Button variant="outline-success" href="/dashboard" as={RLink}>
             {t("common:go_home")}
           </Button>
         </Stack>

--- a/webapp/src/pages/OnboardingFinish.js
+++ b/webapp/src/pages/OnboardingFinish.js
@@ -1,3 +1,4 @@
+import RLink from "../components/RLink";
 import { mdp, t } from "../localization";
 import { useUser } from "../state/useUser";
 import React from "react";
@@ -13,7 +14,7 @@ export default function OnboardingFinish() {
         mdp("onboarding:finish")
       )}
       <div className="button-stack">
-        <Button href="/dashboard" variant="outline-primary" className="mt-3">
+        <Button href="/dashboard" variant="outline-primary" className="mt-3" as={RLink}>
           {t("common:okay_ex")}
         </Button>
       </div>


### PR DESCRIPTION
These were causing a full browser navigation;
instead we should use `RLink` which will use react-router links with a `to` as the `href` value.