### PR TITLE
Ability to automatically onboard members

### DIFF
--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -61,8 +61,10 @@ class Suma::API::Auth < Suma::API::V1
       begin
         Suma::Member::ResetCode::Unusable if me.nil?
         if Suma::Member.matches_allowlist?(me, Suma::Member.superadmin_allowlist)
-          me.update(onboarding_verified_at: Time.now)
+          me.update(onboarding_verified_at: Time.now) unless me.onboarding_verified?
           me.ensure_role(Suma::Role.admin_role)
+        elsif Suma::Member.matches_allowlist?(me, Suma::Member.onboard_allowlist)
+          me.update(onboarding_verified_at: Time.now) unless me.onboarding_verified?
         elsif Suma::Member.matches_allowlist?(me, Suma::Member.skip_verification_allowlist)
           nil
         else

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -19,6 +19,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
   class ReadOnlyMode < RuntimeError; end
 
   configurable(:member) do
+    setting :onboard_allowlist, [], convert: ->(s) { s.split }
     setting :skip_verification_allowlist, [], convert: ->(s) { s.split }
     setting :superadmin_allowlist, [], convert: ->(s) { s.split }
   end

--- a/spec/suma/api/auth_spec.rb
+++ b/spec/suma/api/auth_spec.rb
@@ -146,6 +146,20 @@ RSpec.describe Suma::API::Auth, :db do
       expect(last_response).to have_session_cookie.with_payload_key("warden.user.member.key")
     end
 
+    it "returns a 200 and onboards user if configured" do
+      c = Suma::Fixtures.member.create
+      Suma::Member.onboard_allowlist = ["*"]
+
+      post("/v1/auth/verify", phone: c.phone, token: "abc")
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_session_cookie.with_payload_key("warden.user.member.key")
+      expect(c.refresh).to have_attributes(
+        onboarding_verified?: true,
+        roles: [],
+      )
+    end
+
     it "returns a 200 and handles superadmin promotion configured" do
       c = Suma::Fixtures.member.create
       Suma::Member.superadmin_allowlist = ["*"]


### PR DESCRIPTION
Add new MEMBER_ONBOARD_ALLOWLIST to automatically
auth users (like SKIP_VERIFICATION_ALLOWLIST)
and mark them onboarded.

Needed for more testing on staging.