### PR TITLE
Fix stale language on useOffering

### DIFF
--- a/db/migrations/024_fulfillment_prompt.rb
+++ b/db/migrations/024_fulfillment_prompt.rb
@@ -6,18 +6,20 @@ Sequel.migration do
       add_foreign_key :fulfillment_prompt_id, :translated_texts, null: true
       add_foreign_key :fulfillment_confirmation_id, :translated_texts, null: true
     end
-    prompt_id = from(:translated_texts).insert(
-      en: "How do you want to get your stuff?",
-      es: "¿Cómo desea obtener sus cosas?",
-    )
-    confirm_id = from(:translated_texts).insert(
-      en: "How you’re getting it",
-      es: "Cómo lo está recibiendo",
-    )
-    from(:commerce_offerings).update(
-      fulfillment_prompt_id: prompt_id,
-      fulfillment_confirmation_id: confirm_id,
-    )
+    if ENV["RACK_ENV"] != "test"
+      prompt_id = from(:translated_texts).insert(
+        en: "How do you want to get your stuff?",
+        es: "¿Cómo desea obtener sus cosas?",
+      )
+      confirm_id = from(:translated_texts).insert(
+        en: "How you’re getting it",
+        es: "Cómo lo está recibiendo",
+      )
+      from(:commerce_offerings).update(
+        fulfillment_prompt_id: prompt_id,
+        fulfillment_confirmation_id: confirm_id,
+      )
+    end
     alter_table(:commerce_offerings) do
       set_column_not_null :fulfillment_prompt_id
       set_column_not_null :fulfillment_confirmation_id

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -64,11 +64,13 @@ export default function App() {
           <UserProvider>
             <I18NextProvider>
               <ScreenLoaderProvider>
-                <HelmetProvider>
-                  <OfferingProvider>
-                    <InnerApp />
-                  </OfferingProvider>
-                </HelmetProvider>
+                <RerenderOnLangChange>
+                  <HelmetProvider>
+                    <OfferingProvider>
+                      <InnerApp />
+                    </OfferingProvider>
+                  </HelmetProvider>
+                </RerenderOnLangChange>
               </ScreenLoaderProvider>
             </I18NextProvider>
           </UserProvider>
@@ -76,6 +78,23 @@ export default function App() {
       </ErrorToastProvider>
     </GlobalViewStateProvider>
   );
+}
+
+/**
+ * Language choice has implicit state dependencies,
+ * since API calls are done in the user's current language.
+ * To avoid having a web of state modifications, we can just rebuild the DOM
+ * and make all new API requests when language changes.
+ *
+ * This is really only needed for cross-screen API call state, like useOffering.
+ * Components in the UI itself usually end up being redraw,
+ * but contexts at a higher level would not be.
+ *
+ * This component must be placed outside of any localized API calls.
+ */
+function RerenderOnLangChange({ children }) {
+  const { language } = useI18Next();
+  return <React.Fragment key={language}>{children}</React.Fragment>;
 }
 
 function InnerApp() {


### PR DESCRIPTION
Fixes #418 

Language choice has implicit state dependencies, since API calls are done in the user's current language. To avoid having a web of state modifications, we can just rebuild the DOMand make all new API requests when language changes.

This is really only needed for cross-screen API call state, like useOffering. Components in the UI itself usually end up being redraw, but contexts at a higher level would not be.