### PR TITLE
Verify members offering eligibility

### DIFF
--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -55,6 +55,8 @@ export default {
   getCurrencies: (data) => get(`/adminapi/v1/meta/currencies`, data),
   getVendorServiceCategories: (data) =>
     get(`/adminapi/v1/meta/vendor_service_categories`, data),
+  getEligibilityConstraints: (data) =>
+    get(`/adminapi/v1/meta/eligibility_constraints`, data),
 
   getBankAccount: ({ id, ...data }) => get(`/adminapi/v1/bank_accounts/${id}`, data),
 
@@ -84,6 +86,8 @@ export default {
 
   getMembers: (data) => get(`/adminapi/v1/members`, data),
   getMember: ({ id, ...data }) => get(`/adminapi/v1/members/${id}`, data),
+  changeMemberEligibility: ({ id, ...data }) =>
+    post(`/adminapi/v1/members/${id}/eligibilities`, data),
 
   searchPaymentInstruments: (data) =>
     get(`/adminapi/v1/search/payment_instruments`, data),

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -86,6 +86,7 @@ export default {
 
   getMembers: (data) => get(`/adminapi/v1/members`, data),
   getMember: ({ id, ...data }) => get(`/adminapi/v1/members/${id}`, data),
+  updateMember: ({ id, ...data }) => post(`/adminapi/v1/members/${id}`, data),
   changeMemberEligibility: ({ id, ...data }) =>
     post(`/adminapi/v1/members/${id}/eligibilities`, data),
 

--- a/adminapp/src/components/InlineEditField.js
+++ b/adminapp/src/components/InlineEditField.js
@@ -1,0 +1,62 @@
+import CancelIcon from "@mui/icons-material/Cancel";
+import EditIcon from "@mui/icons-material/Edit";
+import SaveIcon from "@mui/icons-material/Save";
+import IconButton from "@mui/material/IconButton";
+import React from "react";
+
+/**
+ * Inline editing component that wraps display and edit states.
+ * 'display' rendering gets an Edit icon.
+ * 'edit' rendering gets Save and Cancel icons.
+ *
+ * @param renderDisplay Value to be used when not in editing mode. An Edit icon is added to the right.
+ * @param renderEdit Function to be called with (editingState, setEditingState) when in edit mode.
+ *   This usually renders an Input that calls setEditingState when it changes.
+ * @param initialEditingState Value to use as the initial editing state.
+ *   This is usually an empty object (or one with just an id).
+ * @param onSave Called with the current editing state
+ *   (initialEditingState, then any changes from setEditingState in the renderEdit callback)
+ *   when the save button is pressed.
+ */
+export default function InlineEditField({
+  renderDisplay,
+  renderEdit,
+  initialEditingState,
+  onSave,
+}) {
+  const [editing, setEditing] = React.useState(false);
+  const [editingState, setEditingState] = React.useState(initialEditingState);
+  function startEditing(e) {
+    setEditing(true);
+    setEditingState(initialEditingState);
+  }
+  async function saveChanges(e) {
+    await onSave(editingState);
+    setEditing(false);
+  }
+  function discardChanges(e) {
+    setEditing(false);
+    setEditingState(initialEditingState); // Not strictly needed
+  }
+  if (!editing) {
+    return (
+      <div>
+        {renderDisplay}
+        <IconButton onClick={startEditing}>
+          <EditIcon />
+        </IconButton>
+      </div>
+    );
+  }
+  return (
+    <div>
+      {renderEdit(editingState, setEditingState)}
+      <IconButton onClick={saveChanges}>
+        <SaveIcon />
+      </IconButton>
+      <IconButton onClick={discardChanges}>
+        <CancelIcon />
+      </IconButton>
+    </div>
+  );
+}

--- a/adminapp/src/pages/MemberDetailPage.js
+++ b/adminapp/src/pages/MemberDetailPage.js
@@ -38,9 +38,7 @@ export default function MemberDetailPage() {
   let { id } = useParams();
   id = Number(id);
   const getMember = React.useCallback(() => {
-    return api
-      .getMember({ id })
-      .catch((e) => enqueueErrorSnackbar(e, { variant: "error" }));
+    return api.getMember({ id }).catch((e) => enqueueErrorSnackbar(e));
   }, [id, enqueueErrorSnackbar]);
   const {
     state: member,
@@ -438,13 +436,13 @@ function ImpersonateButton({ id }) {
     api
       .impersonate({ id })
       .then((r) => setUser(r.data))
-      .catch((e) => enqueueErrorSnackbar(e, { variant: "error" }));
+      .catch((e) => enqueueErrorSnackbar(e));
   }
   function handleUnimpersonate() {
     api
       .unimpersonate()
       .then((r) => setUser(r.data))
-      .catch((e) => enqueueErrorSnackbar(e, { variant: "error" }));
+      .catch((e) => enqueueErrorSnackbar(e));
   }
   if (user.impersonating) {
     return (

--- a/db/migrations/025_eligibility.rb
+++ b/db/migrations/025_eligibility.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "sequel/unambiguous_constraint"
+
+Sequel.migration do
+  up do
+    create_table(:eligibility_constraints) do
+      primary_key :id
+      timestamptz :created_at, null: false, default: Sequel.function(:now)
+      timestamptz :updated_at
+
+      text :name, null: false
+    end
+
+    create_table(:eligibility_member_associations) do
+      primary_key :id
+
+      foreign_key :constraint_id, :eligibility_constraints, null: false
+
+      foreign_key :verified_member_id, :members
+      foreign_key :pending_member_id, :members
+      foreign_key :rejected_member_id, :members
+
+      column :effective_member_id, :integer, generated_always_as: Sequel.function(
+        :coalesce,
+        :verified_member_id,
+        :pending_member_id,
+        :rejected_member_id,
+      )
+
+      index [:effective_member_id, :constraint_id],
+            name: :unique_member_idx,
+            unique: true
+
+      constraint(
+        :one_member_set,
+        Sequel.unambiguous_constraint(
+          [
+            :verified_member_id,
+            :pending_member_id,
+            :rejected_member_id,
+          ],
+        ),
+      )
+    end
+
+    create_join_table(
+      {constraint_id: :eligibility_constraints, offering_id: :commerce_offerings},
+      name: :eligibility_offering_associations,
+    )
+
+    run("ALTER TABLE eligibility_member_associations ADD CONSTRAINT unique_member UNIQUE USING INDEX unique_member_idx")
+  end
+end

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -201,4 +201,10 @@ module Suma::AdminAPI::Entities
     expose :checkout_id
     expose :member, with: MemberEntity, &self.delegate_to(:checkout, :cart, :member)
   end
+
+  class EligibilityConstraintEntity < BaseEntity
+    include AutoExposeBase
+    expose :id
+    expose :name
+  end
 end

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -60,6 +60,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
         optional :phone, type: Integer
         optional :timezone, type: String, values: ALL_TIMEZONES
         optional :roles, type: Array[String]
+        optional :onboarding_verified, type: Boolean
       end
       post do
         member = lookup_member!
@@ -171,6 +172,8 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :available_roles do |_|
       Suma::Role.order(:name).select_map(:name)
     end
+    expose :onboarding_verified?, as: :onboarding_verified
+    expose :onboarding_verified_at
 
     expose :legal_entity, with: LegalEntityEntity
     expose :payment_account, with: DetailedPaymentAccountEntity

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -155,6 +155,11 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :offering, with: OfferingEntity, &self.delegate_to(:checkout, :cart, :offering)
   end
 
+  class MemberEligibilityConstraintEntity < BaseEntity
+    expose :status
+    expose :constraint, with: Suma::AdminAPI::Entities::EligibilityConstraintEntity
+  end
+
   class DetailedMemberEntity < MemberEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
@@ -171,7 +176,9 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :payment_account, with: DetailedPaymentAccountEntity
     expose :bank_accounts, with: PaymentInstrumentEntity
     expose :charges, with: ChargeEntity
-    expose :eligibility_constraints, &self.delegate_to(:unified_eligibility_constraints)
+    expose :eligibility_constraints,
+           with: MemberEligibilityConstraintEntity,
+           &self.delegate_to(:eligibility_constraints_with_status)
 
     expose :activities, with: MemberActivityEntity
     expose :reset_codes, with: MemberResetCodeEntity

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -171,7 +171,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :payment_account, with: DetailedPaymentAccountEntity
     expose :bank_accounts, with: PaymentInstrumentEntity
     expose :charges, with: ChargeEntity
-    # TODO: Include eligibilities
+    expose :eligibility_constraints, &self.delegate_to(:unified_eligibility_constraints)
 
     expose :activities, with: MemberActivityEntity
     expose :reset_codes, with: MemberResetCodeEntity

--- a/lib/suma/admin_api/meta.rb
+++ b/lib/suma/admin_api/meta.rb
@@ -20,8 +20,9 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
 
     get :eligibility_constraints do
       use_http_expires_caching 12.hours
-      ec = Suma::Eligibility::Constraint.dataset.order(:id).all
-      present_collection ec, with: EligibilityConstraintEntity
+      ec = Suma::Eligibility::Constraint.dataset.order(:name).all
+      present({items: ec, statuses: Suma::Eligibility::Constraint::STATUSES},
+              with: EligibilityConstraintCollectionEntity,)
     end
   end
 
@@ -36,7 +37,8 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
     expose :full_label, as: :label
   end
 
-  class EligibilityConstraintEntity < BaseEntity
-    expose :name
+  class EligibilityConstraintCollectionEntity < BaseEntity
+    expose :items, with: Suma::AdminAPI::Entities::EligibilityConstraintEntity
+    expose :statuses
   end
 end

--- a/lib/suma/admin_api/meta.rb
+++ b/lib/suma/admin_api/meta.rb
@@ -17,6 +17,12 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
       sc = Suma::Vendor::ServiceCategory.dataset.order(:name).all
       present_collection sc, with: HierarchicalCategoryEntity
     end
+
+    get :eligibility_constraints do
+      use_http_expires_caching 12.hours
+      ec = Suma::Eligibility::Constraint.dataset.order(:id).all
+      present_collection ec, with: EligibilityConstraintEntity
+    end
   end
 
   class CurrencyEntity < BaseEntity
@@ -28,5 +34,9 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
     expose :slug
     expose :name
     expose :full_label, as: :label
+  end
+
+  class EligibilityConstraintEntity < BaseEntity
+    expose :name
   end
 end

--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -12,9 +12,9 @@ class Suma::API::Commerce < Suma::API::V1
     resource :offerings do
       desc "Return all commerce offerings that are not closed"
       get do
-        current_member
+        me = current_member
         t = Time.now
-        ds = Suma::Commerce::Offering.available_at(t)
+        ds = Suma::Commerce::Offering.available_at(t).available_to(me)
         present_collection ds, with: OfferingEntity
       end
 

--- a/lib/suma/commerce/offering.rb
+++ b/lib/suma/commerce/offering.rb
@@ -107,6 +107,11 @@ class Suma::Commerce::Offering < Suma::Postgres::Model(:commerce_offerings)
     def available_at(t)
       return self.where(Sequel.pg_range(:period).contains(Sequel.cast(t, :timestamptz)))
     end
+
+    def available_to(member)
+      # TODO: add funcitonallity to show only offerings available to specific people based on eligibility constraints
+      return self
+    end
   end
 
   def rel_admin_link = "/offering/#{self.id}"

--- a/lib/suma/commerce/offering.rb
+++ b/lib/suma/commerce/offering.rb
@@ -20,6 +20,12 @@ class Suma::Commerce::Offering < Suma::Postgres::Model(:commerce_offerings)
   one_to_many :offering_products, class: "Suma::Commerce::OfferingProduct"
   one_to_many :carts, class: "Suma::Commerce::Cart"
 
+  many_to_many :eligibility_constraints,
+               class: "Suma::Eligibility::Constraint",
+               join_table: :eligibility_offering_associations,
+               right_key: :constraint_id,
+               left_key: :offering_id
+
   many_through_many :products,
                     [
                       [:commerce_offering_products, :offering_id, :product_id],

--- a/lib/suma/commerce/offering.rb
+++ b/lib/suma/commerce/offering.rb
@@ -108,9 +108,13 @@ class Suma::Commerce::Offering < Suma::Postgres::Model(:commerce_offerings)
       return self.where(Sequel.pg_range(:period).contains(Sequel.cast(t, :timestamptz)))
     end
 
-    def available_to(_member)
-      # TODO: add funcitonallity to show only offerings available to specific people based on eligibility constraints
-      return self
+    def available_to(member)
+      ds = self.exclude(eligibility_constraints: Suma::Eligibility::Constraint.dataset)
+      if member.verified_eligibility_constraints.empty?
+        # If the member has no constraints, return all offerings that also have no constraints.
+        return ds
+      end
+      return ds.or(eligibility_constraints: member.verified_eligibility_constraints)
     end
   end
 

--- a/lib/suma/commerce/offering.rb
+++ b/lib/suma/commerce/offering.rb
@@ -108,7 +108,7 @@ class Suma::Commerce::Offering < Suma::Postgres::Model(:commerce_offerings)
       return self.where(Sequel.pg_range(:period).contains(Sequel.cast(t, :timestamptz)))
     end
 
-    def available_to(member)
+    def available_to(_member)
       # TODO: add funcitonallity to show only offerings available to specific people based on eligibility constraints
       return self
     end

--- a/lib/suma/eligibility.rb
+++ b/lib/suma/eligibility.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Suma::Eligibility
+end

--- a/lib/suma/eligibility/constraint.rb
+++ b/lib/suma/eligibility/constraint.rb
@@ -5,5 +5,7 @@ require "suma/postgres/model"
 require "suma/eligibility"
 
 class Suma::Eligibility::Constraint < Suma::Postgres::Model(:eligibility_constraints)
+  STATUSES = ["pending", "verified", "rejected"].freeze
+
   plugin :timestamps
 end

--- a/lib/suma/eligibility/constraint.rb
+++ b/lib/suma/eligibility/constraint.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "suma/postgres/model"
+
+require "suma/eligibility"
+
+class Suma::Eligibility::Constraint < Suma::Postgres::Model(:eligibility_constraints)
+  plugin :timestamps
+end

--- a/lib/suma/fixtures/eligibility_constraints.rb
+++ b/lib/suma/fixtures/eligibility_constraints.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "suma/fixtures"
+
+module Suma::Fixtures::EligbilityConstraints
+  extend Suma::Fixtures
+
+  fixtured_class Suma::Eligibility::Constraint
+
+  base :eligibility_constraint do
+    self.name ||= Faker::Lorem.words(number: 2).join(" ") + SecureRandom.hex(2)
+  end
+end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -179,6 +179,10 @@ class Suma::Member < Suma::Postgres::Model(:members)
     return self.onboarding_verified_at ? true : false
   end
 
+  def onboarding_verified=(v)
+    self.onboarding_verified_at = v ? Time.now : nil
+  end
+
   def read_only_reason
     return "read_only_unverified" if self.onboarding_verified_at.nil?
     return "read_only_technical_error" if self.payment_account.nil?

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -139,7 +139,6 @@ class Suma::Member < Suma::Postgres::Model(:members)
   end
 
   def unified_eligibility_constraints
-    # TODO: Add tests
     return [] if self.db[:eligibility_member_associations].empty?
     constraints = []
     self.db[:eligibility_member_associations].each do |ema|

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -61,6 +61,7 @@ module Suma::Postgres
     "suma/commerce/order_audit_log",
     "suma/commerce/product",
     "suma/commerce/product_inventory",
+    "suma/eligibility/constraint",
     "suma/image",
     "suma/member",
     "suma/member/activity",

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -110,13 +110,17 @@ module Suma::Service::Helpers
     merror!(403, "Sorry, this action is unavailable.", code: "role_check")
   end
 
-  def merror!(status, message, code:, more: {})
-    if Suma::Service.localized_error_codes && !Suma::Service.localized_error_codes.include?(code)
+  def merror!(status, message, code:, more: {}, skip_loc_check: false)
+    if !skip_loc_check && Suma::Service.localized_error_codes && !Suma::Service.localized_error_codes.include?(code)
       merror!(500, "Error code is unlocalized: #{code}", code: "unhandled_error")
     end
     header "Content-Type", "application/json"
     body = Suma::Service.error_body(status, message, code:, more:)
     error!(body, status)
+  end
+
+  def adminerror!(status, message, code: "admin", more: {})
+    merror!(status, message, code:, more:, skip_loc_check: true)
   end
 
   def unauthenticated!

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -255,10 +255,16 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
         begin_fulfillment_at: self.sjfm_2023_end,
       )
     end
+
     if offering.images.empty?
       offering.add_image({uploaded_file: hero})
     else
       offering.images.first.update(uploaded_file: hero)
+    end
+
+    if offering.eligibility_constraints.empty?
+      constraint = Suma::Eligibility::Constraint.find_or_create(name: "New Columbia, Portland, OR")
+      offering.add_eligibility_constraint(constraint)
     end
 
     fulfillment_params = [

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -177,4 +177,25 @@ RSpec.describe Suma::AdminAPI::Members, :db do
       expect(Suma::Member.last.activities).to contain_exactly(have_attributes(message_name: "accountclosed"))
     end
   end
+
+  describe "POST /v1/members/:id/eligibilities" do
+    it "replaces the eligibilities" do
+      member = Suma::Fixtures.member.create
+      el = Suma::Fixtures.eligibility_constraint.create
+
+      post "/v1/members/#{member.id}/eligibilities", {values: [{constraint_id: el.id, status: "pending"}]}
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(id: member.id)
+      expect(member.refresh.pending_eligibility_constraints).to contain_exactly(be === el)
+    end
+
+    it "403s if the constraint does not exist" do
+      member = Suma::Fixtures.member.create
+
+      post "/v1/members/#{member.id}/eligibilities", {values: [{constraint_id: 0, status: "pending"}]}
+
+      expect(last_response).to have_status(403)
+    end
+  end
 end

--- a/spec/suma/admin_api/meta_spec.rb
+++ b/spec/suma/admin_api/meta_spec.rb
@@ -41,4 +41,18 @@ RSpec.describe Suma::AdminAPI::Meta, :db do
       )
     end
   end
+
+  describe "GET /v1/meta/eligibility_constraints" do
+    it "returns categories" do
+      a = Suma::Fixtures.eligibility_constraint.create
+
+      get "/v1/meta/eligibility_constraints"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        :statuses,
+        items: have_same_ids_as(a),
+      )
+    end
+  end
 end

--- a/spec/suma/eligibility_spec.rb
+++ b/spec/suma/eligibility_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::Eligibility", :db do
+  let(:described_class) { Suma::Eligibility }
+
+  it "can create constraints for offerings" do
+    e = Suma::Fixtures.eligibility_constraint.create
+    o = Suma::Fixtures.offering.create
+    o.add_eligibility_constraint(e)
+    o.remove_eligibility_constraint(e)
+  end
+
+  describe "for members" do
+    let(:e) { Suma::Fixtures.eligibility_constraint.create }
+    let(:o) { Suma::Fixtures.member.create }
+
+    it "cannot have multiple member ids within the same row" do
+      expect do
+        o.db[:eligibility_member_associations].insert(
+          constraint_id: e.id,
+          verified_member_id: o.id,
+          rejected_member_id: o.id,
+        )
+      end.to raise_error(/one_member_set/)
+    end
+
+    it "cannot have the same member for multiple rows with the same constraint" do
+      expect do
+        o.db[:eligibility_member_associations].insert(
+          constraint_id: e.id,
+          verified_member_id: o.id,
+        )
+        o.db[:eligibility_member_associations].insert(
+          constraint_id: e.id,
+          rejected_member_id: o.id,
+        )
+      end.to raise_error(/duplicate key value violates unique constraint "unique_member"/)
+    end
+
+    it "can manage constraints for members" do
+      o.replace_eligibility_constraint(e, :verified)
+      expect(o).to have_attributes(
+        verified_eligibility_constraints: contain_exactly(be === e),
+        pending_eligibility_constraints: [],
+        rejected_eligibility_constraints: [],
+      )
+
+      o.replace_eligibility_constraint(e, :pending)
+      expect(o).to have_attributes(
+        verified_eligibility_constraints: [],
+        pending_eligibility_constraints: contain_exactly(be === e),
+        rejected_eligibility_constraints: [],
+      )
+
+      o.replace_eligibility_constraint(e, :rejected)
+      expect(o).to have_attributes(
+        verified_eligibility_constraints: [],
+        pending_eligibility_constraints: [],
+        rejected_eligibility_constraints: contain_exactly(be === e),
+      )
+    end
+  end
+end

--- a/spec/suma/eligibility_spec.rb
+++ b/spec/suma/eligibility_spec.rb
@@ -59,5 +59,7 @@ RSpec.describe "Suma::Eligibility", :db do
         rejected_eligibility_constraints: contain_exactly(be === e),
       )
     end
+
+    it "can return con"
   end
 end

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -274,22 +274,21 @@ RSpec.describe "Suma::Member", :db do
     end
   end
 
-  describe "unified_eligibility_constraint" do
+  describe "eligibility_constraints_with_status" do
     it "gets member unified eligibility constraints" do
       m = Suma::Fixtures.member.onboarding_verified.create
-      e = Suma::Fixtures.eligibility_constraint.create
-      e2 = Suma::Fixtures.eligibility_constraint.create
-      m.replace_eligibility_constraint(e, :pending)
-      m.replace_eligibility_constraint(e2, :verified)
+      pending = Suma::Fixtures.eligibility_constraint.create
+      verified = Suma::Fixtures.eligibility_constraint.create
+      m.replace_eligibility_constraint(pending, :pending)
+      m.replace_eligibility_constraint(verified, :verified)
 
-      puts m.unified_eligibility_constraints
-      expect(m.unified_eligibility_constraints).to contain_exactly(
-        have_attributes(
-          constraint_id: e,
+      expect(m.eligibility_constraints_with_status).to contain_exactly(
+        include(
+          constraint: be === pending,
           status: "pending",
         ),
-        have_attributes(
-          constraint_id: e2,
+        include(
+          constraint: be === verified,
           status: "verified",
         ),
       )

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -273,4 +273,26 @@ RSpec.describe "Suma::Member", :db do
       expect(Suma::Fixtures.member(terms_agreed: date).instance).to_not be_requires_terms_agreement
     end
   end
+
+  describe "unified_eligibility_constraint" do
+    it "gets member unified eligibility constraints" do
+      m = Suma::Fixtures.member.onboarding_verified.create
+      e = Suma::Fixtures.eligibility_constraint.create
+      e2 = Suma::Fixtures.eligibility_constraint.create
+      m.replace_eligibility_constraint(e, :pending)
+      m.replace_eligibility_constraint(e2, :verified)
+
+      puts m.unified_eligibility_constraints
+      expect(m.unified_eligibility_constraints).to contain_exactly(
+        have_attributes(
+          constraint_id: e,
+          status: "pending",
+        ),
+        have_attributes(
+          constraint_id: e2,
+          status: "verified",
+        ),
+      )
+    end
+  end
 end


### PR DESCRIPTION
Fixes #424 and #410

- Create `Suma::Eligibility::Constraint` model and an association join table with commerce/food offerings
- Ensure we add a bootstrap script that creates a constraint for the St. Johns market offering
- Refactor available offerings displayed to each member depending on their eligibility constraints 
- Add UI that allows an admin to login and add/modify current eligibilities for any member
---
- Add UI ability to switch members onboarding verification "on" or "off" in Admin
---
- Fix error snackbar parameters

