### PR TITLE
Ledger subsidy automation involves constraints

### DIFF
--- a/lib/suma/async/automation_trigger_runner.rb
+++ b/lib/suma/async/automation_trigger_runner.rb
@@ -10,7 +10,7 @@ class Suma::Async::AutomationTriggerRunner
   def _perform(event)
     Suma::AutomationTrigger.active_at(Time.now).each do |at|
       next unless File.fnmatch(at.topic, event.name, File::FNM_EXTGLOB)
-      at.klass.run(at, event)
+      at.klass.new(at, event).run
     end
   end
 

--- a/lib/suma/automation_trigger.rb
+++ b/lib/suma/automation_trigger.rb
@@ -15,6 +15,23 @@ class Suma::AutomationTrigger < Suma::Postgres::Model(:automation_triggers)
   plugin :timestamps
   plugin :tstzrange_fields, :active_during
 
+  class Action
+    # @!attribute automation_trigger
+    # @return [Suma::AutomationTrigger]
+
+    # @!attribute event
+    # @return [Amigo::Event]
+
+    attr_reader :automation_trigger, :event
+
+    def initialize(automation_trigger, event)
+      @automation_trigger = automation_trigger
+      @event = event
+    end
+
+    def run = raise NotImplementedError
+  end
+
   dataset_module do
     def active_at(t)
       return self.where(Sequel.pg_range(:active_during).contains(Sequel.cast(t, :timestamptz)))
@@ -27,7 +44,7 @@ class Suma::AutomationTrigger < Suma::Postgres::Model(:automation_triggers)
 
   def run_with_payload(*payload)
     event = Amigo::Event.new("test", self.topic, payload)
-    self.klass.run(self, event)
+    self.klass.new(self, event).run
   end
 
   def self.load_implementations

--- a/lib/suma/automation_trigger/auto_onboard.rb
+++ b/lib/suma/automation_trigger/auto_onboard.rb
@@ -2,10 +2,10 @@
 
 require "suma/automation_trigger"
 
-class Suma::AutomationTrigger::AutoOnboard
-  def self.run(instance, event)
-    member = Suma::Member.find!(event.payload.first)
-    instance.db.transaction do
+class Suma::AutomationTrigger::AutoOnboard < Suma::AutomationTrigger::Action
+  def run
+    member = Suma::Member.find!(self.event.payload.first)
+    self.automation_trigger.db.transaction do
       member.lock!
       member.onboarding_verified_at ||= Time.now
       member.save_changes

--- a/lib/suma/automation_trigger/tester.rb
+++ b/lib/suma/automation_trigger/tester.rb
@@ -2,6 +2,11 @@
 
 require "suma/automation_trigger"
 
-class Suma::AutomationTrigger::Tester
-  def self.run(_instance, _event); end
+class Suma::AutomationTrigger::Tester < Suma::AutomationTrigger::Action
+  class << self
+    def runs = @runs ||= []
+  end
+  def run
+    self.class.runs << self
+  end
 end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -161,6 +161,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
         constraint_id: constraint.id,
         "#{group}_member_id".to_sym => self.id,
       )
+    self.publish_deferred("eligibilitychanged", self.id)
     self.associations.delete(:verified_eligibility_constraints)
     self.associations.delete(:pending_eligibility_constraints)
     self.associations.delete(:rejected_eligibility_constraints)

--- a/lib/suma/postgres/model_utilities.rb
+++ b/lib/suma/postgres/model_utilities.rb
@@ -218,7 +218,7 @@ module Suma::Postgres::ModelUtilities
   def find!(params)
     x = self[params]
     return x if x
-    raise Suma::InvalidPostcondition, "No row matching #{self.class.name}[#{params}]"
+    raise Suma::InvalidPostcondition, "No row matching #{self.name}[#{params}]"
   end
 
   module InstanceMethods

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -387,7 +387,7 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
     Suma::AutomationTrigger.dataset.delete
     Suma::AutomationTrigger.create(
       name: "Holidays 2022 Promo",
-      topic: "suma.payment.account.created",
+      topic: "suma.member.created",
       active_during_begin: self.holiday_2022_begin,
       active_during_end: self.holiday_2022_end,
       klass_name: "Suma::AutomationTrigger::CreateAndSubsidizeLedger",
@@ -412,7 +412,7 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
     )
     Suma::AutomationTrigger.create(
       name: "Summer 2023 Promo",
-      topic: "suma.payment.account.subsidize-sjfm-2023",
+      topic: "suma.member.eligibilitychanged",
       active_during_begin: self.sjfm_2023_begin,
       active_during_end: self.sjfm_2023_end,
       klass_name: "Suma::AutomationTrigger::CreateAndSubsidizeLedger",
@@ -426,6 +426,7 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
           en: "Farmers Market subsidy",
           es: "Subsidio al mercado de agricultores",
         },
+        verified_constraint_name: "New Columbia, Portland, OR",
       },
     )
   end
@@ -434,7 +435,7 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
   def holiday_2022_end = Time.parse("2023-12-18T12:00:00-0700")
 
   def sjfm_2023_begin = Time.parse("2023-06-01T12:00:00-0700")
-  def sjfm_2023_end = Time.parse("2023-07-15T12:00:00-0700")
+  def sjfm_2023_end = Time.parse("2023-07-15T23:00:00-0700")
 
   def create_uploaded_file(filename, content_type, file_path: "spec/data/images/")
     bytes = File.binread(file_path + filename)

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -12,15 +12,22 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
   end
 
   describe "AutomationTriggerRunner" do
+    before(:each) do
+      Suma::AutomationTrigger::Tester.runs.clear
+    end
+
     it "runs active automations" do
       active = Suma::Fixtures.automation_trigger.create
       active_mismatch_topic = Suma::Fixtures.automation_trigger.create(topic: "suma.z")
       inactive = Suma::Fixtures.automation_trigger.inactive.create
-      expect(Suma::AutomationTrigger::Tester).to receive(:run).with(be === active, have_attributes(payload: [5, 6]))
 
       expect do
         Amigo.publish("suma.x", 5, 6)
       end.to perform_async_job(Suma::Async::AutomationTriggerRunner)
+
+      expect(Suma::AutomationTrigger::Tester.runs).to contain_exactly(
+        have_attributes(automation_trigger: be === active, event: have_attributes(payload: [5, 6])),
+      )
     end
   end
 

--- a/spec/suma/automation_trigger_spec.rb
+++ b/spec/suma/automation_trigger_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Suma::AutomationTrigger", :db do
 
   describe Suma::AutomationTrigger::CreateAndSubsidizeLedger do
     let(:at) do
-      at = Suma::Fixtures.automation_trigger(
+      Suma::Fixtures.automation_trigger(
         klass_name: "Suma::AutomationTrigger::CreateAndSubsidizeLedger",
         parameter: {
           ledger_name: "Holidays2022",
@@ -21,15 +21,49 @@ RSpec.describe "Suma::AutomationTrigger", :db do
 
     it "creates and subsidizes the specified ledger", lang: :es do
       Suma::Fixtures.vendor_service_category(name: "Test Category").create
-      at.run_with_payload(pa.id)
+      at.run_with_payload(pa.member.id)
       expect(pa.ledgers).to contain_exactly(have_attributes(name: "Holidays2022"))
       expect(pa.ledgers.first.received_book_transactions).to contain_exactly(have_attributes(memo_string: "Subsidy Es"))
     end
 
     it "noops if the ledger exists" do
       Suma::Fixtures.ledger(account: pa).create(name: "Holidays2022")
-      at.run_with_payload(pa.id)
+      at.run_with_payload(pa.member.id)
       expect(pa.refresh.ledgers.first.received_book_transactions).to be_empty
+    end
+
+    describe "when constraints are set on the trigger" do
+      let(:constraint) { Suma::Fixtures.eligibility_constraint(name: "Special Person").create }
+      before(:each) do
+        at.parameter = at.parameter.merge("verified_constraint_name" => constraint.name)
+        at.save_changes.refresh
+        Suma::Fixtures.vendor_service_category(name: "Test Category").create
+      end
+
+      it "noops if the member does not satisfy constraints" do
+        pa.member.replace_eligibility_constraint(constraint, "pending")
+        at.run_with_payload(pa.member.id)
+        expect(pa.ledgers).to be_empty
+      end
+
+      it "creates and subsidizes the ledger if it does satisfy constraints" do
+        pa.member.replace_eligibility_constraint(constraint, "verified")
+        at.run_with_payload(pa.member.id)
+        expect(pa.ledgers).to contain_exactly(have_attributes(name: "Holidays2022"))
+      end
+    end
+  end
+
+  describe Suma::AutomationTrigger::AutoOnboard do
+    let(:at) do
+      Suma::Fixtures.automation_trigger(klass_name: "Suma::AutomationTrigger::AutoOnboard").create
+    end
+
+    it "verifies the member" do
+      member = Suma::Fixtures.member.create
+      expect(member.refresh).to_not be_onboarding_verified
+      at.run_with_payload(member.id)
+      expect(member.refresh).to be_onboarding_verified
     end
   end
 end

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -293,5 +293,13 @@ RSpec.describe "Suma::Member", :db do
         ),
       )
     end
+
+    it "publishes an event", :async, :do_not_defer_events do
+      m = Suma::Fixtures.member.onboarding_verified.create
+      pending = Suma::Fixtures.eligibility_constraint.create
+      expect do
+        m.replace_eligibility_constraint(pending, :pending)
+      end.to publish("suma.member.eligibilitychanged", [m.id])
+    end
   end
 end

--- a/spec/suma/postgres/model_spec.rb
+++ b/spec/suma/postgres/model_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe "Suma::Postgres::Model", :db do
     it "can error if an instance or dataset entry is not found" do
       expect do
         model_class.find!(name: "foo")
-      end.to raise_error(Suma::InvalidPostcondition, 'No row matching Class[{:name=>"foo"}]')
+      end.to raise_error(Suma::InvalidPostcondition, 'No row matching Suma::Postgres::TestingPixie[{:name=>"foo"}]')
 
       expect do
         model_class.dataset.where(name: "foo").find!


### PR DESCRIPTION
The `CreateAndSubsidizeLedger` automation action
now supports a `verified_constraint_name` parameter. If set, it ensures members have a verified constraint with the given name.

To support this, there are a few other changes here:

- Formalize 'automation actions' into a specific class and set of subclasses. This is better for organization and type documentation purposes, since we can clearly show what the requirements of an 'action' are.
- Add more tests for other automation actions
- Modify the SJFM bootstrap code to use the new functionality
- Modify `CreateAndSubsidizeLedger` so it works whenever a member is created, rather than a payment account. Using a member id, rather than payment account id, is more generic and useful.
- Replacing eligibility constraints emits a `suma.member.eligibilitychanged` event. The SJFM automation looks for this in order to add the subsidy.