### PR TITLE
Fix link in member detail and offering picklist page

### DIFF
--- a/adminapp/src/components/DetailGrid.js
+++ b/adminapp/src/components/DetailGrid.js
@@ -4,6 +4,7 @@ import isEmpty from "lodash/isEmpty";
 import React from "react";
 
 /**
+ * @param title The title of the detailgrid section
  * @param {Array<DetailGridProperty>} properties
  * @constructor
  */
@@ -18,23 +19,21 @@ export default function DetailGrid({ title, properties }) {
   return (
     <Box mt={2}>
       {title && (
-        <Typography variant="h6" gutterBottom>
+        <Typography variant="h6" gutterBottom mb={2}>
           {title}
         </Typography>
       )}
-      <Grid container spacing={2}>
-        <Grid item sx={{ width: "180px" }}>
-          {usedProperties.map(({ label }) => (
-            <Label key={label}>{label}</Label>
-          ))}
-        </Grid>
-        <Grid item>
-          {usedProperties.map(({ label, value, children }) => (
-            <Value key={label} value={value}>
-              {children}
-            </Value>
-          ))}
-        </Grid>
+      <Grid container spacing={2} alignItems="center" justifyContent="flex-end">
+        {usedProperties.map(({ label, value, children }) => (
+          <React.Fragment key={label}>
+            <Grid item xs={4} sm={3} lg={2} sx={{ paddingTop: "5px!important" }}>
+              <Label>{label}</Label>
+            </Grid>
+            <Grid item xs={8} sm={9} lg={10} sx={{ paddingTop: "5px!important" }}>
+              <Value value={value}>{children}</Value>
+            </Grid>
+          </React.Fragment>
+        ))}
       </Grid>
     </Box>
   );
@@ -42,7 +41,7 @@ export default function DetailGrid({ title, properties }) {
 
 function Label({ children }) {
   return (
-    <Typography variant="body1" color="textSecondary" align="right" gutterBottom>
+    <Typography variant="body1" color="textSecondary" align="right">
       {children}:
     </Typography>
   );
@@ -56,11 +55,7 @@ function Value({ value, children }) {
   if (value instanceof dayjs) {
     fmtVal = value.format("lll");
   }
-  return (
-    <Typography variant="body1" gutterBottom>
-      {fmtVal}
-    </Typography>
-  );
+  return <Typography variant="body1">{fmtVal}</Typography>;
 }
 
 /**

--- a/adminapp/src/components/InlineEditField.js
+++ b/adminapp/src/components/InlineEditField.js
@@ -43,7 +43,7 @@ export default function InlineEditField({
       <div>
         {renderDisplay}
         <IconButton onClick={startEditing}>
-          <EditIcon />
+          <EditIcon color="info" />
         </IconButton>
       </div>
     );
@@ -52,10 +52,10 @@ export default function InlineEditField({
     <div>
       {renderEdit(editingState, setEditingState)}
       <IconButton onClick={saveChanges}>
-        <SaveIcon />
+        <SaveIcon color="success" />
       </IconButton>
       <IconButton onClick={discardChanges}>
-        <CancelIcon />
+        <CancelIcon color="error" />
       </IconButton>
     </div>
   );

--- a/adminapp/src/pages/MemberDetailPage.js
+++ b/adminapp/src/pages/MemberDetailPage.js
@@ -199,7 +199,14 @@ function EligibilityConstraints({ memberConstraints, memberId, replaceMemberData
       });
     } else {
       memberConstraints.forEach(({ status, constraint }) =>
-        properties.push({ label: constraint.name, value: status })
+        properties.push({
+          label: constraint.name,
+          value: (
+            <Typography variant="span" sx={{ lineHeight: "2.5!important" }}>
+              {status}
+            </Typography>
+          ),
+        })
       );
     }
     return (
@@ -209,7 +216,7 @@ function EligibilityConstraints({ memberConstraints, memberId, replaceMemberData
             <>
               Eligibility Constraints
               <IconButton onClick={startEditing}>
-                <EditIcon />
+                <EditIcon color="info" />
               </IconButton>
             </>
           }
@@ -297,10 +304,10 @@ function EligibilityConstraints({ memberConstraints, memberId, replaceMemberData
           <>
             Eligibility Constraints
             <IconButton onClick={saveChanges}>
-              <SaveIcon />
+              <SaveIcon color="success" />
             </IconButton>
             <IconButton onClick={discardChanges}>
-              <CancelIcon />
+              <CancelIcon color="error" />
             </IconButton>
           </>
         }
@@ -313,7 +320,7 @@ function EligibilityConstraints({ memberConstraints, memberId, replaceMemberData
 function ConstraintStatus({ activeStatus, statuses, onChange }) {
   return (
     <div>
-      <Select label="Status" value={activeStatus} onChange={onChange}>
+      <Select value={activeStatus} onChange={onChange} size="small">
         {statuses.map((status) => (
           <MenuItem key={status} value={status}>
             {status}

--- a/adminapp/src/pages/OfferingDetailPage.js
+++ b/adminapp/src/pages/OfferingDetailPage.js
@@ -1,13 +1,14 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import DetailGrid from "../components/DetailGrid";
+import Link from "../components/Link";
 import RelatedList from "../components/RelatedList";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import { dayjs } from "../modules/dayConfig";
 import Money from "../shared/react/Money";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import ListAltIcon from "@mui/icons-material/ListAlt";
-import { CircularProgress, Link } from "@mui/material";
+import { CircularProgress } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
@@ -61,7 +62,7 @@ export default function OfferingDetailPage() {
           />
           {!isEmpty(offering.orders) && (
             <Link
-              href={`/offering/${offering.id}/picklist`}
+              to={`/offering/${offering.id}/picklist`}
               sx={{ display: "inline-block", marginTop: "15px" }}
             >
               <ListAltIcon sx={{ verticalAlign: "middle", paddingRight: "5px" }} />
@@ -89,7 +90,7 @@ export default function OfferingDetailPage() {
   );
 }
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   closed: {
     opacity: 0.5,
   },

--- a/adminapp/src/pages/OfferingPickListPage.js
+++ b/adminapp/src/pages/OfferingPickListPage.js
@@ -2,12 +2,12 @@ import api from "../api";
 import AdminLink from "../components/AdminLink";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
-import { Link, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { alpha, styled } from "@mui/material/styles";
 import { DataGrid, gridClasses } from "@mui/x-data-grid";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 export default function OfferingPickListPage() {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
@@ -25,7 +25,7 @@ export default function OfferingPickListPage() {
       {!isEmpty(pickList) && (
         <>
           <Typography variant="h5" gutterBottom>
-            Offering <Link href={`/offering/${id}`}>{id}</Link> Pick/Pack List
+            Offering <Link to={`/offering/${id}`}>{id}</Link> Pick/Pack List
           </Typography>
           <StripedDataGrid
             columns={[


### PR DESCRIPTION
Fixes #417 

* Fix links for member detail page and Offering pick/pack list page
* Fix `DetailGrid` inline styling bug and make responsive - it does not shift anymore on change
* Added color prop to the icons

### Admin Member details - Before
<img width="455" alt="Screenshot 2023-07-13 at 7 32 30 PM" src="https://github.com/lithictech/suma/assets/66847768/f9978669-17b0-4c15-8aff-0ec8dfbd66ee">

### Admin Member details - After
![Screenshot 2023-07-13 at 7 33 06 PM](https://github.com/lithictech/suma/assets/66847768/16a12a04-d06e-425a-b887-3adf00570deb)

### Admin Member details - After starting to edit inline fields
![Screenshot 2023-07-13 at 7 33 37 PM](https://github.com/lithictech/suma/assets/66847768/8cfe5ee2-b1d3-4cd5-ab1a-b78b26325cc8)
