### PR TITLE
Add bin scripts must use `set -e`

### DIFF
--- a/bin/build-adminapp
+++ b/bin/build-adminapp
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 cd adminapp
 # Need dev deps to build

--- a/bin/build-webapp
+++ b/bin/build-webapp
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 cd webapp
 # Need dev deps to build

--- a/bin/notify
+++ b/bin/notify
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+set -e
 
 osascript -e "display notification \"$1\" with title \"Suma\""

--- a/webapp/src/pages/ContactListAdd.js
+++ b/webapp/src/pages/ContactListAdd.js
@@ -94,7 +94,7 @@ export default function ContactListAdd() {
           errors={errors}
           value={phone}
           onChange={(e) => handlePhoneChange(e, setPhone)}
-          autoComplete="tel-national"
+          autoComplete="tel"
         />
         <Row className="mb-3">
           <FormControlGroup

--- a/webapp/src/pages/Start.js
+++ b/webapp/src/pages/Start.js
@@ -81,7 +81,7 @@ export default function Start() {
           value={phone}
           onChange={handlePhoneChange}
           aria-describedby="phoneRequired"
-          autoComplete="tel-national"
+          autoComplete="tel"
           autoFocus
           required
         />


### PR DESCRIPTION
Admin build was failing but didn't break the deploy.

Some dependency was 404ing, as per https://github.com/lithictech/suma/actions/runs/5558153486/jobs/10152881709, but it's there now, so hopefully this will work on staging.