### PR TITLE
Improve vendor polling, and free scooters

### DIFF
--- a/lib/sequel/advisory_lock.rb
+++ b/lib/sequel/advisory_lock.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "sequel"
+
+class Sequel::AdvisoryLock
+  def initialize(db, key_or_key1, key2=nil, shared: false, xact: false)
+    @db = db
+    xstr = xact ? "_xact" : ""
+    sharestr = shared ? "_shared" : ""
+    @locker = to_expr("pg_advisory#{xstr}_lock#{sharestr}", key_or_key1, key2)
+    @trylocker = to_expr("pg_try_advisory#{xstr}_lock#{sharestr}", key_or_key1, key2)
+    @unlocker = to_expr(shared ? "pg_advisory_unlock_shared" : "pg_advisory_unlock", key_or_key1, key2)
+    if key2
+      @cond = {classid: key_or_key1, objid: key2, objsubid: 2}
+    else
+      k2 = key_or_key1 & 0xFFFF_FFFF
+      @cond = {classid: 1, objid: k2, objsubid: 1}
+    end
+  end
+
+  private def to_expr(name, key1, key2)
+    return key2.nil? ? Sequel.function(name.to_sym, key1) : Sequel.function(name.to_sym, key1, key2)
+  end
+
+  def dataset(this: false)
+    ds = @db[:pg_locks]
+    ds = ds.where(@cond) if this
+    return ds
+  end
+
+  # pg_advisory_lock
+  # pg_advisory_lock_shared
+  # pg_advisory_xact_lock
+  # pg_advisory_xact_lock_shared
+  def with_lock
+    raise LocalJumpError unless block_given?
+    @db.get(@locker)
+    return yield
+  ensure
+    self.unlock
+  end
+
+  # pg_try_advisory_lock
+  # pg_try_advisory_lock_shared
+  # pg_try_advisory_xact_lock
+  # pg_try_advisory_xact_lock_shared
+  def with_lock?
+    raise LocalJumpError unless block_given?
+    acquired = @db.get(@trylocker)
+    return false, nil unless acquired
+    begin
+      return true, yield
+    ensure
+      self.unlock
+    end
+  end
+
+  def unlock
+    @db.get(@unlocker)
+  end
+
+  def unlock_all
+    @db.get(Sequel.function(:pg_advisory_unlock_all))
+  end
+end

--- a/lib/suma/api/anon_proxy.rb
+++ b/lib/suma/api/anon_proxy.rb
@@ -26,6 +26,7 @@ class Suma::API::AnonProxy < Suma::API::V1
           to_h { |h| [h[:id], h[:latest_access_code]] }
         ds = member.anon_proxy_vendor_accounts_dataset.
           where(Sequel[id: latest_codes_by_id.keys] & Sequel.~(latest_access_code: nil)).
+          where { latest_access_code_set_at > Suma::AnonProxy::VendorAccount::RECENT_ACCESS_CODE_CUTOFF.ago }.
           exclude(latest_access_code: latest_codes_by_id.values.compact)
         started_polling = Time.now
         found_change = false

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -147,6 +147,12 @@ class Suma::API::Mobility < Suma::API::V1
     expose :o, expose_nil: false
   end
 
+  class MobilityMapVendorServiceEntity < VendorServiceEntity
+    expose :zero_balance_ok do |instance|
+      instance.rates.first&.surcharge&.zero? || false
+    end
+  end
+
   class MobilityMapEntity < BaseEntity
     include Suma::API::Entities
     expose :precision do |_|
@@ -155,7 +161,7 @@ class Suma::API::Mobility < Suma::API::V1
     expose :refresh do |_|
       30_000
     end
-    expose :providers, with: VendorServiceEntity
+    expose :providers, with: MobilityMapVendorServiceEntity
     expose :escooter, with: MobilityMapVehicleEntity, expose_nil: false
     expose :ebike, with: MobilityMapVehicleEntity, expose_nil: false
   end

--- a/lib/suma/webhookdb.rb
+++ b/lib/suma/webhookdb.rb
@@ -21,6 +21,7 @@ module Suma::Webhookdb
     setting :database_url, ENV.fetch("DATABASE_URL", nil)
     setting :schema, :public
     setting :postmark_inbound_messages_table, :postmark_inbound_message_v1_fixture
+    setting :postmark_inbound_messages_secret, "fakesecret"
 
     after_configured do
       self.connection = Sequel.connect(self.database_url, extensions: [:pg_json])

--- a/spec/suma/api/anon_proxy_spec.rb
+++ b/spec/suma/api/anon_proxy_spec.rb
@@ -191,4 +191,25 @@ RSpec.describe Suma::API::AnonProxy, :db do
         that_includes(instructions: "see this: x@y.z")
     end
   end
+
+  describe "POST /v1/anon_proxy/relays/webhookdb/webhooks" do
+    before(:each) do
+      logout
+    end
+
+    it "enqueues the async jobs" do
+      header "Whdb-Webhook-Secret", Suma::Webhookdb.postmark_inbound_messages_secret
+      expect(Suma::Async::ProcessAnonProxyInboundWebhookdbRelays).to receive(:perform_async)
+
+      post "/v1/anon_proxy/relays/webhookdb/webhooks", {x: 1}
+
+      expect(last_response).to have_status(202)
+    end
+
+    it "errors if the webhook header does not match" do
+      post "/v1/anon_proxy/relays/webhookdb/webhooks", {x: 1}
+
+      expect(last_response).to have_status(401)
+    end
+  end
 end

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -321,7 +321,7 @@ export default class MapBuilder {
           loc: bike.c,
           type: vehicleType,
           disambiguator: bike.d,
-          providerId: providers[bike.p].id,
+          provider: providers[bike.p],
         };
         this._onVehicleClick(mapVehicle);
         this._clickedVehicle = e.target;


### PR DESCRIPTION
Add a webhook endpoint for postmark messages

This ensures we get faster updates when new messages come in

Fixes https://github.com/lithictech/suma/issues/426

---

Allow taking a ride on free scooters

Fixes https://github.com/lithictech/suma/issues/446

If a vendor service has a $0 rate, show that they
can ride the scooter via the map prompt.

Note, this doesn't test it out all the way end-to-end,
that they can ride with a $0 balance,
but we may need that eventually.

---

Fix vendor account access polling

If we had an old access code, we'd always find the vendor account,
because the frontend is looking for 'null'
(since we return a null access code since it's old) but the database
has rows without null.

We only want to look for recently-set rows.