### PR TITLE
Add a new 'match funding transaction' automation

### DIFF
--- a/lib/suma/automation_trigger.rb
+++ b/lib/suma/automation_trigger.rb
@@ -30,6 +30,18 @@ class Suma::AutomationTrigger < Suma::Postgres::Model(:automation_triggers)
     end
 
     def run = raise NotImplementedError
+
+    def params = self.automation_trigger.parameter.deep_symbolize_keys
+
+    def member_passes_constraints?(member_id, constraint_name)
+      return true if constraint_name.blank?
+      constraints_ds = Suma::Eligibility::Constraint.where(name: constraint_name)
+      member_passes_constraints = !Suma::Member.
+        where(id: member_id).
+        where(verified_eligibility_constraints: constraints_ds).
+        empty?
+      return member_passes_constraints
+    end
   end
 
   dataset_module do

--- a/lib/suma/automation_trigger/funding_transaction_match.rb
+++ b/lib/suma/automation_trigger/funding_transaction_match.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "suma/automation_trigger"
+
+class Suma::AutomationTrigger::FundingTransactionMatch < Suma::AutomationTrigger::Action
+  def run
+    funding_xaction = Suma::Payment::FundingTransaction.find!(self.event.payload.first)
+    # Only match this transaction if it was a 'normal' fund add, not commerce.
+    # It doesn't make sense to match commerce funding movements since they have already used it to pay.
+    return unless funding_xaction.associated_charges_dataset.empty?
+    acct = funding_xaction.originating_payment_account
+    member = acct.member
+    params = self.params
+    return unless self.member_passes_constraints?(member.id, params[:verified_constraint_name])
+    self.automation_trigger.db.transaction do
+      ledger = acct.ledgers_dataset.find!(name: params.fetch(:ledger_name))
+      ledger.lock!
+      vsc = ledger.vendor_service_categories.first
+      raise Suma::InvalidPrecondition, "Cannot subsidize a ledger without a vendor service category" if vsc.nil?
+      ratio = params.fetch(:match_ratio, 1)
+      amount = funding_xaction.amount * ratio
+      if (max_cents = params.fetch(:max_cents, nil))
+        max_amount = Money.new(max_cents, amount.currency)
+        amount = [amount, max_amount].min
+        balance = ledger.balance
+        # Treat the max amount as both the maximum individual contribution,
+        # AND the maximum total subsidy.
+        amount = max_amount - balance if amount + balance > max_amount
+      end
+      return if amount.zero?
+      Suma::Payment::BookTransaction.create(
+        apply_at: Time.now,
+        amount:,
+        originating_ledger: Suma::Payment::Account.lookup_platform_vendor_service_category_ledger(vsc),
+        receiving_ledger: ledger,
+        associated_vendor_service_category: vsc,
+        memo: Suma::TranslatedText.create(**params.fetch(:subsidy_memo)),
+      )
+    end
+  end
+end

--- a/lib/suma/payment/funding_transaction.rb
+++ b/lib/suma/payment/funding_transaction.rb
@@ -28,6 +28,12 @@ class Suma::Payment::FundingTransaction < Suma::Postgres::Model(:payment_funding
   many_to_one :increase_ach_strategy, class: "Suma::Payment::FundingTransaction::IncreaseAchStrategy"
   many_to_one :stripe_card_strategy, class: "Suma::Payment::FundingTransaction::StripeCardStrategy"
 
+  many_to_many :associated_charges,
+               class: "Suma::Charge",
+               join_table: :charges_associated_funding_transactions,
+               right_key: :charge_id,
+               left_key: :funding_transaction_id
+
   state_machine :status, initial: :created do
     state :created,
           :collecting,

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -343,8 +343,8 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
       product.images.first.update(uploaded_file: logo)
     end
     Suma::Commerce::ProductInventory.update_or_create(product:) do |p|
-      p.max_quantity_per_order = 1
-      p.max_quantity_per_offering = 25
+      p.max_quantity_per_order = 100
+      p.max_quantity_per_offering = 100
     end
     Suma::Commerce::OfferingProduct.update_or_create(offering:, product:) do |op|
       op.customer_price = Money.new(2400)
@@ -425,10 +425,10 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
       klass_name: "Suma::AutomationTrigger::AutoOnboard",
     )
     Suma::AutomationTrigger.create(
-      name: "Summer 2023 Promo",
+      name: "SJFM NC 2023 $19 Match",
       topic: "suma.member.eligibilitychanged",
       active_during_begin: self.sjfm_2023_begin,
-      active_during_end: self.sjfm_2023_end,
+      active_during_end: self.sjfm_2023_season_end,
       klass_name: "Suma::AutomationTrigger::CreateAndSubsidizeLedger",
       parameter: {
         ledger_name: "Summer2023FarmersMarket",
@@ -443,6 +443,22 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
         verified_constraint_name: "New Columbia, Portland, OR",
       },
     )
+    Suma::AutomationTrigger.create(
+      name: "SJFM NC 2023 1-1 Match",
+      topic: "suma.payment.fundingtransaction.created",
+      active_during_begin: self.sjfm_2023_begin,
+      active_during_end: self.sjfm_2023_season_end,
+      klass_name: "Suma::AutomationTrigger::FundingTransactionMatch",
+      parameter: {
+        ledger_name: "Summer2023FarmersMarket",
+        max_cents: 1500,
+        subsidy_memo: {
+          en: "Farmers Market matching subsidy",
+          es: "Subsidio al mercado de agricultores",
+        },
+        verified_constraint_name: "New Columbia, Portland, OR",
+      },
+    )
   end
 
   def holiday_2022_begin = Time.parse("2023-11-01T12:00:00-0700")
@@ -450,6 +466,7 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
 
   def sjfm_2023_begin = Time.parse("2023-06-01T12:00:00-0700")
   def sjfm_2023_end = Time.parse("2023-07-15T23:00:00-0700")
+  def sjfm_2023_season_end = Time.parse("2023-10-28T14:00:00-0700")
 
   def create_uploaded_file(filename, content_type, file_path: "spec/data/images/")
     bytes = File.binread(file_path + filename)

--- a/spec/suma/automation_trigger_spec.rb
+++ b/spec/suma/automation_trigger_spec.rb
@@ -66,4 +66,97 @@ RSpec.describe "Suma::AutomationTrigger", :db do
       expect(member.refresh).to be_onboarding_verified
     end
   end
+
+  describe Suma::AutomationTrigger::FundingTransactionMatch do
+    let(:at) do
+      Suma::Fixtures.automation_trigger(
+        klass_name: "Suma::AutomationTrigger::FundingTransactionMatch",
+        parameter: {
+          ledger_name: "Tester",
+          subsidy_memo: {en: "Subsidy En", es: "Subsidy Es"},
+        },
+      ).create
+    end
+    let(:funding_xaction) { Suma::Fixtures.funding_transaction.with_fake_strategy.create(amount_cents: 1000) }
+    let(:payment_account) { funding_xaction.originating_payment_account }
+    let!(:vsc) { Suma::Fixtures.vendor_service_category(name: "Test Category").create }
+    let!(:ledger) do
+      led = Suma::Fixtures.ledger.create(name: "Tester", account: payment_account)
+      led.add_vendor_service_category(vsc)
+      led
+    end
+
+    it "subsidizes the specified ledger", lang: :es do
+      at.run_with_payload(funding_xaction.id)
+      expect(ledger.refresh.received_book_transactions).to contain_exactly(
+        have_attributes(
+          associated_vendor_service_category: be === vsc,
+          memo_string: "Subsidy Es",
+          amount: cost("$10"),
+        ),
+      )
+    end
+
+    it "can subsidize with a ratio and max" do
+      at.update(parameter: at.parameter.merge(match_ratio: 2, max_cents: 1500))
+      at.run_with_payload(funding_xaction.id)
+      expect(ledger.refresh.received_book_transactions).to contain_exactly(
+        have_attributes(
+          amount: cost("$15"),
+        ),
+      )
+    end
+
+    it "does not subsidize funding transactions already used in a charge" do
+      charge = Suma::Fixtures.charge.create
+      charge.add_associated_funding_transaction(funding_xaction)
+      at.run_with_payload(funding_xaction.id)
+      expect(ledger.refresh.received_book_transactions).to be_empty
+    end
+
+    it "handles existing subsidy on the ledger and only goes up to max_cents" do
+      at.update(parameter: at.parameter.merge(max_cents: 1500))
+      at.run_with_payload(funding_xaction.id)
+      expect(ledger.refresh.received_book_transactions).to contain_exactly(
+        have_attributes(amount: cost("$10")),
+      )
+
+      second_fx = Suma::Fixtures.funding_transaction.with_fake_strategy.
+        create(originating_payment_account: payment_account, amount_cents: 1000)
+      at.run_with_payload(second_fx.id)
+      expect(ledger.refresh.received_book_transactions).to contain_exactly(
+        have_attributes(amount: cost("$10")),
+        have_attributes(amount: cost("$5")),
+      )
+
+      noop_fx = Suma::Fixtures.funding_transaction.with_fake_strategy.
+        create(originating_payment_account: payment_account, amount_cents: 1000)
+      at.run_with_payload(noop_fx.id)
+      expect(ledger.refresh.received_book_transactions).to contain_exactly(
+        have_attributes(amount: cost("$10")),
+        have_attributes(amount: cost("$5")),
+      )
+    end
+
+    describe "when constraints are set on the trigger" do
+      let(:constraint) { Suma::Fixtures.eligibility_constraint(name: "Special Person").create }
+      let(:member) { funding_xaction.originating_payment_account.member }
+      before(:each) do
+        at.parameter = at.parameter.merge("verified_constraint_name" => constraint.name)
+        at.save_changes.refresh
+      end
+
+      it "noops if the member does not satisfy constraints" do
+        member.replace_eligibility_constraint(constraint, "pending")
+        at.run_with_payload(funding_xaction.id)
+        expect(ledger.refresh.received_book_transactions).to be_empty
+      end
+
+      it "creates and subsidizes the ledger if it does satisfy constraints" do
+        member.replace_eligibility_constraint(constraint, "verified")
+        at.run_with_payload(funding_xaction.id)
+        expect(ledger.refresh.received_book_transactions).to contain_exactly(have_attributes(amount: cost("$10")))
+      end
+    end
+  end
 end


### PR DESCRIPTION
When someone loads money, we can add a matching book transaction into a specified ledger.

Use this to match 1-to-n dollars for incentives.