### PR TITLE
Show at least the most recent 10 ledger lines

### DIFF
--- a/lib/suma/payment/ledgers_view.rb
+++ b/lib/suma/payment/ledgers_view.rb
@@ -2,10 +2,12 @@
 
 class Suma::Payment::LedgersView
   attr_reader :ledgers
+  attr_accessor :minimum_recent_lines
 
   def initialize(ledgers, now: Time.now)
     @ledgers = ledgers || []
     @now = now
+    @minimum_recent_lines = 10
   end
 
   def total_balance
@@ -17,8 +19,28 @@ class Suma::Payment::LedgersView
     lines = []
     [:received_book_transactions_dataset, :originated_book_transactions_dataset].each do |dsmethod|
       lines.concat(self.ledgers.map do |ledger|
-        ledger.send(dsmethod).where { apply_at > recent }.all.map { |bt| bt.directed(ledger) }
+        ledger.send(dsmethod).
+          where { apply_at > recent }.
+          all.
+          map { |bt| bt.directed(ledger) }
       end.flatten)
+    end
+    remainder_to_show = self.minimum_recent_lines - lines.length
+
+    if remainder_to_show.positive?
+      [:received_book_transactions_dataset, :originated_book_transactions_dataset].each do |dsmethod|
+        lines.concat(self.ledgers.map do |ledger|
+          # Same as above, except grab a limited set of older transactions.
+          ledger.send(dsmethod).
+            where { apply_at <= recent }.
+            limit(remainder_to_show).
+            all.
+            map { |bt| bt.directed(ledger) }
+        end.flatten)
+      end
+      # We can end up with extra transactions, since we LIMIT and add multiple sets.
+      # Ensure we end up with a consistent amount.
+      lines = lines.take(self.minimum_recent_lines)
     end
     lines = lines.sort_by(&:apply_at).reverse
     return lines

--- a/spec/suma/payment/ledgers_view_spec.rb
+++ b/spec/suma/payment/ledgers_view_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Suma::Payment::LedgersView, :db do
     Suma::Fixtures.book_transaction.from(grocery_ledger).create(amount: money("$1"), apply_at: 80.days.ago)
     Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$27"))
     d = described_class.new(account.ledgers)
+    d.minimum_recent_lines = 3
     expect(d).to have_attributes(
       total_balance: cost("$1"),
       recent_lines: match(
@@ -32,5 +33,50 @@ RSpec.describe Suma::Payment::LedgersView, :db do
       ),
       ledgers: have_same_ids_as(cash_ledger, grocery_ledger).ordered,
     )
+  end
+
+  describe "recent_lines" do
+    let(:account) { Suma::Fixtures.payment_account.create }
+    let!(:cash_ledger) { Suma::Fixtures.ledger(account:).category(:cash).create(name: "Dolla") }
+    let!(:grocery_ledger) { Suma::Fixtures.ledger(account:).category(:food).create(name: "Grub") }
+
+    it "includes the last 60 days of transactions" do
+      d = described_class.new(account.ledgers)
+      d.minimum_recent_lines = 2
+
+      Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$1"))
+      Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$2"), apply_at: 2.hours.ago)
+      Suma::Fixtures.book_transaction.to(grocery_ledger).create(amount: money("$3"), apply_at: 3.hours.ago)
+      Suma::Fixtures.book_transaction.to(grocery_ledger).create(amount: money("$4"), apply_at: 4.hours.ago)
+      expect(d).to have_attributes(
+        recent_lines: match(
+          [
+            have_attributes(amount: cost("$1")),
+            have_attributes(amount: cost("$2")),
+            have_attributes(amount: cost("$3")),
+            have_attributes(amount: cost("$4")),
+          ],
+        ),
+      )
+    end
+
+    it "always includes a minimum number of transactions if not enough are recent" do
+      d = described_class.new(account.ledgers)
+      d.minimum_recent_lines = 3
+
+      Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$1"))
+      Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$2"), apply_at: 100.days.ago)
+      Suma::Fixtures.book_transaction.to(grocery_ledger).create(amount: money("$3"), apply_at: 101.days.ago)
+      Suma::Fixtures.book_transaction.to(grocery_ledger).create(amount: money("$4"), apply_at: 102.days.ago)
+      expect(d).to have_attributes(
+        recent_lines: match(
+          [
+            have_attributes(amount: cost("$1")),
+            have_attributes(amount: cost("$2")),
+            have_attributes(amount: cost("$3")),
+          ],
+        ),
+      )
+    end
   end
 end


### PR DESCRIPTION
If a user had transactions only more than 60 days old, nothing would show up on their dashboard.

We depend on showing *some* history on the dashboard if the user has had any transactions,
so show the most recent 10 transactions, beyond all of those within the last 60 days.

Fixes #459