### PR TITLE
Fix map issues

### DIFF
--- a/webapp/src/components/mobilitymap/Map.js
+++ b/webapp/src/components/mobilitymap/Map.js
@@ -84,10 +84,12 @@ const Map = () => {
   );
 
   const handleEndTrip = React.useCallback(() => {
-    loadedMap?.loadScooters({
-      onVehicleClick: handleVehicleClick,
-      onVehicleRemove: handleVehicleRemove,
-    });
+    loadedMap
+      ?.setVehicleEventHandlers({
+        onClick: handleVehicleClick,
+        onSelectedRemoved: handleVehicleRemove,
+      })
+      .loadScooters();
   }, [handleVehicleClick, handleVehicleRemove, loadedMap]);
 
   const handleCloseTrip = React.useCallback(() => {
@@ -105,17 +107,18 @@ const Map = () => {
       onLocationFound: handleLocationFound,
       onLocationError: handleLocationError,
     });
-    // Need these so loadScooters works.
-    // We handle any changes to the event handlers with their own useEffect later on.
-    map.setVehicleEventHandlers({
-      onClick: handleVehicleClick,
-      onSelectedRemoved: handleVehicleRemove,
-    });
     // We only want this evaluated on load. We handle it imperatively otherwise.
     if (ongoingTrip) {
       map.beginTrip();
     } else {
-      map.loadScooters();
+      // Need these so loadScooters works.
+      // We handle any changes to the event handlers with their own useEffect later on.
+      map
+        .setVehicleEventHandlers({
+          onClick: handleVehicleClick,
+          onSelectedRemoved: handleVehicleRemove,
+        })
+        .loadScooters();
     }
     setLoadedMap(map);
     return () => {

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -134,6 +134,8 @@ export default class MapBuilder {
       return;
     }
     this._lastExtendedBounds = expandBounds(bounds);
+    // Stop refresh timer to avoid multiple API calls when moving map
+    this.stopRefreshTimer();
     this.getAndUpdateScooters(this._lastExtendedBounds, this._mcg);
   }
 

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -201,7 +201,7 @@ export default class MapBuilder {
     ["ebike", "escooter"].forEach((vehicleType) => {
       data[vehicleType]?.forEach((bike) => {
         const id = `${bike.p}-${bike.c[0]}-${bike.c[1]}${bike.d ? "-" + bike.d : ""}`;
-        const marker = this.newMarker(
+        const marker = this.createVehicleMarker(
           id,
           bike,
           vehicleType,
@@ -236,6 +236,34 @@ export default class MapBuilder {
     }
     this._onSelectedVehicleRemoved();
     this._clickedVehicle = null;
+  }
+
+  createVehicleMarker(id, bike, vehicleType, providers, precisionFactor) {
+    // calculate lat, lng offsets when available
+    let [lat, lng] = bike.c;
+    if (bike.o) {
+      lat += bike.o[0];
+      lng += bike.o[1];
+    }
+    lat = lat * precisionFactor;
+    lng = lng * precisionFactor;
+    return this._l
+      .marker([lat, lng], {
+        id,
+        icon: this._scooterIcon,
+        riseOnHover: true,
+      })
+      .on("click", (e) => {
+        this.centerLocation(e.latlng);
+        const mapVehicle = {
+          loc: bike.c,
+          type: vehicleType,
+          disambiguator: bike.d,
+          provider: providers[bike.p],
+        };
+        this._onVehicleClick(mapVehicle);
+        this._clickedVehicle = e.target;
+      });
   }
 
   getAndUpdateRestrictedAreas(bounds, group) {
@@ -313,34 +341,6 @@ export default class MapBuilder {
     }
     clearInterval(this._refreshId);
     this._refreshId = null;
-  }
-
-  newMarker(id, bike, vehicleType, providers, precisionFactor) {
-    // calculate lat, lng offsets when available
-    let [lat, lng] = bike.c;
-    if (bike.o) {
-      lat += bike.o[0];
-      lng += bike.o[1];
-    }
-    lat = lat * precisionFactor;
-    lng = lng * precisionFactor;
-    return this._l
-      .marker([lat, lng], {
-        id,
-        icon: this._scooterIcon,
-        riseOnHover: true,
-      })
-      .on("click", (e) => {
-        this.centerLocation(e.latlng);
-        const mapVehicle = {
-          loc: bike.c,
-          type: vehicleType,
-          disambiguator: bike.d,
-          provider: providers[bike.p],
-        };
-        this._onVehicleClick(mapVehicle);
-        this._clickedVehicle = e.target;
-      });
   }
 
   _getLocationZoom() {

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -173,7 +173,6 @@ export default class MapBuilder {
     this.getAndUpdateScooters(this._lastExtendedBounds, this._mcg);
     this.setMapEventHandlers();
     this._map.addLayer(this._mcg);
-    return this;
   }
 
   getAndUpdateScooters(bounds, mcg) {

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -568,7 +568,7 @@ function boundsToParams(bounds) {
 const refreshTimer = (function () {
   let timer = 0;
   // Because the inner function is bound to the refreshTimer variable,
-  // it will remain in score and will allow the timer variable to be manipulated
+  // it will remain in scope and will allow the timer variable to be manipulated
   return function (cb, ms) {
     clearTimeout(timer);
     timer = setInterval(cb, ms);

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -159,6 +159,7 @@ export default class MapBuilder {
   setVehicleEventHandlers({ onClick, onSelectedRemoved }) {
     this._onVehicleClick = onClick;
     this._onSelectedVehicleRemoved = onSelectedRemoved;
+    return this;
   }
 
   loadScooters() {

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -147,7 +147,6 @@ export default class MapBuilder {
     if (!this._clickedVehicle) {
       return;
     }
-    this._onVehicleClick(null);
     this._clickedVehicle = null;
   }
 


### PR DESCRIPTION
Fixes #461 & #466

- prevent mapBuilder `vehicleClick` function from being removed
- refactor the way refreshTimer state managed when initialized and when unmounted to fix persisting API call issues
   - `refreshTimer` persists and it's `_refreshId` now resets every time we update scooters
   - clearing the timer id is only necessary when unmounting or beginning a trip to prevent any hanging API calls
- Refactor/fix map initial loading and callback

Note:
- Changed restriction area red layer opacity from 0.3 -> 0.25