### PR TITLE
Improve admin book transactions

### DIFF
--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -98,9 +98,9 @@ export default {
     post(`/adminapi/v1/members/${id}/eligibilities`, data),
 
   searchPaymentInstruments: (data) =>
-    get(`/adminapi/v1/search/payment_instruments`, data),
-  searchReceivingLedger: (data) => get(`/adminapi/v1/search/receiving_ledger`, data),
-  searchLedgers: (data) => get(`/adminapi/v1/search/ledgers`, data),
+    post(`/adminapi/v1/search/payment_instruments`, data),
+  searchLedgers: (data) => post(`/adminapi/v1/search/ledgers`, data),
+  searchLedgersLookup: (data) => post(`/adminapi/v1/search/ledgers/lookup`, data),
 
   /**
    * Return an API url.

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -99,6 +99,7 @@ export default {
 
   searchPaymentInstruments: (data) =>
     get(`/adminapi/v1/search/payment_instruments`, data),
+  searchLedger: (data) => get(`/adminapi/v1/search/ledger`, data),
   searchLedgers: (data) => get(`/adminapi/v1/search/ledgers`, data),
 
   /**

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -99,7 +99,7 @@ export default {
 
   searchPaymentInstruments: (data) =>
     get(`/adminapi/v1/search/payment_instruments`, data),
-  searchLedger: (data) => get(`/adminapi/v1/search/ledger`, data),
+  searchReceivingLedger: (data) => get(`/adminapi/v1/search/ledger`, data),
   searchLedgers: (data) => get(`/adminapi/v1/search/ledgers`, data),
 
   /**

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -99,7 +99,7 @@ export default {
 
   searchPaymentInstruments: (data) =>
     get(`/adminapi/v1/search/payment_instruments`, data),
-  searchReceivingLedger: (data) => get(`/adminapi/v1/search/ledger`, data),
+  searchReceivingLedger: (data) => get(`/adminapi/v1/search/receiving_ledger`, data),
   searchLedgers: (data) => get(`/adminapi/v1/search/ledgers`, data),
 
   /**

--- a/adminapp/src/components/AutocompleteSearch.js
+++ b/adminapp/src/components/AutocompleteSearch.js
@@ -40,7 +40,7 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       autoHighlight={true}
       autoSelect={true}
       selectOnFocus={true}
-      value={defaultValue}
+      value={defaultValue || null}
       onChange={handleSelect}
       fullWidth={fullWidth}
       renderInput={(params) => (

--- a/adminapp/src/components/AutocompleteSearch.js
+++ b/adminapp/src/components/AutocompleteSearch.js
@@ -3,7 +3,7 @@ import debounce from "lodash/debounce";
 import React from "react";
 
 const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
-  { search, fullWidth, onValueSelect, ...rest },
+  { search, fullWidth, onValueSelect, defaultValue, ...rest },
   ref
 ) {
   const activePromise = React.useRef(Promise.resolve());
@@ -37,6 +37,10 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
     <Autocomplete
       freeSolo
       options={options}
+      autoHighlight={true}
+      autoSelect={true}
+      selectOnFocus={true}
+      value={defaultValue}
       onChange={handleSelect}
       fullWidth={fullWidth}
       renderInput={(params) => (

--- a/adminapp/src/components/MultiLingualText.js
+++ b/adminapp/src/components/MultiLingualText.js
@@ -1,4 +1,4 @@
-import { FormHelperText, Stack, TextField } from "@mui/material";
+import { TextField } from "@mui/material";
 import React from "react";
 
 /**
@@ -7,33 +7,25 @@ import React from "react";
  * for example adding additional TextFields for the multiple languages
  * @returns {JSX.Element}
  */
-const MultiLingualText = React.forwardRef(function MultiLingualText(
-  { value, label, helperText, onChange, ...rest },
-  ref
-) {
+export default function MultiLingualText({ value, label, onChange, ...rest }) {
   const handleOnChange = (val, language) => {
-    // There should always be an English memo translation
-    let memo = value || { en: "" };
-    memo[language] = val ? val : "";
-    onChange(memo);
+    // There should always be an English translation
+    let newValue = value || { en: "" };
+    newValue[language] = val ? val : "";
+    onChange(newValue);
   };
   return (
-    <Stack alignItems="stretch" gap={2}>
+    <>
       <TextField
         {...rest}
-        label={`En ${label}`}
+        label={`English ${label}`}
         onChange={(e) => handleOnChange(e.target.value, "en")}
       />
-      <div>
-        <TextField
-          {...rest}
-          label={`Es ${label}`}
-          onChange={(e) => handleOnChange(e.target.value, "es")}
-        />
-        <FormHelperText>{helperText}</FormHelperText>
-      </div>
-    </Stack>
+      <TextField
+        {...rest}
+        label={`Spanish ${label}`}
+        onChange={(e) => handleOnChange(e.target.value, "es")}
+      />
+    </>
   );
-});
-
-export default MultiLingualText;
+}

--- a/adminapp/src/components/MultiLingualText.js
+++ b/adminapp/src/components/MultiLingualText.js
@@ -12,28 +12,26 @@ const MultiLingualText = React.forwardRef(function MultiLingualText(
   ref
 ) {
   const handleOnChange = (val, language) => {
-    if (!val) {
-      return;
-    }
     // There should always be an English memo translation
     let memo = value || { en: "" };
-    memo[language] = val;
+    memo[language] = val ? val : "";
     onChange(memo);
   };
   return (
-    <Stack alignItems="stretch">
+    <Stack alignItems="stretch" gap={2}>
       <TextField
         {...rest}
         label={`En ${label}`}
         onChange={(e) => handleOnChange(e.target.value, "en")}
       />
-      <br />
-      <TextField
-        {...rest}
-        label={`Es ${label}`}
-        onChange={(e) => handleOnChange(e.target.value, "es")}
-      />
-      <FormHelperText>{helperText}</FormHelperText>
+      <div>
+        <TextField
+          {...rest}
+          label={`Es ${label}`}
+          onChange={(e) => handleOnChange(e.target.value, "es")}
+        />
+        <FormHelperText>{helperText}</FormHelperText>
+      </div>
     </Stack>
   );
 });

--- a/adminapp/src/components/MultiLingualText.js
+++ b/adminapp/src/components/MultiLingualText.js
@@ -1,0 +1,41 @@
+import { FormHelperText, Stack, TextField } from "@mui/material";
+import React from "react";
+
+/**
+ * Supports multiple language text fields.
+ * This component supports English and Spanish but could change in the future,
+ * for example adding additional TextFields for the multiple languages
+ * @returns {JSX.Element}
+ */
+const MultiLingualText = React.forwardRef(function MultiLingualText(
+  { value, label, helperText, onChange, ...rest },
+  ref
+) {
+  const handleOnChange = (val, language) => {
+    if (!val) {
+      return;
+    }
+    // There should always be an English memo translation
+    let memo = value || { en: "" };
+    memo[language] = val;
+    onChange(memo);
+  };
+  return (
+    <Stack alignItems="stretch">
+      <TextField
+        {...rest}
+        label={`En ${label}`}
+        onChange={(e) => handleOnChange(e.target.value, "en")}
+      />
+      <br />
+      <TextField
+        {...rest}
+        label={`Es ${label}`}
+        onChange={(e) => handleOnChange(e.target.value, "es")}
+      />
+      <FormHelperText>{helperText}</FormHelperText>
+    </Stack>
+  );
+});
+
+export default MultiLingualText;

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -1,6 +1,7 @@
 import { dayjs } from "../modules/dayConfig";
 import Money, { formatMoney } from "../shared/react/Money";
 import AdminLink from "./AdminLink";
+import Link from "./Link";
 import RelatedList from "./RelatedList";
 import map from "lodash/map";
 import React from "react";
@@ -9,11 +10,13 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
   if (!paymentAccount) {
     return null;
   }
+  // TODO: receive this from backend somehow
+  const sumaPlatformLedgerId = -1;
   return (
     <>
       <RelatedList
         title={`Ledgers - ${formatMoney(paymentAccount.totalBalance)}`}
-        headers={["Id", "Currency", "Categories", "Balance"]}
+        headers={["Id", "Currency", "Categories", "Balance", "New Transaction"]}
         rows={paymentAccount.ledgers}
         keyRowAttr="id"
         toCells={(row) => [
@@ -21,6 +24,12 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
           row.currency,
           map(row.vendorServiceCategories, "name").join(", "),
           <Money key="balance">{row.balance}</Money>,
+          <Link
+            key="transaction"
+            to={`/book-transaction/new?originatingLedgerId=${sumaPlatformLedgerId}&receivingLedgerId=${row.id}`}
+          >
+            Create Book Transaction
+          </Link>,
           row.softDeletedAt ? dayjs(row.softDeletedAt).format("lll") : "",
         ]}
       />

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -26,14 +26,14 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
           <Money key="balance">{row.balance}</Money>,
           <Link
             key="transaction"
-            to={`/book-transaction/new?receivingLedgerId=${
+            to={`/book-transaction/new?originatingLedgerId=0&receivingLedgerId=${
               row.id
             }&vendorServiceCategorySlug=${get(
               first(row.vendorServiceCategories),
               "slug"
             )}`}
           >
-            Create Book Transaction
+            Add Book Credit
           </Link>,
           row.softDeletedAt ? dayjs(row.softDeletedAt).format("lll") : "",
         ]}

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -3,6 +3,9 @@ import Money, { formatMoney } from "../shared/react/Money";
 import AdminLink from "./AdminLink";
 import Link from "./Link";
 import RelatedList from "./RelatedList";
+import first from "lodash/first";
+import get from "lodash/get";
+import lowerCase from "lodash/lowerCase";
 import map from "lodash/map";
 import React from "react";
 
@@ -24,7 +27,11 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
           <Money key="balance">{row.balance}</Money>,
           <Link
             key="transaction"
-            to={`/book-transaction/new?receivingLedgerId=${row.id}`}
+            to={`/book-transaction/new?receivingLedgerId=${
+              row.id
+            }&vendorServiceCategoryName=${lowerCase(
+              get(first(row.vendorServiceCategories), "name")
+            )}`}
           >
             Create Book Transaction
           </Link>,

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -10,8 +10,6 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
   if (!paymentAccount) {
     return null;
   }
-  // TODO: receive this from backend somehow
-  const sumaPlatformLedgerId = -1;
   return (
     <>
       <RelatedList
@@ -26,7 +24,7 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
           <Money key="balance">{row.balance}</Money>,
           <Link
             key="transaction"
-            to={`/book-transaction/new?originatingLedgerId=${sumaPlatformLedgerId}&receivingLedgerId=${row.id}`}
+            to={`/book-transaction/new?receivingLedgerId=${row.id}`}
           >
             Create Book Transaction
           </Link>,

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -5,7 +5,6 @@ import Link from "./Link";
 import RelatedList from "./RelatedList";
 import first from "lodash/first";
 import get from "lodash/get";
-import lowerCase from "lodash/lowerCase";
 import map from "lodash/map";
 import React from "react";
 
@@ -29,8 +28,9 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
             key="transaction"
             to={`/book-transaction/new?receivingLedgerId=${
               row.id
-            }&vendorServiceCategoryName=${lowerCase(
-              get(first(row.vendorServiceCategories), "name")
+            }&vendorServiceCategorySlug=${get(
+              first(row.vendorServiceCategories),
+              "slug"
             )}`}
           >
             Create Book Transaction

--- a/adminapp/src/components/VendorServiceCategorySelect.js
+++ b/adminapp/src/components/VendorServiceCategorySelect.js
@@ -4,7 +4,7 @@ import map from "lodash/map";
 import React from "react";
 
 const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCategorySelect(
-  { value, defaultValue, helperText, label, onChange, ...rest },
+  { value, defaultValue, helperText, label, className, style, onChange, ...rest },
   ref
 ) {
   const [categories, setCategories] = React.useState([{ slug: "cash", label: "Cash" }]);
@@ -26,7 +26,7 @@ const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCateg
   }, [handleChange, defaultValue]);
 
   return (
-    <FormControl>
+    <FormControl className={className} style={style}>
       {label && <InputLabel htmlFor="vscategory-select">{label}</InputLabel>}
       <Select
         id="vscategory-select"

--- a/adminapp/src/components/VendorServiceCategorySelect.js
+++ b/adminapp/src/components/VendorServiceCategorySelect.js
@@ -1,22 +1,29 @@
 import api from "../api";
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from "@mui/material";
+import map from "lodash/map";
 import React from "react";
 
 const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCategorySelect(
-  { value, helperText, label, onChange, ...rest },
+  { value, defaultValue, helperText, label, onChange, ...rest },
   ref
 ) {
   const [categories, setCategories] = React.useState([{ slug: "cash", label: "Cash" }]);
 
+  const handleChange = React.useCallback(
+    (slug) => {
+      onChange(slug);
+    },
+    [onChange]
+  );
+
   React.useEffect(() => {
     api.getVendorServiceCategories().then((r) => {
       setCategories(r.data.items);
+      if (map(r.data.items, "slug").includes(defaultValue)) {
+        handleChange(defaultValue);
+      }
     });
-  }, []);
-
-  function handleChange(e) {
-    onChange(e);
-  }
+  }, [handleChange, defaultValue]);
 
   return (
     <FormControl>
@@ -26,7 +33,7 @@ const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCateg
         ref={ref}
         value={value}
         label="Category"
-        onChange={handleChange}
+        onChange={(e) => handleChange(e.target.value)}
         {...rest}
       >
         {categories.map(({ label, slug }) => (

--- a/adminapp/src/pages/BookTransactionCreatePage.js
+++ b/adminapp/src/pages/BookTransactionCreatePage.js
@@ -23,7 +23,9 @@ export default function BookTransactionCreatePage() {
   const [receivingLedgerId, setReceivingLedgerId] = React.useState(0);
   const [amount, setAmount] = React.useState(config.defaultZeroMoney);
   const [memo, setMemo] = React.useState("");
-  const [category, setCategory] = React.useState("");
+  const [category, setCategory] = React.useState(
+    searchParams.get("vendorServiceCategoryName") || ""
+  );
   const { isBusy, busy, notBusy } = useBusy();
   const { register, handleSubmit } = useForm();
 

--- a/adminapp/src/pages/BookTransactionCreatePage.js
+++ b/adminapp/src/pages/BookTransactionCreatePage.js
@@ -39,7 +39,7 @@ export default function BookTransactionCreatePage() {
   });
 
   React.useEffect(() => {
-    if (!isEmpty(ledgerData.ledgers)) {
+    if (searchParams.get("receivingLedgerId") && !isEmpty(ledgerData.ledgers)) {
       return;
     }
     ledgerData.initializeToReceivingLedger(Number(searchParams.get("receivingLedgerId")));

--- a/adminapp/src/pages/BookTransactionCreatePage.js
+++ b/adminapp/src/pages/BookTransactionCreatePage.js
@@ -23,9 +23,7 @@ export default function BookTransactionCreatePage() {
   const [receivingLedgerId, setReceivingLedgerId] = React.useState(0);
   const [amount, setAmount] = React.useState(config.defaultZeroMoney);
   const [memo, setMemo] = React.useState("");
-  const [category, setCategory] = React.useState(
-    searchParams.get("vendorServiceCategoryName") || ""
-  );
+  const [category, setCategory] = React.useState("");
   const { isBusy, busy, notBusy } = useBusy();
   const { register, handleSubmit } = useForm();
 
@@ -87,10 +85,11 @@ export default function BookTransactionCreatePage() {
             <div>
               <VendorServiceCategorySelect
                 {...register("category")}
+                defaultValue={searchParams.get("vendorServiceCategorySlug")}
                 label="Category"
                 helperText="What can this be used for?"
                 value={category}
-                onChange={(e) => setCategory(e.target.value)}
+                onChange={(categorySlug) => setCategory(categorySlug)}
               />
             </div>
             <TextField

--- a/adminapp/src/pages/BookTransactionCreatePage.js
+++ b/adminapp/src/pages/BookTransactionCreatePage.js
@@ -8,7 +8,7 @@ import config from "../config";
 import useBusy from "../hooks/useBusy";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import useMountEffect from "../shared/react/useMountEffect";
-import { Stack, Typography } from "@mui/material";
+import { FormLabel, Stack, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import React from "react";
 import { useForm } from "react-hook-form";
@@ -36,7 +36,7 @@ export default function BookTransactionCreatePage() {
     api
       .searchLedgersLookup({
         ids: [originatingLedgerId, receivingLedgerId],
-        platformCategories: [categorySlug],
+        platformCategories: [categorySlug].filter(Boolean),
       })
       .then((r) => {
         const { byId, platformByCategory } = r.data;
@@ -55,7 +55,6 @@ export default function BookTransactionCreatePage() {
   }, [searchParams, enqueueErrorSnackbar]);
 
   function submit() {
-    console.log(memo);
     busy();
     api
       .createBookTransaction({
@@ -80,38 +79,6 @@ export default function BookTransactionCreatePage() {
       </Typography>
       <Box component="form" mt={2} onSubmit={handleSubmit(submit)}>
         <Stack spacing={2} direction="column">
-          <Stack direction="row" spacing={2} alignItems="self-start">
-            <CurrencyTextField
-              {...register("amount")}
-              label="Amount"
-              sx={{ maxWidth: "130px" }}
-              helperText="How much is going from originator to receiver?"
-              money={amount}
-              required
-              onMoneyChange={setAmount}
-            />
-            <div>
-              <VendorServiceCategorySelect
-                {...register("category")}
-                defaultValue={searchParams.get("vendorServiceCategorySlug")}
-                label="Category"
-                sx={{ maxWidth: "200px" }}
-                helperText="What can this be used for?"
-                value={category}
-                onChange={(categorySlug) => setCategory(categorySlug)}
-              />
-            </div>
-            <MultiLingualText
-              {...register("memo")}
-              label="Memo"
-              helperText="This shows on the ledger."
-              fullWidth
-              value={memo}
-              sx={{ minWidth: "300px" }}
-              required
-              onChange={(memo) => setMemo(memo)}
-            />
-          </Stack>
           <Stack direction="row" spacing={2}>
             <AutocompleteSearch
               {...register("originatingLedger")}
@@ -121,6 +88,7 @@ export default function BookTransactionCreatePage() {
               fullWidth
               required
               search={api.searchLedgers}
+              style={{ flex: 1 }}
               onValueSelect={(o) => setOriginatingLedger(o)}
             />
             <AutocompleteSearch
@@ -131,9 +99,41 @@ export default function BookTransactionCreatePage() {
               fullWidth
               required
               search={api.searchLedgers}
+              style={{ flex: 1 }}
               onValueSelect={(o) => setReceivingLedger(o)}
             />
           </Stack>
+          <Stack direction="row" spacing={2}>
+            <CurrencyTextField
+              {...register("amount")}
+              label="Amount"
+              helperText="How much is going from originator to receiver?"
+              money={amount}
+              required
+              style={{ flex: 1 }}
+              onMoneyChange={setAmount}
+            />
+            <VendorServiceCategorySelect
+              {...register("category")}
+              defaultValue={searchParams.get("vendorServiceCategorySlug")}
+              label="Category"
+              helperText="What can this be used for?"
+              value={category}
+              style={{ flex: 1 }}
+              onChange={(categorySlug) => setCategory(categorySlug)}
+            />
+          </Stack>
+          <FormLabel>Memo (appears on the ledger):</FormLabel>
+          <Stack direction="row" spacing={2}>
+            <MultiLingualText
+              label="Memo"
+              fullWidth
+              value={memo}
+              required
+              onChange={(memo) => setMemo(memo)}
+            />
+          </Stack>
+
           <FormButtons back loading={isBusy} />
         </Stack>
       </Box>

--- a/adminapp/src/shared/react/useMountEffect.js
+++ b/adminapp/src/shared/react/useMountEffect.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+/**
+ * Just a `React.useEffect(cb, [])` that is more declarative than
+ * doing it in line and disabling eslint.
+ * @param cb
+ */
+export default function useMountEffect(cb) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(cb, []);
+}

--- a/lib/suma/admin_api/book_transactions.rb
+++ b/lib/suma/admin_api/book_transactions.rb
@@ -30,7 +30,7 @@ class Suma::AdminAPI::BookTransactions < Suma::AdminAPI::V1
     params do
       requires :originating_ledger_id, type: Integer
       requires :receiving_ledger_id, type: Integer
-      requires :memo, type: String
+      requires :memo, type: JSON
       requires :vendor_service_category_slug, type: String
       requires :amount, allow_blank: false, type: JSON do
         use :money
@@ -46,7 +46,7 @@ class Suma::AdminAPI::BookTransactions < Suma::AdminAPI::V1
         originating_ledger: originating,
         receiving_ledger: receiving,
         associated_vendor_service_category: vsc,
-        memo: Suma::TranslatedText.create(all: params[:memo]),
+        memo: Suma::TranslatedText.find_or_create(**params[:memo]),
       )
       created_resource_headers(bx.id, bx.admin_link)
       status 200

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -110,6 +110,7 @@ module Suma::AdminAPI::Entities
   class VendorServiceCategoryEntity < BaseEntity
     expose :id
     expose :name
+    expose :slug
   end
 
   class ChargeEntity < BaseEntity

--- a/lib/suma/admin_api/search.rb
+++ b/lib/suma/admin_api/search.rb
@@ -11,9 +11,10 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
     params do
       optional :id, type: Integer
     end
-    get :ledger do
-      ledger = Suma::Payment::Ledger[params[:id]]
-      present ledger, with: SearchLedgerEntity
+    get :receiving_ledger do
+      receiving_ledger = Suma::Payment::Ledger[params[:id]]
+      platform_ledger = Suma::Payment::Account.lookup_platform_account.cash_ledger!
+      present receiving_ledger, with: SearchReceivingLedgerWithContextEntity, platform_ledger:
     end
 
     params do
@@ -59,6 +60,15 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
     expose :id
     expose :admin_link
     expose :search_label, as: :label
+  end
+
+  class SearchReceivingLedgerWithContextEntity < BaseEntity
+    expose :receiving_ledger, with: SearchLedgerEntity do |instance|
+      instance
+    end
+    expose :platform_ledger, with: SearchLedgerEntity do |_, opts|
+      opts.fetch(:platform_ledger)
+    end
   end
 
   class SearchPaymentInstrumentEntity < BaseEntity

--- a/lib/suma/admin_api/search.rb
+++ b/lib/suma/admin_api/search.rb
@@ -9,6 +9,14 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
 
   resource :search do
     params do
+      optional :id, type: Integer
+    end
+    get :ledger do
+      ledger = Suma::Payment::Ledger[params[:id]]
+      present ledger, with: SearchLedgerEntity
+    end
+
+    params do
       optional :q, type: String
     end
     get :ledgers do

--- a/lib/suma/admin_api/search.rb
+++ b/lib/suma/admin_api/search.rb
@@ -8,15 +8,6 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
   include Suma::AdminAPI::Entities
 
   resource :search do
-    params do
-      optional :id, type: Integer
-    end
-    get :receiving_ledger do
-      receiving_ledger = Suma::Payment::Ledger[params[:id]]
-      platform_ledger = Suma::Payment::Account.lookup_platform_account.cash_ledger!
-      present receiving_ledger, with: SearchReceivingLedgerWithContextEntity, platform_ledger:
-    end
-
     resource :ledgers do
       params do
         optional :q, type: String

--- a/spec/suma/admin_api/book_transactions_spec.rb
+++ b/spec/suma/admin_api/book_transactions_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Suma::AdminAPI::BookTransactions, :db do
            originating_ledger_id: b1.originating_ledger_id,
            receiving_ledger_id: b1.receiving_ledger_id,
            amount: {cents: 100},
-           memo: "hi",
+           memo: {en: "hello", es: "hola"},
            vendor_service_category_slug: "corn"
 
       expect(last_response).to have_status(200)
@@ -81,7 +81,7 @@ RSpec.describe Suma::AdminAPI::BookTransactions, :db do
       expect(b1.refresh.originating_ledger.combined_book_transactions).to contain_exactly(
         be === b1,
         have_attributes(
-          memo: have_attributes(en: "hi"),
+          memo: have_attributes(en: "hello", es: "hola"),
           amount: cost("$1"),
           associated_vendor_service_category: be === corn,
         ),

--- a/spec/suma/admin_api/search_spec.rb
+++ b/spec/suma/admin_api/search_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe Suma::AdminAPI::Search, :db do
     login_as_admin(admin)
   end
 
+  describe "GET /v1/search/ledger" do
+    it "returns ledger with matching id" do
+      o1 = Suma::Fixtures.ledger.create(name: "abc")
+
+      get "/v1/search/ledger", id: o1.id
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(id: o1.id)
+    end
+  end
+
   describe "GET /v1/search/ledgers" do
     it "returns matching ledgers" do
       o1 = Suma::Fixtures.ledger.create(name: "abc")

--- a/spec/suma/admin_api/search_spec.rb
+++ b/spec/suma/admin_api/search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Suma::AdminAPI::Search, :db do
   describe "GET /v1/search/ledger" do
     it "returns receiving ledger along with platform ledger" do
       receiving_ledger = Suma::Fixtures.ledger.create(name: "abc")
-      platform_cash_ledger = Suma::Fixtures::Ledgers.ensure_platform_cash
+
       get "/v1/search/receiving_ledger", id: receiving_ledger.id
 
       expect(last_response).to have_status(200)
@@ -26,24 +26,40 @@ RSpec.describe Suma::AdminAPI::Search, :db do
     end
   end
 
-  describe "GET /v1/search/ledgers" do
+  describe "POST /v1/search/ledgers" do
     it "returns matching ledgers" do
       o1 = Suma::Fixtures.ledger.create(name: "abc")
       o2 = Suma::Fixtures.ledger.create(name: "xyz")
 
-      get "/v1/search/ledgers", q: "abc"
+      post "/v1/search/ledgers", q: "abc"
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(items: have_same_ids_as(o1))
     end
   end
 
-  describe "GET /v1/search/payment_instruments" do
+  describe "POST /v1/search/ledgers/lookup" do
+    it "returns ledgers with the given ids and keys" do
+      o1 = Suma::Fixtures.ledger.create(name: "abc")
+      o2 = Suma::Fixtures.ledger.create(name: "xyz")
+      platform = Suma::Fixtures::Ledgers.ensure_platform_cash
+
+      post "/v1/search/ledgers/lookup", ids: [o1.id, -10], platform_categories: ["cash", "mobility"]
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        by_id: match("#{o1.id}": include(id: o1.id)),
+        platform_by_category: match(cash: include(id: platform.id)),
+      )
+    end
+  end
+
+  describe "POST /v1/search/payment_instruments" do
     it "returns matching payment instruments" do
       o1 = Suma::Fixtures.bank_account.verified.create(name: "abc")
       o2 = Suma::Fixtures.bank_account.verified.create(name: "xyz")
 
-      get "/v1/search/payment_instruments", q: "abc"
+      post "/v1/search/payment_instruments", q: "abc"
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(items: have_same_ids_as(o1))

--- a/spec/suma/admin_api/search_spec.rb
+++ b/spec/suma/admin_api/search_spec.rb
@@ -12,20 +12,6 @@ RSpec.describe Suma::AdminAPI::Search, :db do
     login_as_admin(admin)
   end
 
-  describe "GET /v1/search/ledger" do
-    it "returns receiving ledger along with platform ledger" do
-      receiving_ledger = Suma::Fixtures.ledger.create(name: "abc")
-
-      get "/v1/search/receiving_ledger", id: receiving_ledger.id
-
-      expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(
-        receiving_ledger: include(id: receiving_ledger.id),
-        platform_ledger: include(id: platform_cash_ledger.id),
-      )
-    end
-  end
-
   describe "POST /v1/search/ledgers" do
     it "returns matching ledgers" do
       o1 = Suma::Fixtures.ledger.create(name: "abc")

--- a/spec/suma/admin_api/search_spec.rb
+++ b/spec/suma/admin_api/search_spec.rb
@@ -13,13 +13,16 @@ RSpec.describe Suma::AdminAPI::Search, :db do
   end
 
   describe "GET /v1/search/ledger" do
-    it "returns ledger with matching id" do
-      o1 = Suma::Fixtures.ledger.create(name: "abc")
-
-      get "/v1/search/ledger", id: o1.id
+    it "returns receiving ledger along with platform ledger" do
+      receiving_ledger = Suma::Fixtures.ledger.create(name: "abc")
+      platform_cash_ledger = Suma::Fixtures::Ledgers.ensure_platform_cash
+      get "/v1/search/receiving_ledger", id: receiving_ledger.id
 
       expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(id: o1.id)
+      expect(last_response).to have_json_body.that_includes(
+        receiving_ledger: include(id: receiving_ledger.id),
+        platform_ledger: include(id: platform_cash_ledger.id),
+      )
     end
   end
 


### PR DESCRIPTION
Fixes #487 

* Add links in member detail page to create new book transaction with for individual ledgers (platformLedger is always originating ledger)
* Add API to return receiving ledger information along with Platform cash ledger information
* When click those links, new book transaction page renders ledger inputs based on the passed ledger params
* Add backend tests

* Ability to pre-fill vendor service category sent as a URL param from the member details page

### Member detail page links - URL params
<img width="835" alt="Screenshot 2023-08-24 at 5 08 14 PM" src="https://github.com/lithictech/suma/assets/66847768/b946c73c-62a6-4edd-ad19-587f39a4f5c2">

### Create book transaction pre-filled information from URL params
<img width="794" alt="Screenshot 2023-08-24 at 5 11 31 PM" src="https://github.com/lithictech/suma/assets/66847768/f88e198b-e5b2-4a3f-995b-b6837317e124">

