### PR TITLE
Checkout instrument save

### DIFF
--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -76,6 +76,7 @@ class Suma::API::Commerce < Suma::API::V1
               cart:,
               fulfillment_option: offering.fulfillment_options.first,
               payment_instrument: member.default_payment_instrument,
+              save_payment_instrument: member.default_payment_instrument.present?,
             )
             cart_items = cart.items.select(&:available?)
             merror!(409, "no items in cart", code: "checkout_no_items") if cart_items.empty?

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -190,7 +190,7 @@ function CheckoutPayment({
                 id="savePayment"
                 name="savePayment"
                 label={t("food:save_payment")}
-                defaultChecked={checkout.paymentInstrument}
+                checked={checkout.savePaymentInstrument}
                 onChange={(e) =>
                   onCheckoutChange({ savePaymentInstrument: e.target.checked })
                 }

--- a/webapp/src/pages/FoodCheckout.js
+++ b/webapp/src/pages/FoodCheckout.js
@@ -190,6 +190,7 @@ function CheckoutPayment({
                 id="savePayment"
                 name="savePayment"
                 label={t("food:save_payment")}
+                defaultChecked={checkout.paymentInstrument}
                 onChange={(e) =>
                   onCheckoutChange({ savePaymentInstrument: e.target.checked })
                 }

--- a/webapp/src/pages/FoodCheckoutConfirmation.js
+++ b/webapp/src/pages/FoodCheckoutConfirmation.js
@@ -1,5 +1,6 @@
 import api from "../api";
 import ErrorScreen from "../components/ErrorScreen";
+import FormButtons from "../components/FormButtons";
 import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
 import SumaImage from "../components/SumaImage";
@@ -8,7 +9,6 @@ import useAsyncFetch from "../shared/react/useAsyncFetch";
 import { LayoutContainer } from "../state/withLayout";
 import React from "react";
 import { Alert } from "react-bootstrap";
-import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Stack from "react-bootstrap/Stack";
 import { useLocation, useParams } from "react-router-dom";
@@ -58,11 +58,16 @@ export default function FoodCheckoutConfirmation() {
         <p>{fulfillmentOption.description}</p>
         <hr />
         {mdp("food:confirmation_message", { check: false })}
-        <Stack className="mt-2">
-          <Button variant="outline-success" href="/dashboard" as={RLink}>
-            {t("common:go_home")}
-          </Button>
-        </Stack>
+        <FormButtons
+          className="mt-2"
+          primaryProps={{
+            type: "button",
+            variant: "outline-secondary",
+            children: t("common:go_home"),
+            href: "/dashboard",
+            as: RLink,
+          }}
+        />
       </LayoutContainer>
     </>
   );

--- a/webapp/src/pages/UnclaimedOrderList.js
+++ b/webapp/src/pages/UnclaimedOrderList.js
@@ -67,9 +67,9 @@ export default function UnclaimedOrderList() {
                 fulfilledAt: dayjs(claimedOrder.fulfilledAt).format("lll"),
               })}
             </p>
-            {claimedOrder?.items?.map(({ image, id, name, customerPrice, quantity }) => (
-              <Stack key={name} gap={3}>
-                <Card>
+            <Stack gap={3}>
+              {claimedOrder?.items?.map(({ image, name, customerPrice, quantity }) => (
+                <Card key={name}>
                   <Card.Body>
                     <Stack direction="horizontal" gap={3} className="align-items-start">
                       <SumaImage
@@ -90,8 +90,8 @@ export default function UnclaimedOrderList() {
                     </Stack>
                   </Card.Body>
                 </Card>
-              </Stack>
-            ))}
+              ))}
+            </Stack>
             <div className="mt-2">
               <FormButtons
                 primaryProps={{


### PR DESCRIPTION
Fixes #494
- Default save payment checkbox if there's the member has a default payment instrument (when creating checkout)

This avoids inconsistent `checkout.save_payment_instrument` state when reloading the `FoodCheckout` page.

When adding an payment instrument in `FoodCheckout`, then going back to `FoodCart` and clicking "Continue to checkout" will default `save_payment_instrument` to true because we create a new Checkout table with updated column values with an existing payment method

---

- Refactor checkout confirmation button layout
- Fix claimed order confirmation layout

### Claimed order confirmation layout fix
<img width="501" alt="Screenshot 2023-08-28 at 2 21 25 PM" src="https://github.com/lithictech/suma/assets/66847768/f9cf73b1-84f9-4738-983a-cdd64fb60556">

### Checkout confirmation button layout refactor
<img width="501" alt="Screenshot 2023-08-28 at 2 44 54 PM" src="https://github.com/lithictech/suma/assets/66847768/afdab424-4783-4913-9fdd-8a5134061568">
