### PR TITLE
Fix area restrictions bug

### DIFF
--- a/db/migrations/034_restricted_mobility_area_not_nullable.rb
+++ b/db/migrations/034_restricted_mobility_area_not_nullable.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-  change do
+  up do
+    from(:mobility_restricted_areas).where(restriction: nil).delete
     alter_table(:mobility_restricted_areas) do
       set_column_not_null :restriction
+    end
+  end
+
+  down do
+    alter_table(:mobility_restricted_areas) do
+      set_column_allow_null :restriction
     end
   end
 end

--- a/db/migrations/034_restricted_mobility_area_not_nullable.rb
+++ b/db/migrations/034_restricted_mobility_area_not_nullable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:mobility_restricted_areas) do
+      set_column_not_null :restriction
+    end
+  end
+end

--- a/lib/suma/mobility/gbfs/geofencing_zone.rb
+++ b/lib/suma/mobility/gbfs/geofencing_zone.rb
@@ -24,10 +24,11 @@ class Suma::Mobility::Gbfs::GeofencingZone < Suma::Mobility::Gbfs::ComponentSync
                         "do-not-park-or-ride"
         elsif rule["ride_allowed"] == false
           "do-not-park"
-          elsif rule["ride_through_allowed"] == false
-            "do-not-ride"
+        elsif rule["ride_through_allowed"] == false
+          "do-not-ride"
         end
       end
+      next if restriction.nil?
 
       f["geometry"]["coordinates"].each do |polyline|
         polyline.each do |lng_lat|
@@ -42,8 +43,8 @@ class Suma::Mobility::Gbfs::GeofencingZone < Suma::Mobility::Gbfs::ComponentSync
         title: unique_id,
         vendor_service:,
         multipolygon: coords,
+        restriction:,
       )
-      row.restriction = restriction if restriction.present?
       row.before_save
       yield row.values
     end

--- a/lib/suma/mobility/restricted_area.rb
+++ b/lib/suma/mobility/restricted_area.rb
@@ -78,6 +78,7 @@ class Suma::Mobility::RestrictedArea < Suma::Postgres::Model(:mobility_restricte
     elsif polygon.first != polygon.last
       self.errors.add(:multipolygon, "first and last coordinate must match (closed polygon)")
     end
+    self.validates_includes RESTRICTIONS, :restriction
   end
 end
 

--- a/spec/suma/mobility/gbfs/geofencing_zone_spec.rb
+++ b/spec/suma/mobility/gbfs/geofencing_zone_spec.rb
@@ -182,6 +182,13 @@ RSpec.describe Suma::Mobility::Gbfs::GeofencingZone, :db do
         ),
       )
     end
+
+    it "should not be created when no restrictions are determined by the rules" do
+      fake_geofencing_json["data"]["geofencing_zones"]["features"][0]["properties"]["rules"][0]["ride_allowed"] = true
+
+      Suma::Mobility::Gbfs::VendorSync.new(client:, vendor:, component: described_class.new).sync_all
+      expect(Suma::Mobility::RestrictedArea.all).to be_empty
+    end
   end
 
   it "sets correct zone restriction based on rules" do

--- a/spec/suma/mobility/gbfs/geofencing_zone_spec.rb
+++ b/spec/suma/mobility/gbfs/geofencing_zone_spec.rb
@@ -168,6 +168,19 @@ RSpec.describe Suma::Mobility::Gbfs::GeofencingZone, :db do
         have_attributes(
           title: "NE 24th/NE Knott",
           unique_id: "NE 24th/NE Knott",
+          restriction: "do-not-park",
+        ),
+      )
+    end
+
+    it "uses all vehicle type ids if none are in the rules" do
+      fake_geofencing_json["data"]["geofencing_zones"]["features"][0]["properties"]["rules"][0].delete "vehicle_type_id"
+      Suma::Mobility::Gbfs::VendorSync.new(client:, vendor:, component: described_class.new).sync_all
+      expect(Suma::Mobility::RestrictedArea.all).to contain_exactly(
+        have_attributes(
+          title: "NE 24th/NE Knott",
+          unique_id: "NE 24th/NE Knott",
+          restriction: "do-not-park",
         ),
       )
     end
@@ -183,7 +196,7 @@ RSpec.describe Suma::Mobility::Gbfs::GeofencingZone, :db do
       )
     end
 
-    it "should not be created when no restrictions are determined by the rules" do
+    it "does not create restricted areas for zones that are not handled" do
       fake_geofencing_json["data"]["geofencing_zones"]["features"][0]["properties"]["rules"][0]["ride_allowed"] = true
 
       Suma::Mobility::Gbfs::VendorSync.new(client:, vendor:, component: described_class.new).sync_all

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -313,7 +313,7 @@ export default class MapBuilder {
     }
     const popup = this._l.popup({
       direction: "top",
-      offset: [0, -5],
+      offset: [0, 10],
     });
     const parkingRestrictionContent = `<h6 class='mb-0'>${t(
       "mobility:do_not_park_title"

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -329,28 +329,14 @@ export default class MapBuilder {
     } else if (restriction.startsWith("do-not-ride")) {
       popup.setContent(ridingRestrictionContent);
     }
-
-    const restrictedIcon = this._l.divIcon({
-      iconAnchor: [12, 12],
-      iconSize: [24, 24],
-      className: "mobility-restricted-area-icon",
-      html: "<i class='bi bi-slash-circle'></i>",
-    });
-    const restrictionMarker = this._l
-      .marker(this._l.latLngBounds(latlngs).getCenter(), {
-        icon: restrictedIcon,
-      })
-      .bindPopup(popup);
-    const restrictionPolygon = this._l
+    return this._l
       .polygon([latlngs], {
+        id: id,
         fillOpacity: 0.25,
         color: "#b53d00",
         weight: 1,
       })
-      .on("click", () => {
-        restrictionMarker.openPopup();
-      });
-    return this._l.layerGroup([restrictionMarker, restrictionPolygon], { id });
+      .bindPopup(popup);
   }
 
   stopRefreshTimer() {

--- a/webapp/src/modules/mapBuilder.js
+++ b/webapp/src/modules/mapBuilder.js
@@ -301,11 +301,16 @@ export default class MapBuilder {
         latlngs: r.multipolygon,
         restriction: r.restriction,
       });
-      group.addLayer(restrictedAreaLayer);
+      if (restrictedAreaLayer) {
+        group.addLayer(restrictedAreaLayer);
+      }
     });
   }
 
   createRestrictedArea({ id, latlngs, restriction }) {
+    if (!id || !latlngs || !restriction) {
+      return;
+    }
     const popup = this._l.popup({
       direction: "top",
       offset: [0, -5],


### PR DESCRIPTION
Fixes #491 fixes #386 (by getting rid of centroid) fixes #493

* Create migration to ensure mobilty area `restriction` column are not nullable
* When fetching mobility areas, limit to those who have a determined restriction, otherwise omit
* UI map restriction areas are conditionally rendered to avoid any rendering bugs

---

- UI map Restriction area popups appears where it was clicked, instead of in a centered marker

### Refactored restriction area popup
<img width="497" alt="Screenshot 2023-08-28 at 6 15 04 PM" src="https://github.com/lithictech/suma/assets/66847768/26b46121-ebb5-400e-b142-5a25687b643d">
