### PR TITLE
Redirect member to link after login

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -101,378 +101,374 @@ function RerenderOnLangChange({ children }) {
 
 function InnerApp() {
   const { i18nextLoading } = useI18Next();
-  return i18nextLoading ? (
-    <ScreenLoader show />
-  ) : (
-    <Router basename={process.env.PUBLIC_URL}>
-      <AppRoutes />
-    </Router>
-  );
+  return i18nextLoading ? <ScreenLoader show /> : <AppRoutes />;
 }
 
 function AppRoutes() {
   return (
-    <Routes>
-      <Route
-        path="/"
-        exact
-        element={renderWithHocs(
-          redirectIfAuthed,
-          withMetatags({ title: t("common:welcome_to_suma"), exact: true }),
-          withLayout({ nav: "none", bg: "bg-white" }),
-          Home
-        )}
-      />
-      <Route
-        path="/privacy-policy"
-        exact
-        element={renderWithHocs(withLayout({ noScrollTop: true }), PrivacyPolicy)}
-      />
-      <Route
-        path="/privacy-policy-content"
-        exact
-        element={renderWithHocs(PrivacyPolicyContent)}
-      />
-      <Route
-        path="/terms-of-use"
-        exact
-        element={renderWithHocs(
-          withProps({ namespace: "terms_of_use" }),
-          MarkdownContent
-        )}
-      />
-      <Route
-        path="/terms-of-sale-holiday-2022"
-        exact
-        element={renderWithHocs(
-          withProps({ namespace: "terms_of_sale_holiday_2022" }),
-          MarkdownContent
-        )}
-      />
-      <Route
-        path="/terms-of-sale-summer-2023"
-        exact
-        element={renderWithHocs(
-          withProps({ namespace: "terms_of_sale_summer_2023" }),
-          MarkdownContent
-        )}
-      />
+    <Router basename={process.env.PUBLIC_URL}>
+      <Routes>
+        <Route
+          path="/"
+          exact
+          element={renderWithHocs(
+            redirectIfAuthed,
+            withMetatags({ title: t("common:welcome_to_suma"), exact: true }),
+            withLayout({ nav: "none", bg: "bg-white" }),
+            Home
+          )}
+        />
+        <Route
+          path="/privacy-policy"
+          exact
+          element={renderWithHocs(withLayout({ noScrollTop: true }), PrivacyPolicy)}
+        />
+        <Route
+          path="/privacy-policy-content"
+          exact
+          element={renderWithHocs(PrivacyPolicyContent)}
+        />
+        <Route
+          path="/terms-of-use"
+          exact
+          element={renderWithHocs(
+            withProps({ namespace: "terms_of_use" }),
+            MarkdownContent
+          )}
+        />
+        <Route
+          path="/terms-of-sale-holiday-2022"
+          exact
+          element={renderWithHocs(
+            withProps({ namespace: "terms_of_sale_holiday_2022" }),
+            MarkdownContent
+          )}
+        />
+        <Route
+          path="/terms-of-sale-summer-2023"
+          exact
+          element={renderWithHocs(
+            withProps({ namespace: "terms_of_sale_summer_2023" }),
+            MarkdownContent
+          )}
+        />
 
-      <Route
-        path="/start"
-        exact
-        element={renderWithHocs(
-          redirectIfAuthed,
-          withMetatags({ title: t("titles:start") }),
-          withLayout({ gutters: true, top: true }),
-          Start
-        )}
-      />
-      <Route
-        path="/one-time-password"
-        exact
-        element={renderWithHocs(
-          redirectIfAuthed,
-          withMetatags({ title: t("titles:otp") }),
-          withLayout({ gutters: true, top: true }),
-          OneTimePassword
-        )}
-      />
-      <Route
-        path="/onboarding"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfBoarded,
-          withMetatags({ title: t("titles:onboarding") }),
-          withLayout({}),
-          Onboarding
-        )}
-      />
-      <Route
-        path="/onboarding/signup"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfBoarded,
-          withMetatags({ title: t("titles:onboarding_signup") }),
-          withLayout({ gutters: true, top: true }),
-          OnboardingSignup
-        )}
-      />
-      <Route
-        path="/onboarding/finish"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          withMetatags({ title: t("titles:onboarding_finish") }),
-          withLayout({ gutters: true, top: true }),
-          OnboardingFinish
-        )}
-      />
-      <Route
-        path="/contact-list"
-        exact
-        element={renderWithHocs(
-          redirectIfAuthed,
-          withMetatags({ title: t("titles:contact_list"), exact: true }),
-          withLayout({ nav: "none", bg: "bg-white" }),
-          ContactListHome
-        )}
-      />
-      <Route
-        path="/contact-list/add"
-        exact
-        element={renderWithHocs(
-          redirectIfAuthed,
-          withMetatags({ title: t("titles:contact_list_signup") }),
-          withLayout({ gutters: true, top: true }),
-          ContactListAdd
-        )}
-      />
-      <Route
-        path="/contact-list/success"
-        exact
-        element={renderWithHocs(
-          redirectIfAuthed,
-          withMetatags({ title: t("titles:contact_list_finish") }),
-          withLayout({ gutters: true, top: true }),
-          ContactListSuccess
-        )}
-      />
-      <Route
-        path="/dashboard"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("titles:dashboard") }),
-          withLayout({ appNav: true }),
-          Dashboard
-        )}
-      />
-      <Route
-        path="/mobility"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("mobility:title") }),
-          withLayout({ noBottom: true, appNav: true }),
-          Mobility
-        )}
-      />
-      <Route
-        path="/food"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("food:title") }),
-          withLayout({ gutters: false, top: false, appNav: true }),
-          Food
-        )}
-      />
-      <Route
-        path="/food/:id"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("food:title") }),
-          withLayout({ gutters: false, top: false, appNav: true }),
-          FoodList
-        )}
-      />
-      <Route
-        path="/product/:offeringId/:productId"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("food:title") }),
-          withLayout({ gutters: false, top: false }),
-          FoodDetails
-        )}
-      />
-      <Route
-        path="/cart/:id"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("food:cart_title") }),
-          withLayout({ gutters: false, top: true }),
-          FoodCart
-        )}
-      />
-      <Route
-        path="/checkout/:id"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("food:checkout") }),
-          withLayout({ gutters: false, top: true }),
-          FoodCheckout
-        )}
-      />
-      <Route
-        path="/checkout/:id/confirmation"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("food:checkout") }),
-          withLayout({ appNav: true, gutters: false }),
-          FoodCheckoutConfirmation
-        )}
-      />
+        <Route
+          path="/start"
+          exact
+          element={renderWithHocs(
+            redirectIfAuthed,
+            withMetatags({ title: t("titles:start") }),
+            withLayout({ gutters: true, top: true }),
+            Start
+          )}
+        />
+        <Route
+          path="/one-time-password"
+          exact
+          element={renderWithHocs(
+            redirectIfAuthed,
+            withMetatags({ title: t("titles:otp") }),
+            withLayout({ gutters: true, top: true }),
+            OneTimePassword
+          )}
+        />
+        <Route
+          path="/onboarding"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfBoarded,
+            withMetatags({ title: t("titles:onboarding") }),
+            withLayout({}),
+            Onboarding
+          )}
+        />
+        <Route
+          path="/onboarding/signup"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfBoarded,
+            withMetatags({ title: t("titles:onboarding_signup") }),
+            withLayout({ gutters: true, top: true }),
+            OnboardingSignup
+          )}
+        />
+        <Route
+          path="/onboarding/finish"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            withMetatags({ title: t("titles:onboarding_finish") }),
+            withLayout({ gutters: true, top: true }),
+            OnboardingFinish
+          )}
+        />
+        <Route
+          path="/contact-list"
+          exact
+          element={renderWithHocs(
+            redirectIfAuthed,
+            withMetatags({ title: t("titles:contact_list"), exact: true }),
+            withLayout({ nav: "none", bg: "bg-white" }),
+            ContactListHome
+          )}
+        />
+        <Route
+          path="/contact-list/add"
+          exact
+          element={renderWithHocs(
+            redirectIfAuthed,
+            withMetatags({ title: t("titles:contact_list_signup") }),
+            withLayout({ gutters: true, top: true }),
+            ContactListAdd
+          )}
+        />
+        <Route
+          path="/contact-list/success"
+          exact
+          element={renderWithHocs(
+            redirectIfAuthed,
+            withMetatags({ title: t("titles:contact_list_finish") }),
+            withLayout({ gutters: true, top: true }),
+            ContactListSuccess
+          )}
+        />
+        <Route
+          path="/dashboard"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:dashboard") }),
+            withLayout({ appNav: true }),
+            Dashboard
+          )}
+        />
+        <Route
+          path="/mobility"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("mobility:title") }),
+            withLayout({ noBottom: true, appNav: true }),
+            Mobility
+          )}
+        />
+        <Route
+          path="/food"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("food:title") }),
+            withLayout({ gutters: false, top: false, appNav: true }),
+            Food
+          )}
+        />
+        <Route
+          path="/food/:id"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("food:title") }),
+            withLayout({ gutters: false, top: false, appNav: true }),
+            FoodList
+          )}
+        />
+        <Route
+          path="/product/:offeringId/:productId"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("food:title") }),
+            withLayout({ gutters: false, top: false }),
+            FoodDetails
+          )}
+        />
+        <Route
+          path="/cart/:id"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("food:cart_title") }),
+            withLayout({ gutters: false, top: true }),
+            FoodCart
+          )}
+        />
+        <Route
+          path="/checkout/:id"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("food:checkout") }),
+            withLayout({ gutters: false, top: true }),
+            FoodCheckout
+          )}
+        />
+        <Route
+          path="/checkout/:id/confirmation"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("food:checkout") }),
+            withLayout({ appNav: true, gutters: false }),
+            FoodCheckoutConfirmation
+          )}
+        />
 
-      <Route
-        path="/utilities"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("utilities:title") }),
-          withLayout({ appNav: true }),
-          Utilities
-        )}
-      />
-      <Route
-        path="/funding"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("titles:funding") }),
-          withLayout({ top: true, gutters: true }),
-          Funding
-        )}
-      />
-      <Route
-        path="/link-bank-account"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("payments:link_bank_account") }),
-          withLayout({ top: true, gutters: true }),
-          FundingLinkBankAccount
-        )}
-      />
-      <Route
-        path="/add-card"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("payments:add_card") }),
-          withLayout({ top: true, gutters: true }),
-          FundingAddCard
-        )}
-      />
-      <Route
-        path="/add-funds"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("payments:add_funds") }),
-          withLayout({ top: true, gutters: true }),
-          FundingAddFunds
-        )}
-      />
-      <Route
-        path="/ledgers"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("titles:ledgers_overview") }),
-          withLayout(),
-          LedgersOverview
-        )}
-      />
-      <Route
-        path="/order-history"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("titles:order_history") }),
-          withLayout(),
-          OrderHistoryList
-        )}
-      />
-      <Route
-        path="/unclaimed-orders"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("food:unclaimed_order_history_title") }),
-          withLayout(),
-          UnclaimedOrderList
-        )}
-      />
-      <Route
-        path="/order/:id"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("titles:order") }),
-          withLayout(),
-          OrderHistoryDetail
-        )}
-      />
-      <Route
-        path="/private-accounts"
-        exact
-        element={renderWithHocs(
-          redirectIfUnauthed,
-          redirectIfUnboarded,
-          withScreenLoaderMount(),
-          withMetatags({ title: t("titles:private_accounts") }),
-          withLayout(),
-          PrivateAccountsList
-        )}
-      />
-      <Route
-        path="/error"
-        exact
-        element={renderWithHocs(
-          withMetatags({ title: t("common:error") }),
-          withLayout(),
-          () => (
-            <div className="mt-4">
-              <ErrorScreen />
-            </div>
-          )
-        )}
-      />
-      <Route path="/styleguide" exact element={<Styleguide />} />
-      <Route path="/*" element={<Redirect to="/" />} />
-    </Routes>
+        <Route
+          path="/utilities"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("utilities:title") }),
+            withLayout({ appNav: true }),
+            Utilities
+          )}
+        />
+        <Route
+          path="/funding"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:funding") }),
+            withLayout({ top: true, gutters: true }),
+            Funding
+          )}
+        />
+        <Route
+          path="/link-bank-account"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("payments:link_bank_account") }),
+            withLayout({ top: true, gutters: true }),
+            FundingLinkBankAccount
+          )}
+        />
+        <Route
+          path="/add-card"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("payments:add_card") }),
+            withLayout({ top: true, gutters: true }),
+            FundingAddCard
+          )}
+        />
+        <Route
+          path="/add-funds"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("payments:add_funds") }),
+            withLayout({ top: true, gutters: true }),
+            FundingAddFunds
+          )}
+        />
+        <Route
+          path="/ledgers"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:ledgers_overview") }),
+            withLayout(),
+            LedgersOverview
+          )}
+        />
+        <Route
+          path="/order-history"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:order_history") }),
+            withLayout(),
+            OrderHistoryList
+          )}
+        />
+        <Route
+          path="/unclaimed-orders"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("food:unclaimed_order_history_title") }),
+            withLayout(),
+            UnclaimedOrderList
+          )}
+        />
+        <Route
+          path="/order/:id"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:order") }),
+            withLayout(),
+            OrderHistoryDetail
+          )}
+        />
+        <Route
+          path="/private-accounts"
+          exact
+          element={renderWithHocs(
+            redirectIfUnauthed,
+            redirectIfUnboarded,
+            withScreenLoaderMount(),
+            withMetatags({ title: t("titles:private_accounts") }),
+            withLayout(),
+            PrivateAccountsList
+          )}
+        />
+        <Route
+          path="/error"
+          exact
+          element={renderWithHocs(
+            withMetatags({ title: t("common:error") }),
+            withLayout(),
+            () => (
+              <div className="mt-4">
+                <ErrorScreen />
+              </div>
+            )
+          )}
+        />
+        <Route path="/styleguide" exact element={<Styleguide />} />
+        <Route path="/*" element={<Redirect to="/" />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -101,374 +101,378 @@ function RerenderOnLangChange({ children }) {
 
 function InnerApp() {
   const { i18nextLoading } = useI18Next();
-  return i18nextLoading ? <ScreenLoader show /> : <AppRoutes />;
+  return i18nextLoading ? (
+    <ScreenLoader show />
+  ) : (
+    <Router basename={process.env.PUBLIC_URL}>
+      <AppRoutes />
+    </Router>
+  );
 }
 
 function AppRoutes() {
   return (
-    <Router basename={process.env.PUBLIC_URL}>
-      <Routes>
-        <Route
-          path="/"
-          exact
-          element={renderWithHocs(
-            redirectIfAuthed,
-            withMetatags({ title: t("common:welcome_to_suma"), exact: true }),
-            withLayout({ nav: "none", bg: "bg-white" }),
-            Home
-          )}
-        />
-        <Route
-          path="/privacy-policy"
-          exact
-          element={renderWithHocs(withLayout({ noScrollTop: true }), PrivacyPolicy)}
-        />
-        <Route
-          path="/privacy-policy-content"
-          exact
-          element={renderWithHocs(PrivacyPolicyContent)}
-        />
-        <Route
-          path="/terms-of-use"
-          exact
-          element={renderWithHocs(
-            withProps({ namespace: "terms_of_use" }),
-            MarkdownContent
-          )}
-        />
-        <Route
-          path="/terms-of-sale-holiday-2022"
-          exact
-          element={renderWithHocs(
-            withProps({ namespace: "terms_of_sale_holiday_2022" }),
-            MarkdownContent
-          )}
-        />
-        <Route
-          path="/terms-of-sale-summer-2023"
-          exact
-          element={renderWithHocs(
-            withProps({ namespace: "terms_of_sale_summer_2023" }),
-            MarkdownContent
-          )}
-        />
+    <Routes>
+      <Route
+        path="/"
+        exact
+        element={renderWithHocs(
+          redirectIfAuthed,
+          withMetatags({ title: t("common:welcome_to_suma"), exact: true }),
+          withLayout({ nav: "none", bg: "bg-white" }),
+          Home
+        )}
+      />
+      <Route
+        path="/privacy-policy"
+        exact
+        element={renderWithHocs(withLayout({ noScrollTop: true }), PrivacyPolicy)}
+      />
+      <Route
+        path="/privacy-policy-content"
+        exact
+        element={renderWithHocs(PrivacyPolicyContent)}
+      />
+      <Route
+        path="/terms-of-use"
+        exact
+        element={renderWithHocs(
+          withProps({ namespace: "terms_of_use" }),
+          MarkdownContent
+        )}
+      />
+      <Route
+        path="/terms-of-sale-holiday-2022"
+        exact
+        element={renderWithHocs(
+          withProps({ namespace: "terms_of_sale_holiday_2022" }),
+          MarkdownContent
+        )}
+      />
+      <Route
+        path="/terms-of-sale-summer-2023"
+        exact
+        element={renderWithHocs(
+          withProps({ namespace: "terms_of_sale_summer_2023" }),
+          MarkdownContent
+        )}
+      />
 
-        <Route
-          path="/start"
-          exact
-          element={renderWithHocs(
-            redirectIfAuthed,
-            withMetatags({ title: t("titles:start") }),
-            withLayout({ gutters: true, top: true }),
-            Start
-          )}
-        />
-        <Route
-          path="/one-time-password"
-          exact
-          element={renderWithHocs(
-            redirectIfAuthed,
-            withMetatags({ title: t("titles:otp") }),
-            withLayout({ gutters: true, top: true }),
-            OneTimePassword
-          )}
-        />
-        <Route
-          path="/onboarding"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfBoarded,
-            withMetatags({ title: t("titles:onboarding") }),
-            withLayout({}),
-            Onboarding
-          )}
-        />
-        <Route
-          path="/onboarding/signup"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfBoarded,
-            withMetatags({ title: t("titles:onboarding_signup") }),
-            withLayout({ gutters: true, top: true }),
-            OnboardingSignup
-          )}
-        />
-        <Route
-          path="/onboarding/finish"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            withMetatags({ title: t("titles:onboarding_finish") }),
-            withLayout({ gutters: true, top: true }),
-            OnboardingFinish
-          )}
-        />
-        <Route
-          path="/contact-list"
-          exact
-          element={renderWithHocs(
-            redirectIfAuthed,
-            withMetatags({ title: t("titles:contact_list"), exact: true }),
-            withLayout({ nav: "none", bg: "bg-white" }),
-            ContactListHome
-          )}
-        />
-        <Route
-          path="/contact-list/add"
-          exact
-          element={renderWithHocs(
-            redirectIfAuthed,
-            withMetatags({ title: t("titles:contact_list_signup") }),
-            withLayout({ gutters: true, top: true }),
-            ContactListAdd
-          )}
-        />
-        <Route
-          path="/contact-list/success"
-          exact
-          element={renderWithHocs(
-            redirectIfAuthed,
-            withMetatags({ title: t("titles:contact_list_finish") }),
-            withLayout({ gutters: true, top: true }),
-            ContactListSuccess
-          )}
-        />
-        <Route
-          path="/dashboard"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("titles:dashboard") }),
-            withLayout({ appNav: true }),
-            Dashboard
-          )}
-        />
-        <Route
-          path="/mobility"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("mobility:title") }),
-            withLayout({ noBottom: true, appNav: true }),
-            Mobility
-          )}
-        />
-        <Route
-          path="/food"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("food:title") }),
-            withLayout({ gutters: false, top: false, appNav: true }),
-            Food
-          )}
-        />
-        <Route
-          path="/food/:id"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("food:title") }),
-            withLayout({ gutters: false, top: false, appNav: true }),
-            FoodList
-          )}
-        />
-        <Route
-          path="/product/:offeringId/:productId"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("food:title") }),
-            withLayout({ gutters: false, top: false }),
-            FoodDetails
-          )}
-        />
-        <Route
-          path="/cart/:id"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("food:cart_title") }),
-            withLayout({ gutters: false, top: true }),
-            FoodCart
-          )}
-        />
-        <Route
-          path="/checkout/:id"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("food:checkout") }),
-            withLayout({ gutters: false, top: true }),
-            FoodCheckout
-          )}
-        />
-        <Route
-          path="/checkout/:id/confirmation"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("food:checkout") }),
-            withLayout({ appNav: true, gutters: false }),
-            FoodCheckoutConfirmation
-          )}
-        />
+      <Route
+        path="/start"
+        exact
+        element={renderWithHocs(
+          redirectIfAuthed,
+          withMetatags({ title: t("titles:start") }),
+          withLayout({ gutters: true, top: true }),
+          Start
+        )}
+      />
+      <Route
+        path="/one-time-password"
+        exact
+        element={renderWithHocs(
+          redirectIfAuthed,
+          withMetatags({ title: t("titles:otp") }),
+          withLayout({ gutters: true, top: true }),
+          OneTimePassword
+        )}
+      />
+      <Route
+        path="/onboarding"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfBoarded,
+          withMetatags({ title: t("titles:onboarding") }),
+          withLayout({}),
+          Onboarding
+        )}
+      />
+      <Route
+        path="/onboarding/signup"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfBoarded,
+          withMetatags({ title: t("titles:onboarding_signup") }),
+          withLayout({ gutters: true, top: true }),
+          OnboardingSignup
+        )}
+      />
+      <Route
+        path="/onboarding/finish"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withMetatags({ title: t("titles:onboarding_finish") }),
+          withLayout({ gutters: true, top: true }),
+          OnboardingFinish
+        )}
+      />
+      <Route
+        path="/contact-list"
+        exact
+        element={renderWithHocs(
+          redirectIfAuthed,
+          withMetatags({ title: t("titles:contact_list"), exact: true }),
+          withLayout({ nav: "none", bg: "bg-white" }),
+          ContactListHome
+        )}
+      />
+      <Route
+        path="/contact-list/add"
+        exact
+        element={renderWithHocs(
+          redirectIfAuthed,
+          withMetatags({ title: t("titles:contact_list_signup") }),
+          withLayout({ gutters: true, top: true }),
+          ContactListAdd
+        )}
+      />
+      <Route
+        path="/contact-list/success"
+        exact
+        element={renderWithHocs(
+          redirectIfAuthed,
+          withMetatags({ title: t("titles:contact_list_finish") }),
+          withLayout({ gutters: true, top: true }),
+          ContactListSuccess
+        )}
+      />
+      <Route
+        path="/dashboard"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("titles:dashboard") }),
+          withLayout({ appNav: true }),
+          Dashboard
+        )}
+      />
+      <Route
+        path="/mobility"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("mobility:title") }),
+          withLayout({ noBottom: true, appNav: true }),
+          Mobility
+        )}
+      />
+      <Route
+        path="/food"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("food:title") }),
+          withLayout({ gutters: false, top: false, appNav: true }),
+          Food
+        )}
+      />
+      <Route
+        path="/food/:id"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("food:title") }),
+          withLayout({ gutters: false, top: false, appNav: true }),
+          FoodList
+        )}
+      />
+      <Route
+        path="/product/:offeringId/:productId"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("food:title") }),
+          withLayout({ gutters: false, top: false }),
+          FoodDetails
+        )}
+      />
+      <Route
+        path="/cart/:id"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("food:cart_title") }),
+          withLayout({ gutters: false, top: true }),
+          FoodCart
+        )}
+      />
+      <Route
+        path="/checkout/:id"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("food:checkout") }),
+          withLayout({ gutters: false, top: true }),
+          FoodCheckout
+        )}
+      />
+      <Route
+        path="/checkout/:id/confirmation"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("food:checkout") }),
+          withLayout({ appNav: true, gutters: false }),
+          FoodCheckoutConfirmation
+        )}
+      />
 
-        <Route
-          path="/utilities"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("utilities:title") }),
-            withLayout({ appNav: true }),
-            Utilities
-          )}
-        />
-        <Route
-          path="/funding"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("titles:funding") }),
-            withLayout({ top: true, gutters: true }),
-            Funding
-          )}
-        />
-        <Route
-          path="/link-bank-account"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("payments:link_bank_account") }),
-            withLayout({ top: true, gutters: true }),
-            FundingLinkBankAccount
-          )}
-        />
-        <Route
-          path="/add-card"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("payments:add_card") }),
-            withLayout({ top: true, gutters: true }),
-            FundingAddCard
-          )}
-        />
-        <Route
-          path="/add-funds"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("payments:add_funds") }),
-            withLayout({ top: true, gutters: true }),
-            FundingAddFunds
-          )}
-        />
-        <Route
-          path="/ledgers"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("titles:ledgers_overview") }),
-            withLayout(),
-            LedgersOverview
-          )}
-        />
-        <Route
-          path="/order-history"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("titles:order_history") }),
-            withLayout(),
-            OrderHistoryList
-          )}
-        />
-        <Route
-          path="/unclaimed-orders"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("food:unclaimed_order_history_title") }),
-            withLayout(),
-            UnclaimedOrderList
-          )}
-        />
-        <Route
-          path="/order/:id"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("titles:order") }),
-            withLayout(),
-            OrderHistoryDetail
-          )}
-        />
-        <Route
-          path="/private-accounts"
-          exact
-          element={renderWithHocs(
-            redirectIfUnauthed,
-            redirectIfUnboarded,
-            withScreenLoaderMount(),
-            withMetatags({ title: t("titles:private_accounts") }),
-            withLayout(),
-            PrivateAccountsList
-          )}
-        />
-        <Route
-          path="/error"
-          exact
-          element={renderWithHocs(
-            withMetatags({ title: t("common:error") }),
-            withLayout(),
-            () => (
-              <div className="mt-4">
-                <ErrorScreen />
-              </div>
-            )
-          )}
-        />
-        <Route path="/styleguide" exact element={<Styleguide />} />
-        <Route path="/*" element={<Redirect to="/" />} />
-      </Routes>
-    </Router>
+      <Route
+        path="/utilities"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("utilities:title") }),
+          withLayout({ appNav: true }),
+          Utilities
+        )}
+      />
+      <Route
+        path="/funding"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("titles:funding") }),
+          withLayout({ top: true, gutters: true }),
+          Funding
+        )}
+      />
+      <Route
+        path="/link-bank-account"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("payments:link_bank_account") }),
+          withLayout({ top: true, gutters: true }),
+          FundingLinkBankAccount
+        )}
+      />
+      <Route
+        path="/add-card"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("payments:add_card") }),
+          withLayout({ top: true, gutters: true }),
+          FundingAddCard
+        )}
+      />
+      <Route
+        path="/add-funds"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("payments:add_funds") }),
+          withLayout({ top: true, gutters: true }),
+          FundingAddFunds
+        )}
+      />
+      <Route
+        path="/ledgers"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("titles:ledgers_overview") }),
+          withLayout(),
+          LedgersOverview
+        )}
+      />
+      <Route
+        path="/order-history"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("titles:order_history") }),
+          withLayout(),
+          OrderHistoryList
+        )}
+      />
+      <Route
+        path="/unclaimed-orders"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("food:unclaimed_order_history_title") }),
+          withLayout(),
+          UnclaimedOrderList
+        )}
+      />
+      <Route
+        path="/order/:id"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("titles:order") }),
+          withLayout(),
+          OrderHistoryDetail
+        )}
+      />
+      <Route
+        path="/private-accounts"
+        exact
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          redirectIfUnboarded,
+          withScreenLoaderMount(),
+          withMetatags({ title: t("titles:private_accounts") }),
+          withLayout(),
+          PrivateAccountsList
+        )}
+      />
+      <Route
+        path="/error"
+        exact
+        element={renderWithHocs(
+          withMetatags({ title: t("common:error") }),
+          withLayout(),
+          () => (
+            <div className="mt-4">
+              <ErrorScreen />
+            </div>
+          )
+        )}
+      />
+      <Route path="/styleguide" exact element={<Styleguide />} />
+      <Route path="/*" element={<Redirect to="/" />} />
+    </Routes>
   );
 }
 

--- a/webapp/src/hocs/authRedirects.js
+++ b/webapp/src/hocs/authRedirects.js
@@ -19,6 +19,7 @@ function redirectUnless(to, test, callback) {
         return <Wrapped {...props} />;
       }
       // We are unauthenticated at this point
+      // This allows the callback to set the redirect link in local session storage
       if (callback) {
         callback(setRedirectLink, pathname);
       }

--- a/webapp/src/hocs/authRedirects.js
+++ b/webapp/src/hocs/authRedirects.js
@@ -4,14 +4,7 @@ import { useUser } from "../state/useUser";
 import React from "react";
 import { useLocation } from "react-router-dom";
 
-export const redirectUnless = (to, test) => redirect(to, test);
-
-const redirectUnlessUnauthed = (to, test) =>
-  redirect(to, test, (setRedirectLink, pathname) => {
-    setRedirectLink(pathname);
-  });
-
-function redirect(to, test, callback) {
+function redirectUnless(to, test, callback) {
   return (Wrapped) => {
     return (props) => {
       const userCtx = useUser();
@@ -39,9 +32,12 @@ export const redirectIfAuthed = redirectUnless(
   ({ userUnauthed }) => userUnauthed
 );
 
-export const redirectIfUnauthed = redirectUnlessUnauthed(
+export const redirectIfUnauthed = redirectUnless(
   "/",
-  ({ userAuthed }) => userAuthed
+  ({ userAuthed }) => userAuthed,
+  (setRedirectLink, pathname) => {
+    setRedirectLink(pathname);
+  }
 );
 
 export const redirectIfBoarded = redirectUnless(

--- a/webapp/src/hocs/authRedirects.js
+++ b/webapp/src/hocs/authRedirects.js
@@ -4,7 +4,8 @@ import { useUser } from "../state/useUser";
 import React from "react";
 import { useLocation } from "react-router-dom";
 
-function redirectUnless(to, test, callback) {
+function redirectUnless(to, test, options) {
+  const { setRedirectLinkOnTestFalse } = options || {};
   return (Wrapped) => {
     return (props) => {
       const userCtx = useUser();
@@ -18,10 +19,8 @@ function redirectUnless(to, test, callback) {
       if (test(userCtx)) {
         return <Wrapped {...props} />;
       }
-      // We are unauthenticated at this point
-      // This allows the callback to set the redirect link in local session storage
-      if (callback) {
-        callback(setRedirectLink, pathname);
+      if (setRedirectLinkOnTestFalse) {
+        setRedirectLink(pathname);
       }
       return <Redirect to={to} />;
     };
@@ -33,13 +32,9 @@ export const redirectIfAuthed = redirectUnless(
   ({ userUnauthed }) => userUnauthed
 );
 
-export const redirectIfUnauthed = redirectUnless(
-  "/",
-  ({ userAuthed }) => userAuthed,
-  (setRedirectLink, pathname) => {
-    setRedirectLink(pathname);
-  }
-);
+export const redirectIfUnauthed = redirectUnless("/", ({ userAuthed }) => userAuthed, {
+  setRedirectLinkOnTestFalse: true,
+});
 
 export const redirectIfBoarded = redirectUnless(
   "/dashboard",

--- a/webapp/src/pages/OneTimePassword.js
+++ b/webapp/src/pages/OneTimePassword.js
@@ -79,7 +79,7 @@ const OneTimePassword = () => {
         setUser(r.data);
         if (r.data.onboarded && redirectLink) {
           navigate(redirectLink);
-        } else if (redirectLink) {
+        } else if (r.data.onboarded) {
           navigate("/dashboard");
         } else {
           navigate("/onboarding");

--- a/webapp/src/pages/OneTimePassword.js
+++ b/webapp/src/pages/OneTimePassword.js
@@ -5,6 +5,7 @@ import FormSuccess from "../components/FormSuccess";
 import { md, t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
+import useLoginRedirectLink from "../shared/react/useLoginRedirectLink";
 import { extractErrorCode, useError } from "../state/useError";
 import { useUser } from "../state/useUser";
 import React from "react";
@@ -22,6 +23,7 @@ const OneTimePassword = () => {
   const submitRef = React.useRef(null);
   const phoneNumber = state ? state.phoneNumber : undefined;
   const requireTerms = state ? state.requiresTermsAgreement : true;
+  const { redirectLink, removeRedirectLink } = useLoginRedirectLink();
 
   React.useEffect(() => {
     if (!phoneNumber) {
@@ -75,11 +77,14 @@ const OneTimePassword = () => {
       .authVerify({ phone: phoneNumber, token: otpChars.join(""), termsAgreed: true })
       .then((r) => {
         setUser(r.data);
-        if (r.data.onboarded) {
+        if (r.data.onboarded && redirectLink) {
+          navigate(redirectLink);
+        } else if (redirectLink) {
           navigate("/dashboard");
         } else {
           navigate("/onboarding");
         }
+        removeRedirectLink();
       })
       .catch((err) => {
         setOtpChars(new Array(6).fill(""));

--- a/webapp/src/pages/OneTimePassword.js
+++ b/webapp/src/pages/OneTimePassword.js
@@ -23,7 +23,7 @@ const OneTimePassword = () => {
   const submitRef = React.useRef(null);
   const phoneNumber = state ? state.phoneNumber : undefined;
   const requireTerms = state ? state.requiresTermsAgreement : true;
-  const { redirectLink, removeRedirectLink } = useLoginRedirectLink();
+  const { redirectLink, clearRedirectLink } = useLoginRedirectLink();
 
   React.useEffect(() => {
     if (!phoneNumber) {
@@ -84,7 +84,7 @@ const OneTimePassword = () => {
         } else {
           navigate("/onboarding");
         }
-        removeRedirectLink();
+        clearRedirectLink();
       })
       .catch((err) => {
         setOtpChars(new Array(6).fill(""));

--- a/webapp/src/shared/react/useLoginRedirectLink.js
+++ b/webapp/src/shared/react/useLoginRedirectLink.js
@@ -3,7 +3,7 @@ import useSessionStorageState from "./useSessionStorageState";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 
-const REDIRECT_LINK_SESSION_KEY = "sumaNextUrll";
+const REDIRECT_LINK_SESSION_KEY = "sumaNextUrl";
 
 export default function useLoginRedirectLink() {
   const [link, setInnerLink] = useSessionStorageState(REDIRECT_LINK_SESSION_KEY);

--- a/webapp/src/shared/react/useLoginRedirectLink.js
+++ b/webapp/src/shared/react/useLoginRedirectLink.js
@@ -1,0 +1,30 @@
+import { sessionStorageCache } from "../localStorageHelper";
+import useSessionStorageState from "./useSessionStorageState";
+import isEmpty from "lodash/isEmpty";
+import React from "react";
+
+const REDIRECT_LINK_SESSION_KEY = "sumaNextUrll";
+
+export default function useLoginRedirectLink() {
+  const [link, setInnerLink] = useSessionStorageState(REDIRECT_LINK_SESSION_KEY);
+
+  const setLink = React.useCallback(
+    (redirectLink) => {
+      if (!isEmpty(link)) {
+        return;
+      }
+      setInnerLink(redirectLink);
+    },
+    [setInnerLink, link]
+  );
+
+  const value = React.useMemo(
+    () => ({
+      redirectLink: link,
+      setRedirectLink: setLink,
+      removeRedirectLink: () => sessionStorageCache.removeItem(REDIRECT_LINK_SESSION_KEY),
+    }),
+    [setLink, link]
+  );
+  return value;
+}

--- a/webapp/src/shared/react/useLoginRedirectLink.js
+++ b/webapp/src/shared/react/useLoginRedirectLink.js
@@ -1,30 +1,26 @@
-import { sessionStorageCache } from "../localStorageHelper";
 import useSessionStorageState from "./useSessionStorageState";
-import isEmpty from "lodash/isEmpty";
 import React from "react";
 
 const REDIRECT_LINK_SESSION_KEY = "sumaNextUrl";
 
 export default function useLoginRedirectLink() {
-  const [link, setInnerLink] = useSessionStorageState(REDIRECT_LINK_SESSION_KEY);
-
-  const setLink = React.useCallback(
-    (redirectLink) => {
-      if (!isEmpty(link)) {
-        return;
-      }
-      setInnerLink(redirectLink);
-    },
-    [setInnerLink, link]
+  const [redirectLink, setRedirectLinkInner] = useSessionStorageState(
+    REDIRECT_LINK_SESSION_KEY
   );
-
+  const setRedirectLink = React.useCallback(
+    (x) => {
+      if (x !== redirectLink) {
+        setRedirectLinkInner(x);
+      }
+    },
+    [redirectLink, setRedirectLinkInner]
+  );
+  const clearRedirectLink = React.useCallback(() => {
+    setRedirectLink("");
+  }, [setRedirectLink]);
   const value = React.useMemo(
-    () => ({
-      redirectLink: link,
-      setRedirectLink: setLink,
-      removeRedirectLink: () => sessionStorageCache.removeItem(REDIRECT_LINK_SESSION_KEY),
-    }),
-    [setLink, link]
+    () => ({ redirectLink, setRedirectLink, clearRedirectLink }),
+    [clearRedirectLink, redirectLink, setRedirectLink]
   );
   return value;
 }


### PR DESCRIPTION
Fixes #420 

We provide order text message confirmations that include suma platform links to e.g. to allow the member to view their orders. Check #420 description and comments for step-by-step tasks.

- When member clicks this link, if they are not logged in to suma, they will have to login. We must save this link in session and redirected to it after login.
