### PR TITLE
Disable prefilled fields when creating Admin Book Transaction

### DIFF
--- a/adminapp/src/components/AutocompleteSearch.js
+++ b/adminapp/src/components/AutocompleteSearch.js
@@ -3,7 +3,7 @@ import debounce from "lodash/debounce";
 import React from "react";
 
 const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
-  { search, fullWidth, onValueSelect, defaultValue, ...rest },
+  { search, fullWidth, onValueSelect, defaultValue, disabled, ...rest },
   ref
 ) {
   const activePromise = React.useRef(Promise.resolve());
@@ -40,14 +40,17 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       autoHighlight={true}
       autoSelect={true}
       selectOnFocus={true}
+      title={defaultValue || null}
       value={defaultValue || null}
       onChange={handleSelect}
       fullWidth={fullWidth}
+      disabled={disabled}
       renderInput={(params) => (
         <TextField
           {...params}
           {...rest}
           fullWidth={fullWidth}
+          disabled={disabled}
           onChange={handleChange}
           InputProps={{
             ...params.InputProps,

--- a/adminapp/src/components/MultiLingualText.js
+++ b/adminapp/src/components/MultiLingualText.js
@@ -7,10 +7,10 @@ import React from "react";
  * for example adding additional TextFields for the multiple languages
  * @returns {JSX.Element}
  */
-export default function MultiLingualText({ value, label, onChange, ...rest }) {
+export default function MultiLingualText({ value, label, onChange, disabled, ...rest }) {
+  const { en, es } = value || { en: "", es: "" };
   const handleOnChange = (val, language) => {
-    // There should always be an English translation
-    let newValue = value || { en: "" };
+    let newValue = value;
     newValue[language] = val ? val : "";
     onChange(newValue);
   };
@@ -18,13 +18,19 @@ export default function MultiLingualText({ value, label, onChange, ...rest }) {
     <>
       <TextField
         {...rest}
+        title={en}
+        defaultValue={en}
         label={`English ${label}`}
         onChange={(e) => handleOnChange(e.target.value, "en")}
+        disabled={disabled && Boolean(en)}
       />
       <TextField
         {...rest}
+        title={es}
+        defaultValue={es}
         label={`Spanish ${label}`}
         onChange={(e) => handleOnChange(e.target.value, "es")}
+        disabled={disabled && Boolean(es)}
       />
     </>
   );

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -3,6 +3,7 @@ import Money, { formatMoney } from "../shared/react/Money";
 import AdminLink from "./AdminLink";
 import Link from "./Link";
 import RelatedList from "./RelatedList";
+import Typography from "@mui/material/Typography";
 import first from "lodash/first";
 import get from "lodash/get";
 import map from "lodash/map";
@@ -57,7 +58,16 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
             <AdminLink key="id" model={row} />,
             dayjs(row.createdAt).format("lll"),
             dayjs(row.applyAt).format("lll"),
-            <Money key="amt">{row.amount}</Money>,
+            <MoneyFlow
+              key="amt"
+              debit={
+                !row.originatingLedger.adminLabel
+                  .toLowerCase()
+                  .startsWith("suma platform")
+              }
+            >
+              {row.amount}
+            </MoneyFlow>,
             row.associatedVendorServiceCategory.name,
             <AdminLink key="originating" model={row.originatingLedger}>
               {row.originatingLedger.adminLabel}
@@ -77,7 +87,7 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
           <AdminLink key="id" model={row} />,
           dayjs(row.createdAt).format("lll"),
           row.status,
-          <Money key="amt">{row.amount}</Money>,
+          <MoneyFlow key="amt">{row.amount}</MoneyFlow>,
         ]}
       />
       <RelatedList
@@ -89,9 +99,23 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
           <AdminLink key="id" model={row} />,
           dayjs(row.createdAt).format("lll"),
           row.status,
-          <Money key="amt">{row.amount}</Money>,
+          <MoneyFlow key="amt" debit={true}>
+            {row.amount}
+          </MoneyFlow>,
         ]}
       />
     </>
+  );
+}
+
+function MoneyFlow({ amount, debit, children, ...rest }) {
+  amount = amount || children;
+  const greenColor = "#198754";
+  const redColor = "#b53d00";
+  return (
+    <Typography {...rest} variant="body2" sx={{ fontWeight: "bold", color: debit ? redColor : greenColor }}>
+      {debit ? "-" : "+"}
+      <Money>{amount}</Money>
+    </Typography>
   );
 }

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -113,7 +113,11 @@ function MoneyFlow({ amount, debit, children, ...rest }) {
   const greenColor = "#198754";
   const redColor = "#b53d00";
   return (
-    <Typography {...rest} variant="body2" sx={{ fontWeight: "bold", color: debit ? redColor : greenColor }}>
+    <Typography
+      {...rest}
+      variant="body2"
+      sx={{ fontWeight: "bold", color: debit ? redColor : greenColor }}
+    >
       {debit ? "-" : "+"}
       <Money>{amount}</Money>
     </Typography>

--- a/adminapp/src/components/VendorServiceCategorySelect.js
+++ b/adminapp/src/components/VendorServiceCategorySelect.js
@@ -1,6 +1,5 @@
 import api from "../api";
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from "@mui/material";
-import first from "lodash/first";
 import get from "lodash/get";
 import map from "lodash/map";
 import React from "react";

--- a/adminapp/src/components/VendorServiceCategorySelect.js
+++ b/adminapp/src/components/VendorServiceCategorySelect.js
@@ -1,14 +1,30 @@
 import api from "../api";
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from "@mui/material";
+import first from "lodash/first";
+import get from "lodash/get";
 import map from "lodash/map";
 import React from "react";
 
 const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCategorySelect(
-  { value, defaultValue, helperText, label, className, style, onChange, ...rest },
+  {
+    value,
+    defaultValue,
+    helperText,
+    label,
+    className,
+    style,
+    onChange,
+    disabled,
+    ...rest
+  },
   ref
 ) {
   const [categories, setCategories] = React.useState([{ slug: "cash", label: "Cash" }]);
-
+  const selectedCategoryLabel = get(
+    categories.find(({ label, slug }) => slug === value && label.toString()),
+    "label",
+    value
+  );
   const handleChange = React.useCallback(
     (slug) => {
       onChange(slug);
@@ -25,14 +41,17 @@ const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCateg
     });
   }, [handleChange, defaultValue]);
 
+  const title = rest.title || selectedCategoryLabel;
   return (
     <FormControl className={className} style={style}>
       {label && <InputLabel htmlFor="vscategory-select">{label}</InputLabel>}
       <Select
         id="vscategory-select"
         ref={ref}
+        title={title}
         value={value}
         label="Category"
+        disabled={disabled && Boolean(defaultValue)}
         onChange={(e) => handleChange(e.target.value)}
         {...rest}
       >

--- a/adminapp/src/pages/BookTransactionCreatePage.js
+++ b/adminapp/src/pages/BookTransactionCreatePage.js
@@ -22,7 +22,10 @@ export default function BookTransactionCreatePage() {
   const [originatingLedger, setOriginatingLedger] = React.useState(null);
   const [receivingLedger, setReceivingLedger] = React.useState(null);
   const [amount, setAmount] = React.useState(config.defaultZeroMoney);
-  const [memo, setMemo] = React.useState({ en: "" });
+  const [memo, setMemo] = React.useState({
+    en: searchParams.get("memoEn") || "",
+    es: searchParams.get("memoEs") || "",
+  });
   const [category, setCategory] = React.useState("");
   const { isBusy, busy, notBusy } = useBusy();
   const { register, handleSubmit } = useForm();
@@ -69,6 +72,8 @@ export default function BookTransactionCreatePage() {
       .tapCatch(notBusy)
       .catch(enqueueErrorSnackbar);
   }
+
+  const disableFields = searchParams.size > 0;
   return (
     <div style={{ maxWidth: 650 }}>
       <Typography variant="h4" gutterBottom>
@@ -86,6 +91,7 @@ export default function BookTransactionCreatePage() {
               label="Originating Ledger"
               helperText="Where is the money coming from?"
               defaultValue={originatingLedger?.label}
+              disabled={disableFields && Boolean(searchParams.get("originatingLedgerId"))}
               fullWidth
               required
               search={api.searchLedgers}
@@ -97,6 +103,7 @@ export default function BookTransactionCreatePage() {
               label="Receiving Ledger"
               helperText="Where is the money going?"
               defaultValue={receivingLedger?.label}
+              disabled={disableFields && Boolean(searchParams.get("receivingLedgerId"))}
               fullWidth
               required
               search={api.searchLedgers}
@@ -110,6 +117,7 @@ export default function BookTransactionCreatePage() {
               label="Amount"
               helperText="How much is going from originator to receiver?"
               money={amount}
+              autoFocus={disableFields}
               required
               style={{ flex: 1 }}
               onMoneyChange={setAmount}
@@ -117,6 +125,7 @@ export default function BookTransactionCreatePage() {
             <VendorServiceCategorySelect
               {...register("category")}
               defaultValue={searchParams.get("vendorServiceCategorySlug")}
+              disabled={disableFields}
               label="Category"
               helperText="What can this be used for?"
               value={category}
@@ -130,6 +139,7 @@ export default function BookTransactionCreatePage() {
               label="Memo"
               fullWidth
               value={memo}
+              disabled={disableFields}
               required
               onChange={(memo) => setMemo(memo)}
             />

--- a/adminapp/src/pages/MemberDetailPage.js
+++ b/adminapp/src/pages/MemberDetailPage.js
@@ -355,6 +355,7 @@ function ResetCodes({ resetCodes }) {
       title="Login Codes"
       headers={["Sent", "Expires", "Token", "Used"]}
       rows={resetCodes}
+      keyRowAttr={"id"}
       toCells={(row) => [
         dayjs(row.createdAt).format("lll"),
         dayjs(row.expireAt).format("lll"),
@@ -371,6 +372,7 @@ function Sessions({ sessions }) {
       title="Sessions"
       headers={["Started", "IP", "User Agent"]}
       rows={sessions}
+      keyRowAttr={"id"}
       toCells={(row) => [
         dayjs(row.createdAt).format("lll"),
         <SafeExternalLink key={2} href={row.ipLookupLink}>
@@ -388,7 +390,7 @@ function Orders({ orders }) {
       title="Orders"
       rows={orders}
       headers={["Id", "Created At", "Items", "Offering", "Status"]}
-      keyRowAttr="id"
+      keyRowAttr={"id"}
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         dayjs(row.createdAt).format("lll"),
@@ -408,6 +410,7 @@ function Charges({ charges }) {
       title="Charges"
       headers={["Id", "At", "Undiscounted Total", "Opaque Id"]}
       rows={charges}
+      keyRowAttr={"id"}
       toCells={(row) => [
         row.id,
         dayjs(row.createdAt).format("lll"),
@@ -424,7 +427,7 @@ function BankAccounts({ bankAccounts }) {
       title="Bank Accounts"
       headers={["Id", "Name", "Added", "Deleted"]}
       rows={bankAccounts}
-      keyRowAttr="id"
+      keyRowAttr={"id"}
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         row.adminLabel,
@@ -441,7 +444,7 @@ function MessageDeliveries({ messageDeliveries }) {
       title="Message Deliveries"
       headers={["Id", "Created", "Sent", "Template", "To"]}
       rows={messageDeliveries}
-      keyRowAttr="id"
+      keyRowAttr={"id"}
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         dayjs(row.createdAt).format("lll"),


### PR DESCRIPTION
Fixes #499 Fixes #501 
* If any fields are prefilled they will be disabled
* Auto focus on the Amount field if there is prefilled information
* Improve the fields by adding custom title and disabled attribute
* Fix key issue in member detail page

### Disabled prefilled fields and Amount field focused
<img width="647" alt="Screenshot 2023-09-01 at 8 46 24 PM" src="https://github.com/lithictech/suma/assets/66847768/f51e1596-8f8e-4ba4-be13-91fc842389dc">

---

Display credits and debits where money flows in the Admin Member details page

### Money flow credits and debits
<img width="631" alt="Screenshot 2023-09-01 at 11 12 12 PM" src="https://github.com/lithictech/suma/assets/66847768/66aa928d-6ceb-4ab6-8b22-ac44a0e5b57d">
<img width="633" alt="Screenshot 2023-09-01 at 11 12 39 PM" src="https://github.com/lithictech/suma/assets/66847768/26eaa9e4-6584-460f-aff6-59915349b931">
