### PR TITLE
Disable pre-filled book xaction fields, use accounting form, add autocomplete free text mode

### DIFF
--- a/adminapp/src/components/AutocompleteSearch.js
+++ b/adminapp/src/components/AutocompleteSearch.js
@@ -3,7 +3,7 @@ import debounce from "lodash/debounce";
 import React from "react";
 
 const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
-  { search, fullWidth, onValueSelect, value, ...rest },
+  { search, fullWidth, onValueSelect, value, disabled, ...rest },
   ref
 ) {
   const activePromise = React.useRef(Promise.resolve());
@@ -43,11 +43,13 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       value={value || null}
       onChange={handleSelect}
       fullWidth={fullWidth}
+      disabled={disabled}
       renderInput={(params) => (
         <TextField
           {...params}
           {...rest}
           fullWidth={fullWidth}
+          disabled={disabled}
           onChange={handleChange}
           InputProps={{
             ...params.InputProps,

--- a/adminapp/src/components/MultiLingualText.js
+++ b/adminapp/src/components/MultiLingualText.js
@@ -15,6 +15,9 @@ const MultiLingualText = React.forwardRef(function MultiLingualText(
   const handleSelect = (t) => {
     onChange({ en: t.en, es: t.es });
   };
+  const handleTextChange = (lang, txt) => {
+    onChange({ ...value, [lang]: txt });
+  };
   searchParams = searchParams || {};
   const doSearch = React.useCallback(
     (language, seachArg) => {
@@ -31,6 +34,8 @@ const MultiLingualText = React.forwardRef(function MultiLingualText(
         search={(o) => doSearch("en", o)}
         value={value.en}
         onValueSelect={handleSelect}
+        text={value.en}
+        onTextChange={(t) => handleTextChange("en", t)}
       />
       <AutocompleteSearch
         {...rest}
@@ -38,6 +43,8 @@ const MultiLingualText = React.forwardRef(function MultiLingualText(
         search={(o) => doSearch("es", o)}
         value={value.es}
         onValueSelect={handleSelect}
+        text={value.es}
+        onTextChange={(t) => handleTextChange("es", t)}
       />
     </>
   );

--- a/adminapp/src/components/PaymentAccountRelatedLists.js
+++ b/adminapp/src/components/PaymentAccountRelatedLists.js
@@ -1,5 +1,5 @@
 import { dayjs } from "../modules/dayConfig";
-import Money, { formatMoney } from "../shared/react/Money";
+import Money, { formatMoney, scaleMoney } from "../shared/react/Money";
 import AdminLink from "./AdminLink";
 import Link from "./Link";
 import RelatedList from "./RelatedList";
@@ -57,7 +57,11 @@ export default function PaymentAccountRelatedLists({ paymentAccount }) {
             <AdminLink key="id" model={row} />,
             dayjs(row.createdAt).format("lll"),
             dayjs(row.applyAt).format("lll"),
-            <Money key="amt">{row.amount}</Money>,
+            <Money key="amt" accounting>
+              {row.originatingLedger.id === ledger.id
+                ? scaleMoney(row.amount, -1)
+                : row.amount}
+            </Money>,
             row.associatedVendorServiceCategory.name,
             <AdminLink key="originating" model={row.originatingLedger}>
               {row.originatingLedger.adminLabel}

--- a/adminapp/src/components/VendorServiceCategorySelect.js
+++ b/adminapp/src/components/VendorServiceCategorySelect.js
@@ -1,5 +1,6 @@
 import api from "../api";
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from "@mui/material";
+import find from "lodash/find";
 import map from "lodash/map";
 import React from "react";
 
@@ -11,19 +12,23 @@ const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCateg
 
   const handleChange = React.useCallback(
     (slug) => {
-      onChange(slug);
+      const newCategory = find(categories, (c) => c.slug === slug) || { slug };
+      onChange(slug, newCategory);
     },
-    [onChange]
+    [categories, onChange]
   );
 
   React.useEffect(() => {
     api.getVendorServiceCategories().then((r) => {
       setCategories(r.data.items);
-      if (map(r.data.items, "slug").includes(defaultValue)) {
-        handleChange(defaultValue);
-      }
     });
-  }, [handleChange, defaultValue]);
+  }, []);
+
+  React.useEffect(() => {
+    if (map(categories, "slug").includes(defaultValue)) {
+      handleChange(defaultValue);
+    }
+  }, [handleChange, categories, defaultValue]);
 
   return (
     <FormControl className={className} style={style}>

--- a/adminapp/src/pages/BookTransactionCreatePage.js
+++ b/adminapp/src/pages/BookTransactionCreatePage.js
@@ -23,32 +23,35 @@ export default function BookTransactionCreatePage() {
   const [receivingLedger, setReceivingLedger] = React.useState(null);
   const [amount, setAmount] = React.useState(config.defaultZeroMoney);
   const [memo, setMemo] = React.useState({ en: "" });
-  const [category, setCategory] = React.useState("");
+  const [category, setCategory] = React.useState(null);
   const { isBusy, busy, notBusy } = useBusy();
   const { register, handleSubmit } = useForm();
 
   useMountEffect(() => {
-    const originatingLedgerId = Number(searchParams.get("originatingLedgerId"));
-    const receivingLedgerId = Number(searchParams.get("receivingLedgerId"));
+    // If the ID is 0, set the ledger by the platform category.
+    // If the ID is > 0, it should be set with an ID lookup from the backend.
+    const originatingLedgerId = Number(searchParams.get("originatingLedgerId") || -1);
+    const receivingLedgerId = Number(searchParams.get("receivingLedgerId") || -1);
     const categorySlug = searchParams.get("vendorServiceCategorySlug");
-    if (!originatingLedgerId && !receivingLedgerId) {
+    if (originatingLedgerId === -1 && receivingLedgerId === -1 && !categorySlug) {
+      // No params are in the URL so we don't search
       return;
     }
     api
       .searchLedgersLookup({
-        ids: [originatingLedgerId, receivingLedgerId],
+        ids: [originatingLedgerId, receivingLedgerId].filter((x) => x > 0),
         platformCategories: [categorySlug].filter(Boolean),
       })
       .then((r) => {
         const { byId, platformByCategory } = r.data;
         if (originatingLedgerId === 0) {
           setOriginatingLedger(platformByCategory[humps.camelize(categorySlug)]);
-        } else if (originatingLedgerId) {
+        } else if (originatingLedgerId > 0) {
           setOriginatingLedger(byId[originatingLedgerId]);
         }
         if (receivingLedgerId === 0) {
           setReceivingLedger(platformByCategory[humps.camelize(categorySlug)]);
-        } else if (receivingLedgerId) {
+        } else if (receivingLedgerId > 0) {
           setReceivingLedger(byId[receivingLedgerId]);
         }
       })
@@ -63,7 +66,7 @@ export default function BookTransactionCreatePage() {
         receivingLedgerId: receivingLedger?.id,
         amount,
         memo,
-        vendorServiceCategorySlug: category,
+        vendorServiceCategorySlug: category?.slug,
       })
       .then(api.followRedirect(navigate))
       .tapCatch(notBusy)
@@ -89,6 +92,8 @@ export default function BookTransactionCreatePage() {
               fullWidth
               required
               search={api.searchLedgers}
+              disabled={Boolean(searchParams.get("originatingLedgerId"))}
+              title={originatingLedger?.label}
               style={{ flex: 1 }}
               onValueSelect={(o) => setOriginatingLedger(o)}
             />
@@ -100,6 +105,8 @@ export default function BookTransactionCreatePage() {
               fullWidth
               required
               search={api.searchLedgers}
+              disabled={Boolean(searchParams.get("receivingLedgerId"))}
+              title={receivingLedger?.label}
               style={{ flex: 1 }}
               onValueSelect={(o) => setReceivingLedger(o)}
             />
@@ -111,6 +118,7 @@ export default function BookTransactionCreatePage() {
               helperText="How much is going from originator to receiver?"
               money={amount}
               required
+              autoFocus
               style={{ flex: 1 }}
               onMoneyChange={setAmount}
             />
@@ -119,9 +127,11 @@ export default function BookTransactionCreatePage() {
               defaultValue={searchParams.get("vendorServiceCategorySlug")}
               label="Category"
               helperText="What can this be used for?"
-              value={category}
+              value={category?.slug || ""}
+              disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
+              title={category?.label}
               style={{ flex: 1 }}
-              onChange={(categorySlug) => setCategory(categorySlug)}
+              onChange={(_, categoryObj) => setCategory(categoryObj)}
             />
           </Stack>
           <FormLabel>Memo (appears on the ledger):</FormLabel>

--- a/adminapp/src/pages/BookTransactionCreatePage.js
+++ b/adminapp/src/pages/BookTransactionCreatePage.js
@@ -22,7 +22,7 @@ export default function BookTransactionCreatePage() {
   const [originatingLedger, setOriginatingLedger] = React.useState(null);
   const [receivingLedger, setReceivingLedger] = React.useState(null);
   const [amount, setAmount] = React.useState(config.defaultZeroMoney);
-  const [memo, setMemo] = React.useState({ en: "" });
+  const [memo, setMemo] = React.useState({ en: "", es: "" });
   const [category, setCategory] = React.useState(null);
   const { isBusy, busy, notBusy } = useBusy();
   const { register, handleSubmit } = useForm();

--- a/adminapp/src/shared/react/Money.js
+++ b/adminapp/src/shared/react/Money.js
@@ -103,6 +103,13 @@ export function subtractMoney(m1, m2) {
   return mathMoney(m1, m2, (x, y) => x - y);
 }
 
+export function scaleMoney(m, n) {
+  return {
+    cents: m.cents * n,
+    currency: m.currency,
+  };
+}
+
 export function anyMoney(m) {
   if (!m) {
     return false;


### PR DESCRIPTION
Autocomplete search can work with free-text

Needed for memo inputs, this ability was removed in #506 

---

Disable book transaction fields if prefilled

Also use object for handleChange in VSCSelect.

Fixes #499 

---

Use accounting-form money in admin book transaction

Fixes #501
