### PR TITLE
Replace react-phone-number-input package with built-in helper functions

### DIFF
--- a/adminapp/package-lock.json
+++ b/adminapp/package-lock.json
@@ -30,7 +30,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.42.1",
-        "react-phone-number-input": "^3.2.16",
         "react-router": "^6.7.0",
         "react-router-dom": "^6.7.0",
         "react-scripts": "5.0.1"
@@ -5870,11 +5869,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
-    "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-    },
     "node_modules/clean-css": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
@@ -6244,11 +6238,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/country-flag-icons": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.4.tgz",
-      "integrity": "sha512-/PnU4OZimNfuwQWH4hBBoGVmIbMoDoGF8AH6+TxSJzYOPgWxO7vEPu8Cuyzwy6R/voEiw3wjJESDXvQqmS1mng=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -9172,14 +9161,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/input-format": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.8.tgz",
-      "integrity": "sha512-tLR0XRig1xIcG1PtIpMd/uoltvkAI62CN9OIbtj4/tEJAkqTCQLNHUZ9N4M46w0dopny7Rlt/lRH5Xzp7e6F+g==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -11005,11 +10986,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/libphonenumber-js": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.18.tgz",
-      "integrity": "sha512-NS4ZEgNhwbcPz1gfSXCGFnQm0xEiyTSPRthIuWytDzOiEG9xnZ2FbLyfJC4tI2BMAAXpoWbNxHYH75pa3Dq9og=="
     },
     "node_modules/lilconfig": {
       "version": "2.0.5",
@@ -13513,22 +13489,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "node_modules/react-phone-number-input": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.2.16.tgz",
-      "integrity": "sha512-xNmY6chXarq6BT+1MiB7owzrvitC7BbXUR8RCMJ0g4afeACr9T3KwkDpVDII+DTmPRjSqs7fV7ZI1H2qjDGHcQ==",
-      "dependencies": {
-        "classnames": "^2.3.1",
-        "country-flag-icons": "^1.5.4",
-        "input-format": "^0.3.8",
-        "libphonenumber-js": "^1.10.17",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -20502,11 +20462,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-    },
     "clean-css": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
@@ -20791,11 +20746,6 @@
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
       }
-    },
-    "country-flag-icons": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.4.tgz",
-      "integrity": "sha512-/PnU4OZimNfuwQWH4hBBoGVmIbMoDoGF8AH6+TxSJzYOPgWxO7vEPu8Cuyzwy6R/voEiw3wjJESDXvQqmS1mng=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -22910,14 +22860,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "input-format": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.8.tgz",
-      "integrity": "sha512-tLR0XRig1xIcG1PtIpMd/uoltvkAI62CN9OIbtj4/tEJAkqTCQLNHUZ9N4M46w0dopny7Rlt/lRH5Xzp7e6F+g==",
-      "requires": {
-        "prop-types": "^15.8.1"
-      }
-    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -24276,11 +24218,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
-    },
-    "libphonenumber-js": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.18.tgz",
-      "integrity": "sha512-NS4ZEgNhwbcPz1gfSXCGFnQm0xEiyTSPRthIuWytDzOiEG9xnZ2FbLyfJC4tI2BMAAXpoWbNxHYH75pa3Dq9og=="
     },
     "lilconfig": {
       "version": "2.0.5",
@@ -25917,18 +25854,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-phone-number-input": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.2.16.tgz",
-      "integrity": "sha512-xNmY6chXarq6BT+1MiB7owzrvitC7BbXUR8RCMJ0g4afeACr9T3KwkDpVDII+DTmPRjSqs7fV7ZI1H2qjDGHcQ==",
-      "requires": {
-        "classnames": "^2.3.1",
-        "country-flag-icons": "^1.5.4",
-        "input-format": "^0.3.8",
-        "libphonenumber-js": "^1.10.17",
-        "prop-types": "^15.8.1"
-      }
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/adminapp/package.json
+++ b/adminapp/package.json
@@ -25,7 +25,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.42.1",
-    "react-phone-number-input": "^3.2.16",
     "react-router": "^6.7.0",
     "react-router-dom": "^6.7.0",
     "react-scripts": "5.0.1"

--- a/adminapp/src/modules/formatUsRegionPhoneNumber.js
+++ b/adminapp/src/modules/formatUsRegionPhoneNumber.js
@@ -1,0 +1,6 @@
+export function formatUsRegionPhoneNumber(num) {
+  if (!num) {
+    return "";
+  }
+  return "+" + num.toString().replace(/(\d)(\d\d\d)(\d\d\d)(\d\d\d\d)/, "$1 $2 $3 $4");
+}

--- a/adminapp/src/modules/maskPhoneNumber.js
+++ b/adminapp/src/modules/maskPhoneNumber.js
@@ -1,0 +1,21 @@
+export const maskPhoneNumber = (num) => {
+  if (!num || num.startsWith("0") || num.startsWith("1")) {
+    return "";
+  }
+  let currentNum = num.replace(/\D/g, "");
+  // in case `currentNum` starts with US region code "1", remove it before formatting
+  // also prevent starting with 0
+  if (currentNum.startsWith("1") || currentNum.startsWith("0")) {
+    currentNum = currentNum.slice(1);
+  }
+  if (currentNum.length < 4) {
+    return currentNum;
+  } else if (currentNum.length < 7) {
+    return `(${currentNum.slice(0, 3)}) ${currentNum.slice(3)}`;
+  } else {
+    return `(${currentNum.slice(0, 3)}) ${currentNum.slice(3, 6)}-${currentNum.slice(
+      6,
+      10
+    )}`;
+  }
+};

--- a/adminapp/src/modules/maskPhoneNumber.test.js
+++ b/adminapp/src/modules/maskPhoneNumber.test.js
@@ -1,0 +1,24 @@
+import { maskPhoneNumber } from "./maskPhoneNumber";
+
+it("returns empty string when value starts with 1, 0, or not a number", () => {
+  expect(maskPhoneNumber("e")).toEqual("");
+  expect(maskPhoneNumber("+")).toEqual("");
+  expect(maskPhoneNumber(" ")).toEqual("");
+  expect(maskPhoneNumber("1")).toEqual("");
+  expect(maskPhoneNumber("0")).toEqual("");
+});
+it("formats phone number", () => {
+  expect(maskPhoneNumber("222")).toEqual("222");
+  expect(maskPhoneNumber("(222) 3")).toEqual("(222) 3");
+  expect(maskPhoneNumber("(222) 3334")).toEqual("(222) 333-4");
+  expect(maskPhoneNumber("(222) 333-4444")).toEqual("(222) 333-4444");
+});
+it("remove first character when formatted phone number that start with 1 or 0", () => {
+  expect(maskPhoneNumber("(022)")).toEqual("22");
+  expect(maskPhoneNumber("(122) 2")).toEqual("222");
+  expect(maskPhoneNumber("(022) 222-2")).toEqual("(222) 222");
+  expect(maskPhoneNumber("(122) 222-22")).toEqual("(222) 222-2");
+});
+it("can format US region number", () => {
+  expect(maskPhoneNumber("+12223334444")).toEqual("(222) 333-4444");
+});

--- a/adminapp/src/pages/MemberDetailPage.js
+++ b/adminapp/src/pages/MemberDetailPage.js
@@ -8,6 +8,7 @@ import RelatedList from "../components/RelatedList";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import { useUser } from "../hooks/user";
 import { dayjs } from "../modules/dayConfig";
+import { formatUsRegionPhoneNumber } from "../modules/formatUsRegionPhoneNumber";
 import Money from "../shared/react/Money";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
@@ -30,7 +31,6 @@ import _ from "lodash";
 import capitalize from "lodash/capitalize";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
-import { formatPhoneNumberIntl } from "react-phone-number-input";
 import { useParams } from "react-router-dom";
 
 export default function MemberDetailPage() {
@@ -55,7 +55,6 @@ export default function MemberDetailPage() {
       .then((r) => replaceMember(r.data))
       .catch((e) => enqueueErrorSnackbar(e));
   }
-
   return (
     <>
       {memberLoading && <CircularProgress />}
@@ -73,7 +72,7 @@ export default function MemberDetailPage() {
               { label: "Email", value: member.email },
               {
                 label: "Phone Number",
-                value: formatPhoneNumberIntl("+" + member.phone),
+                value: formatUsRegionPhoneNumber(member.phone),
               },
               {
                 label: "Verified",

--- a/adminapp/src/pages/MemberListPage.js
+++ b/adminapp/src/pages/MemberListPage.js
@@ -3,10 +3,10 @@ import AdminLink from "../components/AdminLink";
 import ResourceTable from "../components/ResourceTable";
 import Unavailable from "../components/Unavailable";
 import { dayjs } from "../modules/dayConfig";
+import { maskPhoneNumber } from "../modules/maskPhoneNumber";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import useListQueryControls from "../shared/react/useListQueryControls";
 import React from "react";
-import { formatPhoneNumber } from "react-phone-number-input";
 
 export default function MemberListPage() {
   const { page, perPage, search, order, orderBy, setListQueryParams } =
@@ -55,9 +55,9 @@ export default function MemberListPage() {
         {
           id: "phone",
           label: "Phone Number",
-          align: "center",
+          align: "left",
           sortable: true,
-          render: (c) => formatPhoneNumber("+" + c.phone),
+          render: (c) => maskPhoneNumber("+" + c.phone),
         },
         {
           id: "name",


### PR DESCRIPTION
Fixes #303 

* Remove `react-phone-number-input` and dependency
* Use built-in helper functions to format numbers
* Create helper function for formatting US region phone numbers

Build size node_modules reduction: 1.26mb to 1.08mb (~180kb)

### Adminapp build size analytics BEFORE
<img width="1269" alt="Screenshot 2023-09-25 at 5 58 04 PM" src="https://github.com/lithictech/suma/assets/66847768/ae5dfc5b-b939-4c00-8704-efbcbf84c091">
 
 ### Adminapp build size analytics AFTER 
<img width="1276" alt="Screenshot 2023-09-25 at 6 00 18 PM" src="https://github.com/lithictech/suma/assets/66847768/b13bf211-ca2c-4fdd-b65a-fac4e1c95fb8">

