### PR TITLE
Fix autocomplete bugs

### DIFF
--- a/adminapp/src/components/AutocompleteSearch.jsx
+++ b/adminapp/src/components/AutocompleteSearch.jsx
@@ -62,7 +62,6 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       freeSolo
       options={options}
       autoHighlight={true}
-      autoSelect={true}
       selectOnFocus={true}
       value={value || null}
       onChange={handleSelect}

--- a/adminapp/src/components/AutocompleteSearch.jsx
+++ b/adminapp/src/components/AutocompleteSearch.jsx
@@ -1,5 +1,6 @@
 import { Autocomplete, TextField } from "@mui/material";
 import debounce from "lodash/debounce";
+import { isObject } from "lodash/lang";
 import React from "react";
 
 /**
@@ -39,7 +40,7 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       return;
     }
     activePromise.current.cancel();
-    const q = e.target.value;
+    const q = e.target.value || "";
     onTextChange && onTextChange(q);
 
     if (q.length < 3) {
@@ -49,7 +50,11 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
     searchDebounced({ q });
   }
   function handleSelect(ev, val) {
-    if (typeof val === "object") {
+    // val can be null (which is type object).
+    // This will happen when we use the 'clear' button (or delete all text),
+    // which calls back a text value change, AND triggers this 'selected' callback.
+    // The caller just has to worry about the text change; onValueSelect will never be called with null.
+    if (isObject(val)) {
       // If this is in uncontrolled mode, select will be called with a string,
       // even after the selection is made. However we always are dealing with objects,
       // never strings, so never alert if this case is hit.
@@ -63,7 +68,6 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       options={options}
       autoHighlight={true}
       selectOnFocus={true}
-      disableClearable
       value={value || null}
       onChange={handleSelect}
       inputValue={text}

--- a/adminapp/src/components/AutocompleteSearch.jsx
+++ b/adminapp/src/components/AutocompleteSearch.jsx
@@ -68,6 +68,7 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       onChange={handleSelect}
       inputValue={text}
       onInputChange={handleChange}
+      filterOptions={(ops) => ops}
       fullWidth={fullWidth}
       disabled={disabled}
       renderInput={(params) => (

--- a/adminapp/src/components/AutocompleteSearch.jsx
+++ b/adminapp/src/components/AutocompleteSearch.jsx
@@ -33,7 +33,7 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
   const [options, setOptions] = React.useState([]);
 
   function handleChange(e) {
-    if (!e || !e.target.value || e.target.value === 0) {
+    if (!e || e.target.value === 0) {
       // Change is invoked on init (with a null event) and on select (with the value 0, no matter what is selected).
       // I don't understand what this means.
       return;
@@ -63,6 +63,7 @@ const AutocompleteSearch = React.forwardRef(function AutocompleteSearch(
       options={options}
       autoHighlight={true}
       selectOnFocus={true}
+      disableClearable
       value={value || null}
       onChange={handleSelect}
       inputValue={text}

--- a/adminapp/src/components/MultiLingualText.jsx
+++ b/adminapp/src/components/MultiLingualText.jsx
@@ -13,9 +13,6 @@ const MultiLingualText = React.forwardRef(function MultiLingualText(
   ref
 ) {
   const handleSelect = (t) => {
-    if (!t) {
-      return;
-    }
     onChange({ en: t.en, es: t.es });
   };
   const handleTextChange = (lang, txt) => {


### PR DESCRIPTION
Fixes #522

Remove `autoSelect` Autocomplete component feature that was selecting when focusing on an option, which is not our desired behavior.

---

Fixes #515 

Disable Autocomplete built-in filtering as [MUI docs](https://mui.com/material-ui/react-autocomplete/#search-as-you-type) suggest when using this component to "Search as you type" , like in our case.

---

Fix a bug where "clearing" Autocomplete would cause the `onInputChange` event to pass an empty value, causing rendering errors.
- Set `disableClearable` to prevent this issue,
- Remove unnecessary `if` conditions on Autocomplete and parent MultiLingualText components that were added as a work-around for this bug