### PR TITLE
Refactor category full_label to name

### DIFF
--- a/adminapp/src/components/VendorServiceCategorySelect.jsx
+++ b/adminapp/src/components/VendorServiceCategorySelect.jsx
@@ -41,9 +41,9 @@ const VendorServiceCategorySelect = React.forwardRef(function VendorServiceCateg
         onChange={(e) => handleChange(e.target.value)}
         {...rest}
       >
-        {categories.map(({ label, slug }) => (
+        {categories.map(({ name, slug }) => (
           <MenuItem key={slug} value={slug}>
-            {label}
+            {name}
           </MenuItem>
         ))}
       </Select>


### PR DESCRIPTION
Fixes #520 

Display the backend category name rather than the `full_label`, which includes parent categories in the label

### Category dropdown change
<img width="683" alt="Screenshot 2023-10-17 at 5 24 58 PM" src="https://github.com/lithictech/suma/assets/66847768/f7d07c20-2411-47ed-9b57-4f747887a776">
