### PR TITLE
Update login disclosures

### DIFF
--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -22,6 +22,7 @@ class Suma::API::Auth < Suma::API::V1
       requires :phone, us_phone: true, type: String, coerce_with: NormalizedPhone
       requires :timezone, type: String, values: ALL_TIMEZONES
       optional :language, type: String, values: Suma::I18n.enabled_locale_codes
+      optional :terms_agreed, type: Boolean
     end
     post :start do
       guard_authed!
@@ -32,6 +33,7 @@ class Suma::API::Auth < Suma::API::V1
           phone: params[:phone],
           name: "",
           password_digest: Suma::Member::PLACEHOLDER_PASSWORD_DIGEST,
+          terms_agreed: params[:terms_agreed] ? Suma::Member::LATEST_TERMS_PUBLISH_DATE : nil,
         )
         member.timezone = params[:timezone]
         save_or_error!(member)
@@ -53,7 +55,6 @@ class Suma::API::Auth < Suma::API::V1
     params do
       requires :phone, us_phone: true, type: String, coerce_with: NormalizedPhone
       requires :token, type: String, allow_blank: false
-      optional :terms_agreed, type: Boolean
     end
     post :verify do
       guard_authed!
@@ -76,7 +77,6 @@ class Suma::API::Auth < Suma::API::V1
         merror!(403, "Sorry, that token is invalid or the phone number is not in our system.", code: "invalid_otp")
       end
 
-      me.update(terms_agreed: Suma::Member::LATEST_TERMS_PUBLISH_DATE) if params[:terms_agreed]
       set_member(me)
       create_session(me)
       status 200

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -1,4 +1,7 @@
 {
+  "auth": {
+    "sign_up_agreement": "By clicking {{ buttonLabel }}, you accept and agree to our [Terms of Use](/terms-of-use) and [Privacy Policy](/privacy-policy). You agree to receive periodic SMS and/or MMS messages from suma. Message and data rates may apply. Text HELP for more information. Text STOP to stop receiving messages."
+  },
   "common": {
     "add_money_to_account": "Press here to add money to your account",
     "add_to_homescreen": "Add to homescreen",
@@ -31,7 +34,6 @@
     "privacy_policy": "Privacy Policy",
     "reference_id": "Reference ID",
     "scooter_cost": "{{startCost, sumaCurrency}} to start then {{costPerMinute, sumaCurrency}}/min + taxes",
-    "sign_up_agreement": "By clicking {{ buttonLabel }}, you are agreeing to receive periodic SMS and/or MMS messages from suma. Message and data rates may apply. Text HELP for more information. Text STOP to stop receiving messages.",
     "terms_of_use": "Terms of Use",
     "translate_to_english": "Translate to English",
     "translate_to_spanish": "Traducir al Español",
@@ -273,7 +275,6 @@
     "enter_code": "Enter code ",
     "enter_code_sent_to": "Enter the code that we sent to",
     "send_new_code": "Send a new code",
-    "terms": "By creating an account or signing in, you accept and agree to our [Terms of Use](/terms-of-use) and [Privacy Policy](/privacy-policy).",
     "verify": "Verify",
     "verify_code": "Verify Code"
   },

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -31,6 +31,7 @@
     "privacy_policy": "Privacy Policy",
     "reference_id": "Reference ID",
     "scooter_cost": "{{startCost, sumaCurrency}} to start then {{costPerMinute, sumaCurrency}}/min + taxes",
+    "sign_up_agreement": "By clicking {{ buttonLabel }}, you are agreeing to receive periodic SMS and/or MMS messages from suma. Message and data rates may apply. Text HELP for more information. Text STOP to stop receiving messages.",
     "terms_of_use": "Terms of Use",
     "translate_to_english": "Translate to English",
     "translate_to_spanish": "Traducir al Español",
@@ -51,7 +52,6 @@
     },
     "referral_label": "How did you hear about suma?",
     "sign_up_again": "Sign up again",
-    "sign_up_agreement": "By clicking submit, you are agreeing to receive periodic SMS and/or MMS messages from suma. Message and data rates may apply. Text HELP for more information. Text STOP to stop receiving messages.",
     "signup_intro": "Fill in the blanks below to join our contact list, and we will update you on all our projects and upcoming money saving opportunities. We’re so excited!",
     "signup_title": "Join suma",
     "success_intro": "Thank you for signing up, and welcome to the suma app!\n\nWe will update you on all future projects, money saving opportunities, and how to complete the app enrollment process. To learn more about suma, visit our website at $t(strings:common:mysuma_website_link), or check us out on our social media using the link below. Chat soon!"

--- a/webapp/public/locale/es/strings.json
+++ b/webapp/public/locale/es/strings.json
@@ -31,6 +31,7 @@
     "privacy_policy": "Política de Privacidad",
     "reference_id": "ID de referencia",
     "scooter_cost": "{{startCost, sumaCurrency}} para empezar, y luego {{costPerMinute, sumaCurrency}}/min + impuestos",
+    "sign_up_agreement": "Al hacer clic en {{ buttonLabel }}, acepta recibir mensajes SMS y/o MMS periódicos de suma. Se pueden aplicar tarifas por mensajes y datos. Envía HELP para obtener más información. Envía STOP para dejar de recibir mensajes.",
     "terms_of_use": "Términos de Uso",
     "translate_to_english": "Translate to English",
     "translate_to_spanish": "Traducir al Español",
@@ -51,7 +52,6 @@
     },
     "referral_label": "¿Como te enteraste de suma?",
     "sign_up_again": "Regístrese de nuevo",
-    "sign_up_agreement": "Al hacer clic en enviar, acepta recibir mensajes SMS y/o MMS periódicos de suma. Se pueden aplicar tarifas por mensajes y datos. Envía HELP para obtener más información. Envía STOP para dejar de recibir mensajes.",
     "signup_intro": "Complete los espacios abajo para unirse a nuestra lista de contactos y lo actualizaremos sobre todos nuestros proyectos y las próximas oportunidades de ahorro de dinero. ¡Estamos tan emocionados!",
     "signup_title": "Unirse a suma",
     "success_intro": "¡Gracias por registrarte y bienvenido a la app suma!\n\n¡Ya estás inscrito en nuestra comunidad! Lo informaremos sobre todos los proyectos futuros, las oportunidades de ahorro de dinero y cómo completar el proceso de inscripción en la aplicación. Para obtener más información sobre suma, visite nuestro sitio web en $t(strings:common:mysuma_website_link), o visítenos en nuestras redes sociales usando el enlace abajo. ¡Nos hablamos pronto!"
@@ -273,7 +273,7 @@
     "enter_code": "Introduzca el código",
     "enter_code_sent_to": "Introducir el código que enviamos",
     "send_new_code": "Enviar un nuevo código",
-    "terms": "Al crear una cuenta o iniciar sesión, aceptas y estás de acuerdo con nuestros [Términos de uso](/terms-of-use).",
+    "terms": "Al crear una cuenta o iniciar sesión, aceptas y estás de acuerdo con nuestros [Términos de Uso](/terms-of-use) y [Política de Privacidad](/privacy-policy).",
     "verify": "Verificar",
     "verify_code": "Verificar el código"
   },

--- a/webapp/public/locale/es/strings.json
+++ b/webapp/public/locale/es/strings.json
@@ -1,4 +1,7 @@
 {
+  "auth": {
+    "sign_up_agreement": "Al hacer clic en {{ buttonLabel }}, aceptas y estás de acuerdo con nuestros [Términos de uso](/términos-de-uso) y [Política de privacidad](/privacy-policy). Aceptas recibir SMS y/o MMS periódicos de suma. Se pueden aplicar tarifas de mensajes y datos. Envíe HELP para obtener más información. Envíe STOP para dejar de recibir mensajes."
+  },
   "common": {
     "add_money_to_account": "Haz click aquí para añadir fondos a tu cuenta",
     "add_to_homescreen": "Agregar a pantalla principal",
@@ -31,7 +34,6 @@
     "privacy_policy": "Política de Privacidad",
     "reference_id": "ID de referencia",
     "scooter_cost": "{{startCost, sumaCurrency}} para empezar, y luego {{costPerMinute, sumaCurrency}}/min + impuestos",
-    "sign_up_agreement": "Al hacer clic en {{ buttonLabel }}, acepta recibir mensajes SMS y/o MMS periódicos de suma. Se pueden aplicar tarifas por mensajes y datos. Envía HELP para obtener más información. Envía STOP para dejar de recibir mensajes.",
     "terms_of_use": "Términos de Uso",
     "translate_to_english": "Translate to English",
     "translate_to_spanish": "Traducir al Español",
@@ -273,7 +275,6 @@
     "enter_code": "Introduzca el código",
     "enter_code_sent_to": "Introducir el código que enviamos",
     "send_new_code": "Enviar un nuevo código",
-    "terms": "Al crear una cuenta o iniciar sesión, aceptas y estás de acuerdo con nuestros [Términos de Uso](/terms-of-use) y [Política de Privacidad](/privacy-policy).",
     "verify": "Verificar",
     "verify_code": "Verificar el código"
   },

--- a/webapp/src/pages/ContactListAdd.jsx
+++ b/webapp/src/pages/ContactListAdd.jsx
@@ -3,7 +3,7 @@ import ContactListTags from "../components/ContactListTags";
 import FormButtons from "../components/FormButtons";
 import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
-import { mdp, t } from "../localization";
+import { md, mdp, t } from "../localization";
 import useI18Next from "../localization/useI18Next";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
@@ -123,7 +123,7 @@ export default function ContactListAdd() {
         </Row>
         <FormError error={error} />
         <p className="text-secondary">
-          {t("common:sign_up_agreement", { buttonLabel: t("forms:submit") })}
+          {md("auth:sign_up_agreement", { buttonLabel: t("forms:submit") })}
         </p>
         <FormButtons
           variant="outline-primary"

--- a/webapp/src/pages/ContactListAdd.jsx
+++ b/webapp/src/pages/ContactListAdd.jsx
@@ -122,7 +122,9 @@ export default function ContactListAdd() {
           </FormControlGroup>
         </Row>
         <FormError error={error} />
-        <p className="text-secondary">{t("contact_list:sign_up_agreement")}</p>
+        <p className="text-secondary">
+          {t("common:sign_up_agreement", { buttonLabel: t("forms:submit") })}
+        </p>
         <FormButtons
           variant="outline-primary"
           back

--- a/webapp/src/pages/OneTimePassword.jsx
+++ b/webapp/src/pages/OneTimePassword.jsx
@@ -73,7 +73,7 @@ const OneTimePassword = () => {
     submitRef.current.disabled = true;
     setError();
     api
-      .authVerify({ phone: phoneNumber, token: otpChars.join(""), termsAgreed: true })
+      .authVerify({ phone: phoneNumber, token: otpChars.join("") })
       .then((r) => {
         setUser(r.data);
         if (r.data.onboarded && redirectLink) {

--- a/webapp/src/pages/OneTimePassword.jsx
+++ b/webapp/src/pages/OneTimePassword.jsx
@@ -2,7 +2,7 @@ import api from "../api";
 import FormButtons from "../components/FormButtons";
 import FormError from "../components/FormError";
 import FormSuccess from "../components/FormSuccess";
-import { md, t } from "../localization";
+import { t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
 import useLoginRedirectLink from "../shared/react/useLoginRedirectLink";
@@ -22,7 +22,6 @@ const OneTimePassword = () => {
   const { state } = useLocation();
   const submitRef = React.useRef(null);
   const phoneNumber = state ? state.phoneNumber : undefined;
-  const requireTerms = state ? state.requiresTermsAgreement : true;
   const { redirectLink, clearRedirectLink } = useLoginRedirectLink();
 
   React.useEffect(() => {
@@ -168,7 +167,6 @@ const OneTimePassword = () => {
             {t("otp:send_new_code")}
           </Button>
         </p>
-        {requireTerms && <p className="w-75 text-center m-auto">{md("otp:terms")}</p>}
         <FormButtons
           back
           primaryProps={{

--- a/webapp/src/pages/Start.jsx
+++ b/webapp/src/pages/Start.jsx
@@ -2,7 +2,7 @@ import api from "../api";
 import FormButtons from "../components/FormButtons";
 import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
-import { t } from "../localization";
+import { mdp, t } from "../localization";
 import useI18Next from "../localization/useI18Next";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
@@ -48,14 +48,7 @@ export default function Start() {
         timezone: dayjs.tz.guess(),
         language,
       })
-      .then((r) =>
-        navigate("/one-time-password", {
-          state: {
-            phoneNumber: phone,
-            requiresTermsAgreement: r.data.requiresTermsAgreement,
-          },
-        })
-      )
+      .then(() => navigate("/one-time-password", { state: { phoneNumber: phone } }))
       .catch((err) => {
         setError(extractErrorCode(err));
         submitDisabled.turnOff();
@@ -86,6 +79,11 @@ export default function Start() {
           required
           onChange={handlePhoneChange}
         />
+
+        <div className="text-secondary small">
+          {mdp("otp:terms")}
+          <p>{t("common:sign_up_agreement", { buttonLabel: t("forms:continue") })}</p>
+        </div>
         <FormError error={error} />
         <FormButtons
           back

--- a/webapp/src/pages/Start.jsx
+++ b/webapp/src/pages/Start.jsx
@@ -47,8 +47,16 @@ export default function Start() {
         phone,
         timezone: dayjs.tz.guess(),
         language,
+        termsAgreed: true,
       })
-      .then(() => navigate("/one-time-password", { state: { phoneNumber: phone } }))
+      .then((r) =>
+        navigate("/one-time-password", {
+          state: {
+            phoneNumber: phone,
+            requiresTermsAgreement: r.data.requiresTermsAgreement,
+          },
+        })
+      )
       .catch((err) => {
         setError(extractErrorCode(err));
         submitDisabled.turnOff();
@@ -81,8 +89,7 @@ export default function Start() {
         />
 
         <div className="text-secondary small">
-          {mdp("otp:terms")}
-          <p>{t("common:sign_up_agreement", { buttonLabel: t("forms:continue") })}</p>
+          {mdp("auth:sign_up_agreement", { buttonLabel: t("forms:continue") })}
         </div>
         <FormError error={error} />
         <FormButtons


### PR DESCRIPTION
- Move ToS/Privacy agreement to where you input your phone number, instead of the OTP page
- Agree to terms on signup, rather than whenever verifying. This makes more sense anyway; we will need to prompt for specific consent if ToS changes.

Fixes #531 