### PR TITLE
Require base_url trailing slash only in development

### DIFF
--- a/adminapp/src/modules/relativeLink.js
+++ b/adminapp/src/modules/relativeLink.js
@@ -26,7 +26,7 @@ export default function relativeLink(href) {
 
 const baseUrl = import.meta.env.BASE_URL;
 
-if (!baseUrl.endsWith("/")) {
+if (!baseUrl.endsWith("/") && import.meta.env.MODE === "development") {
   throw new Error(`BASE_URL must have trailing slash, got '${baseUrl}'`);
 }
 


### PR DESCRIPTION
Admin broke in the production app due to `relativeLink` component not returning accurate path results.
- Fix path returned by relativeLink by handle any missing trailing slash on BASE_URL and result path