### PR TITLE
Assign eligibility constraint to an offering

### DIFF
--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -84,6 +84,8 @@ export default {
     get(`/adminapi/v1/commerce_offerings/${id}`, data),
   createCommerceOffering: (data) =>
     postForm("/adminapi/v1/commerce_offerings/create", data),
+  addOfferingEligibility: ({ id, ...data }) =>
+    post(`/adminapi/v1/commerce_offerings/${id}/add_eligibility`, data),
   getCommerceOfferingPickList: ({ id, ...data }) =>
     get(`/adminapi/v1/commerce_offerings/${id}/picklist`, data),
 


### PR DESCRIPTION
Fixes #527 

- Setup backend `/v1/admin_api/commerce_offering/:id/add_eligibility` endpoint to assign an existing constraint to an offering from the `OfferingDetailPage`
- Test this endpoint
- Update the OfferingDetailPage UI and use the new endpoint to assign the offering eligibility constraint from Admin