### PR TITLE
Admin create products

### DIFF
--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -20,6 +20,7 @@ import OrderDetailPage from "./pages/OrderDetailPage";
 import OrderListPage from "./pages/OrderListPage";
 import PayoutTransactionDetailPage from "./pages/PayoutTransactionDetailPage";
 import PayoutTransactionListPage from "./pages/PayoutTransactionListPage";
+import ProductCreatePage from "./pages/ProductCreatePage";
 import ProductDetailPage from "./pages/ProductDetailPage";
 import ProductListPage from "./pages/ProductListPage";
 import SignInPage from "./pages/SignInPage";
@@ -179,6 +180,11 @@ function PageSwitch() {
         exact
         path="/products"
         element={renderWithHocs(redirectIfUnauthed, withLayout(), ProductListPage)}
+      />
+      <Route
+        exact
+        path="/product/new"
+        element={renderWithHocs(redirectIfUnauthed, withLayout(), ProductCreatePage)}
       />
       <Route
         exact

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -58,6 +58,7 @@ export default {
   unimpersonate: (data) => del(`/adminapi/v1/auth/impersonate`, data),
   getCurrencies: (data) => get(`/adminapi/v1/meta/currencies`, data),
   getSupportedGeographies: (data) => get(`/adminapi/v1/meta/geographies`, data),
+  getVendors: (data) => get(`/adminapi/v1/meta/vendors`, data),
   getVendorServiceCategories: (data) =>
     get(`/adminapi/v1/meta/vendor_service_categories`, data),
   getEligibilityConstraints: (data) =>
@@ -88,6 +89,8 @@ export default {
     get(`/adminapi/v1/commerce_offerings/${id}/picklist`, data),
 
   getCommerceProducts: (data) => get("/adminapi/v1/commerce_products", data),
+  createCommerceProduct: (data) =>
+    postForm("/adminapi/v1/commerce_products/create", data),
   getCommerceProduct: ({ id, ...data }) =>
     get(`/adminapi/v1/commerce_products/${id}`, data),
 

--- a/adminapp/src/components/FormLayout.jsx
+++ b/adminapp/src/components/FormLayout.jsx
@@ -1,0 +1,19 @@
+import { Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import React from "react";
+
+export default function FormLayout({ title, subtitle, onSubmit, children }) {
+  return (
+    <div style={{ maxWidth: 650 }}>
+      <Typography variant="h4" gutterBottom>
+        {title}
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        {subtitle}
+      </Typography>
+      <Box component="form" mt={2} onSubmit={onSubmit}>
+        {children}
+      </Box>
+    </div>
+  );
+}

--- a/adminapp/src/components/ImageFileInput.jsx
+++ b/adminapp/src/components/ImageFileInput.jsx
@@ -1,0 +1,35 @@
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import { Button, FormHelperText, FormLabel, Stack, Typography } from "@mui/material";
+import React from "react";
+
+function ImageFileInput({ image, onImageChange }) {
+  return (
+    <>
+      <FormLabel>Image:</FormLabel>
+      <Stack direction="column" spacing={2}>
+        <Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>
+          Set image
+          <input
+            type="file"
+            name="file"
+            accept=".jpg,.jpeg,.png"
+            hidden
+            required
+            onChange={(e) => onImageChange(e.target.files[0])}
+          />
+        </Button>
+        {Boolean(image) && (
+          <>
+            <img src={URL.createObjectURL(image)} alt={image.name} />
+            <Typography variant="body2">{image.name}</Typography>
+          </>
+        )}
+      </Stack>
+      <FormHelperText sx={{ mb: 2 }}>
+        Use JPEG and PNG formats. Suggest using size 500x500 pixels or above to avoid
+        display issues.
+      </FormHelperText>
+    </>
+  );
+}
+export default ImageFileInput;

--- a/adminapp/src/components/ImageFileInput.jsx
+++ b/adminapp/src/components/ImageFileInput.jsx
@@ -11,10 +11,9 @@ function ImageFileInput({ image, onImageChange }) {
           Set image
           <input
             type="file"
-            name="file"
+            name="image input"
             accept=".jpg,.jpeg,.png"
             hidden
-            required
             onChange={(e) => onImageChange(e.target.files[0])}
           />
         </Button>

--- a/adminapp/src/components/VendorSelect.jsx
+++ b/adminapp/src/components/VendorSelect.jsx
@@ -1,0 +1,57 @@
+import api from "../api";
+import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from "@mui/material";
+import find from "lodash/find";
+import map from "lodash/map";
+import React from "react";
+
+const VendorSelect = React.forwardRef(function VendorServiceCategorySelect(
+  { value, defaultValue, helperText, label, className, style, onChange, ...rest },
+  ref
+) {
+  const [vendors, setVendors] = React.useState([{ name: "" }]);
+
+  const handleChange = React.useCallback(
+    (name) => {
+      const newVendor = find(vendors, (c) => c.name === name) || { name };
+      onChange(name, newVendor);
+    },
+    [vendors, onChange]
+  );
+
+  React.useEffect(() => {
+    api
+      .getVendors()
+      .then(api.pickData)
+      .then((data) => {
+        setVendors(data.items);
+      });
+  }, []);
+
+  React.useEffect(() => {
+    if (map(vendors, "name").includes(defaultValue)) {
+      handleChange(defaultValue);
+    }
+  }, [handleChange, vendors, defaultValue]);
+
+  return (
+    <FormControl className={className} style={style}>
+      {label && <InputLabel htmlFor="vendor-select">{label}</InputLabel>}
+      <Select
+        id="vendor-select"
+        ref={ref}
+        value={value}
+        label="Vendor"
+        onChange={(e) => handleChange(e.target.value)}
+        {...rest}
+      >
+        {vendors.map(({ name }) => (
+          <MenuItem key={name} value={name}>
+            {name}
+          </MenuItem>
+        ))}
+      </Select>
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+    </FormControl>
+  );
+});
+export default VendorSelect;

--- a/adminapp/src/components/VendorSelect.jsx
+++ b/adminapp/src/components/VendorSelect.jsx
@@ -4,7 +4,7 @@ import find from "lodash/find";
 import map from "lodash/map";
 import React from "react";
 
-const VendorSelect = React.forwardRef(function VendorServiceCategorySelect(
+const VendorSelect = React.forwardRef(function VendorSelect(
   { value, defaultValue, helperText, label, className, style, onChange, ...rest },
   ref
 ) {

--- a/adminapp/src/pages/BookTransactionCreatePage.jsx
+++ b/adminapp/src/pages/BookTransactionCreatePage.jsx
@@ -2,14 +2,14 @@ import api from "../api";
 import AutocompleteSearch from "../components/AutocompleteSearch";
 import CurrencyTextField from "../components/CurrencyTextField";
 import FormButtons from "../components/FormButtons";
+import FormLayout from "../components/FormLayout";
 import MultiLingualText from "../components/MultiLingualText";
 import VendorServiceCategorySelect from "../components/VendorServiceCategorySelect";
 import config from "../config";
 import useBusy from "../hooks/useBusy";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import useMountEffect from "../shared/react/useMountEffect";
-import { FormLabel, Stack, Typography } from "@mui/material";
-import Box from "@mui/material/Box";
+import { FormLabel, Stack } from "@mui/material";
 import humps from "humps";
 import React from "react";
 import { useForm } from "react-hook-form";
@@ -73,83 +73,79 @@ export default function BookTransactionCreatePage() {
       .catch(enqueueErrorSnackbar);
   }
   return (
-    <div style={{ maxWidth: 650 }}>
-      <Typography variant="h4" gutterBottom>
-        Create a Book Transaction
-      </Typography>
-      <Typography variant="body1" gutterBottom>
-        Book transactions move virtual money from one ledger to another. They do NOT add
-        funds onto the platform.
-      </Typography>
-      <Box component="form" mt={2} onSubmit={handleSubmit(submit)}>
-        <Stack spacing={2} direction="column">
-          <Stack direction="row" spacing={2}>
-            <AutocompleteSearch
-              {...register("originatingLedger")}
-              label="Originating Ledger"
-              helperText="Where is the money coming from?"
-              value={originatingLedger?.label}
-              fullWidth
-              required
-              search={api.searchLedgers}
-              disabled={Boolean(searchParams.get("originatingLedgerId"))}
-              title={originatingLedger?.label}
-              style={{ flex: 1 }}
-              onValueSelect={(o) => setOriginatingLedger(o)}
-            />
-            <AutocompleteSearch
-              {...register("receivingLedger")}
-              label="Receiving Ledger"
-              helperText="Where is the money going?"
-              value={receivingLedger?.label}
-              fullWidth
-              required
-              search={api.searchLedgers}
-              disabled={Boolean(searchParams.get("receivingLedgerId"))}
-              title={receivingLedger?.label}
-              style={{ flex: 1 }}
-              onValueSelect={(o) => setReceivingLedger(o)}
-            />
-          </Stack>
-          <Stack direction="row" spacing={2}>
-            <CurrencyTextField
-              {...register("amount")}
-              label="Amount"
-              helperText="How much is going from originator to receiver?"
-              money={amount}
-              required
-              autoFocus
-              style={{ flex: 1 }}
-              onMoneyChange={setAmount}
-            />
-            <VendorServiceCategorySelect
-              {...register("category")}
-              defaultValue={searchParams.get("vendorServiceCategorySlug")}
-              label="Category"
-              helperText="What can this be used for?"
-              value={category?.slug || ""}
-              disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
-              title={category?.label}
-              style={{ flex: 1 }}
-              onChange={(_, categoryObj) => setCategory(categoryObj)}
-            />
-          </Stack>
-          <FormLabel>Memo (appears on the ledger):</FormLabel>
-          <Stack direction="row" spacing={2}>
-            <MultiLingualText
-              {...register("memo")}
-              label="Memo"
-              fullWidth
-              value={memo}
-              required
-              searchParams={{ types: ["memo"] }}
-              onChange={(memo) => setMemo(memo)}
-            />
-          </Stack>
-
-          <FormButtons back loading={isBusy} />
+    <FormLayout
+      title="Create a Book Transaction"
+      subtitle="Book transactions move virtual money from one ledger to another. They do NOT add
+        funds onto the platform."
+      onSubmit={handleSubmit(submit)}
+    >
+      <Stack spacing={2} direction="column">
+        <Stack direction="row" spacing={2}>
+          <AutocompleteSearch
+            {...register("originatingLedger")}
+            label="Originating Ledger"
+            helperText="Where is the money coming from?"
+            value={originatingLedger?.label}
+            fullWidth
+            required
+            search={api.searchLedgers}
+            disabled={Boolean(searchParams.get("originatingLedgerId"))}
+            title={originatingLedger?.label}
+            style={{ flex: 1 }}
+            onValueSelect={(o) => setOriginatingLedger(o)}
+          />
+          <AutocompleteSearch
+            {...register("receivingLedger")}
+            label="Receiving Ledger"
+            helperText="Where is the money going?"
+            value={receivingLedger?.label}
+            fullWidth
+            required
+            search={api.searchLedgers}
+            disabled={Boolean(searchParams.get("receivingLedgerId"))}
+            title={receivingLedger?.label}
+            style={{ flex: 1 }}
+            onValueSelect={(o) => setReceivingLedger(o)}
+          />
         </Stack>
-      </Box>
-    </div>
+        <Stack direction="row" spacing={2}>
+          <CurrencyTextField
+            {...register("amount")}
+            label="Amount"
+            helperText="How much is going from originator to receiver?"
+            money={amount}
+            required
+            autoFocus
+            style={{ flex: 1 }}
+            onMoneyChange={setAmount}
+          />
+          <VendorServiceCategorySelect
+            {...register("category")}
+            defaultValue={searchParams.get("vendorServiceCategorySlug")}
+            label="Category"
+            helperText="What can this be used for?"
+            value={category?.slug || ""}
+            disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
+            title={category?.label}
+            style={{ flex: 1 }}
+            onChange={(_, categoryObj) => setCategory(categoryObj)}
+          />
+        </Stack>
+        <FormLabel>Memo (appears on the ledger):</FormLabel>
+        <Stack direction="row" spacing={2}>
+          <MultiLingualText
+            {...register("memo")}
+            label="Memo"
+            fullWidth
+            value={memo}
+            required
+            searchParams={{ types: ["memo"] }}
+            onChange={(memo) => setMemo(memo)}
+          />
+        </Stack>
+
+        <FormButtons back loading={isBusy} />
+      </Stack>
+    </FormLayout>
   );
 }

--- a/adminapp/src/pages/FundingTransactionCreatePage.jsx
+++ b/adminapp/src/pages/FundingTransactionCreatePage.jsx
@@ -2,11 +2,11 @@ import api from "../api";
 import AutocompleteSearch from "../components/AutocompleteSearch";
 import CurrencyTextField from "../components/CurrencyTextField";
 import FormButtons from "../components/FormButtons";
+import FormLayout from "../components/FormLayout";
 import config from "../config";
 import useBusy from "../hooks/useBusy";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
-import { Stack, Typography } from "@mui/material";
-import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
@@ -33,40 +33,36 @@ export default function FundingTransactionCreatePage() {
   }
 
   return (
-    <div style={{ maxWidth: 650 }}>
-      <Typography variant="h4" gutterBottom>
-        Create a Funding Transaction
-      </Typography>
-      <Typography variant="body1" gutterBottom>
-        Funding Transactions add funds onto the platform, and moves funds into the
+    <FormLayout
+      title="Create a Funding Transaction"
+      subtitle="Funding Transactions add funds onto the platform, and moves funds into the
         platform ledger. Creating a Funding Transaction will also create a Book
         Transaction which will transfer the same amount of funds from the platform to the
-        member&rsquo;s cash ledger.
-      </Typography>
-      <Box component="form" mt={2} onSubmit={handleSubmit(submit)}>
-        <Stack spacing={2} direction="column">
-          <Stack direction="row" spacing={2} alignItems="self-start">
-            <CurrencyTextField
-              {...register("amount")}
-              label="Amount"
-              helperText="How much is going from originator to receiver?"
-              money={amount}
-              required
-              onMoneyChange={setAmount}
-            />
-            <AutocompleteSearch
-              {...register("instrument")}
-              label="Payment Instrument"
-              helperText="Where are we debiting the money from?"
-              fullWidth
-              required
-              search={api.searchPaymentInstruments}
-              onValueSelect={(o) => setPaymentInstrument(o)}
-            />
-          </Stack>
-          <FormButtons back loading={isBusy} />
+        member&rsquo;s cash ledger."
+      onSubmit={handleSubmit(submit)}
+    >
+      <Stack spacing={2} direction="column">
+        <Stack direction="row" spacing={2} alignItems="self-start">
+          <CurrencyTextField
+            {...register("amount")}
+            label="Amount"
+            helperText="How much is going from originator to receiver?"
+            money={amount}
+            required
+            onMoneyChange={setAmount}
+          />
+          <AutocompleteSearch
+            {...register("instrument")}
+            label="Payment Instrument"
+            helperText="Where are we debiting the money from?"
+            fullWidth
+            required
+            search={api.searchPaymentInstruments}
+            onValueSelect={(o) => setPaymentInstrument(o)}
+          />
         </Stack>
-      </Box>
-    </div>
+        <FormButtons back loading={isBusy} />
+      </Stack>
+    </FormLayout>
   );
 }

--- a/adminapp/src/pages/OfferingCreatePage.jsx
+++ b/adminapp/src/pages/OfferingCreatePage.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import FormButtons from "../components/FormButtons";
+import FormLayout from "../components/FormLayout";
 import ImageFileInput from "../components/ImageFileInput";
 import MultiLingualText from "../components/MultiLingualText";
 import useBusy from "../hooks/useBusy";
@@ -69,100 +70,96 @@ export default function OfferingCreatePage() {
       .catch(enqueueErrorSnackbar);
   };
   return (
-    <div style={{ maxWidth: 650 }}>
-      <Typography variant="h4" gutterBottom>
-        Create an Offering
-      </Typography>
-      <Typography variant="body1" gutterBottom>
-        Offerings holds products that can be ordered at checkout. They are only available
-        during their period.
-      </Typography>
-      <Box component="form" mt={2} onSubmit={handleSubmit(submit)}>
-        <ImageFileInput image={image} onImageChange={(f) => setImage(f)} />
-        <Stack spacing={2} direction="column">
-          <FormLabel>Description:</FormLabel>
-          <Stack direction={responsiveStackDirection} spacing={2}>
-            <MultiLingualText
-              {...register("description")}
-              label="Description"
-              fullWidth
-              value={description}
-              required
-              onChange={(description) => setDescription(description)}
-            />
-          </Stack>
-          <FormLabel>Fulfillment Prompt (for checkout):</FormLabel>
-          <Stack direction={responsiveStackDirection} spacing={2}>
-            <MultiLingualText
-              {...register("fulfillmentPrompt")}
-              label="Fulfillment Prompt"
-              fullWidth
-              value={fulfillmentPrompt}
-              required
-              onChange={(fulfillmentPrompt) => setFulfillmentPrompt(fulfillmentPrompt)}
-            />
-          </Stack>
-          <FormLabel>Fulfillment Confirmation (for checkout):</FormLabel>
-          <Stack direction={responsiveStackDirection} spacing={2}>
-            <MultiLingualText
-              {...register("fulfillmentConfirmation")}
-              label="Fulfillment Confirmation"
-              fullWidth
-              value={fulfillmentConfirmation}
-              required
-              onChange={(fulfillmentConfirmation) =>
-                setFulfillmentConfirmation(fulfillmentConfirmation)
-              }
-            />
-          </Stack>
-          <FulfillmentOptions
-            options={fulfillmentOptions}
-            setOptions={setFulfillmentOptions}
+    <FormLayout
+      title="Create an Offering"
+      subtitle="Offerings holds products that can be ordered at checkout. They are only available
+        during their period."
+      onSubmit={handleSubmit(submit)}
+    >
+      <ImageFileInput image={image} onImageChange={(f) => setImage(f)} />
+      <Stack spacing={2} direction="column">
+        <FormLabel>Description:</FormLabel>
+        <Stack direction={responsiveStackDirection} spacing={2}>
+          <MultiLingualText
+            {...register("description")}
+            label="Description"
+            fullWidth
+            value={description}
+            required
+            onChange={(description) => setDescription(description)}
           />
-          <FormLabel>Period:</FormLabel>
-          <Stack
-            direction={responsiveStackDirection}
-            alignItems="center"
-            spacing={2}
-            divider={<RemoveIcon />}
-          >
-            <DateTimePicker
-              label="Beginning date *"
-              value={opensAt}
-              closeOnSelect
-              onChange={(date) => setOpensAt(date)}
-              sx={{ width: "100%" }}
-            />
-            <DateTimePicker
-              label="Ending date *"
-              value={closesAt}
-              onChange={(date) => setClosesAt(date)}
-              closeOnSelect
-              sx={{ width: "100%" }}
-            />
-          </Stack>
-          <Divider />
-          <Typography variant="h6">Optional</Typography>
-          <FormLabel>Begin Fulfillment Date (of orders):</FormLabel>
-          <DateTimePicker
-            label="Begin At"
-            value={beginFulfillmentAt}
-            onChange={(date) => setBeginFulfillmentAt(date)}
-            closeOnSelect
-            sx={{ width: { xs: "100%", sm: "50%" } }}
-          />
-          <Stack direction="row" spacing={2}>
-            <FormControlLabel
-              control={<Switch />}
-              label="Prohibit Charge At Checkout"
-              checked={prohibitChargeAtCheckout}
-              onChange={() => setProhibitChargeAtCheckout(!prohibitChargeAtCheckout)}
-            />
-          </Stack>
         </Stack>
-        <FormButtons back loading={isBusy} />
-      </Box>
-    </div>
+        <FormLabel>Fulfillment Prompt (for checkout):</FormLabel>
+        <Stack direction={responsiveStackDirection} spacing={2}>
+          <MultiLingualText
+            {...register("fulfillmentPrompt")}
+            label="Fulfillment Prompt"
+            fullWidth
+            value={fulfillmentPrompt}
+            required
+            onChange={(fulfillmentPrompt) => setFulfillmentPrompt(fulfillmentPrompt)}
+          />
+        </Stack>
+        <FormLabel>Fulfillment Confirmation (for checkout):</FormLabel>
+        <Stack direction={responsiveStackDirection} spacing={2}>
+          <MultiLingualText
+            {...register("fulfillmentConfirmation")}
+            label="Fulfillment Confirmation"
+            fullWidth
+            value={fulfillmentConfirmation}
+            required
+            onChange={(fulfillmentConfirmation) =>
+              setFulfillmentConfirmation(fulfillmentConfirmation)
+            }
+          />
+        </Stack>
+        <FulfillmentOptions
+          options={fulfillmentOptions}
+          setOptions={setFulfillmentOptions}
+        />
+        <FormLabel>Period:</FormLabel>
+        <Stack
+          direction={responsiveStackDirection}
+          alignItems="center"
+          spacing={2}
+          divider={<RemoveIcon />}
+        >
+          <DateTimePicker
+            label="Beginning date *"
+            value={opensAt}
+            closeOnSelect
+            onChange={(date) => setOpensAt(date)}
+            sx={{ width: "100%" }}
+          />
+          <DateTimePicker
+            label="Ending date *"
+            value={closesAt}
+            onChange={(date) => setClosesAt(date)}
+            closeOnSelect
+            sx={{ width: "100%" }}
+          />
+        </Stack>
+        <Divider />
+        <Typography variant="h6">Optional</Typography>
+        <FormLabel>Begin Fulfillment Date (of orders):</FormLabel>
+        <DateTimePicker
+          label="Begin At"
+          value={beginFulfillmentAt}
+          onChange={(date) => setBeginFulfillmentAt(date)}
+          closeOnSelect
+          sx={{ width: { xs: "100%", sm: "50%" } }}
+        />
+        <Stack direction="row" spacing={2}>
+          <FormControlLabel
+            control={<Switch />}
+            label="Prohibit Charge At Checkout"
+            checked={prohibitChargeAtCheckout}
+            onChange={() => setProhibitChargeAtCheckout(!prohibitChargeAtCheckout)}
+          />
+        </Stack>
+      </Stack>
+      <FormButtons back loading={isBusy} />
+    </FormLayout>
   );
 }
 

--- a/adminapp/src/pages/OfferingCreatePage.jsx
+++ b/adminapp/src/pages/OfferingCreatePage.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import FormButtons from "../components/FormButtons";
+import ImageFileInput from "../components/ImageFileInput";
 import MultiLingualText from "../components/MultiLingualText";
 import useBusy from "../hooks/useBusy";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
@@ -9,7 +10,6 @@ import useMountEffect from "../shared/react/useMountEffect";
 import useToggle from "../shared/react/useToggle";
 import withoutAt from "../shared/withoutAt";
 import AddIcon from "@mui/icons-material/Add";
-import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import DeleteIcon from "@mui/icons-material/Delete";
 import RemoveIcon from "@mui/icons-material/Remove";
 import {
@@ -17,7 +17,6 @@ import {
   Divider,
   FormControl,
   FormControlLabel,
-  FormHelperText,
   FormLabel,
   Icon,
   InputLabel,
@@ -79,7 +78,7 @@ export default function OfferingCreatePage() {
         during their period.
       </Typography>
       <Box component="form" mt={2} onSubmit={handleSubmit(submit)}>
-        <OfferingImage image={image} onImageChange={(f) => setImage(f)} />
+        <ImageFileInput image={image} onImageChange={(f) => setImage(f)} />
         <Stack spacing={2} direction="column">
           <FormLabel>Description:</FormLabel>
           <Stack direction={responsiveStackDirection} spacing={2}>
@@ -344,37 +343,6 @@ function OptionAddress({ address, onFieldChange }) {
         />
       </Stack>
     </Stack>
-  );
-}
-
-function OfferingImage({ image, onImageChange }) {
-  return (
-    <>
-      <FormLabel>Image:</FormLabel>
-      <Stack direction="column" spacing={2}>
-        <Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>
-          Set image
-          <input
-            type="file"
-            name="file"
-            accept=".jpg,.jpeg,.png"
-            hidden
-            required
-            onChange={(e) => onImageChange(e.target.files[0])}
-          />
-        </Button>
-        {Boolean(image) && (
-          <>
-            <img src={URL.createObjectURL(image)} alt={image.name} />
-            <Typography variant="body2">{image.name}</Typography>
-          </>
-        )}
-      </Stack>
-      <FormHelperText sx={{ mb: 2 }}>
-        Use JPEG and PNG formats. Suggest using size 500x500 pixels or above to avoid
-        display issues.
-      </FormHelperText>
-    </>
   );
 }
 

--- a/adminapp/src/pages/ProductCreatePage.jsx
+++ b/adminapp/src/pages/ProductCreatePage.jsx
@@ -1,0 +1,154 @@
+import api from "../api";
+import CurrencyTextField from "../components/CurrencyTextField";
+import FormButtons from "../components/FormButtons";
+import ImageFileInput from "../components/ImageFileInput";
+import MultiLingualText from "../components/MultiLingualText";
+import VendorSelect from "../components/VendorSelect";
+import VendorServiceCategorySelect from "../components/VendorServiceCategorySelect";
+import config from "../config";
+import useBusy from "../hooks/useBusy";
+import useErrorSnackbar from "../hooks/useErrorSnackbar";
+import theme from "../theme";
+import { FormLabel, Stack, TextField, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+export default function ProductCreatePage() {
+  const { enqueueErrorSnackbar } = useErrorSnackbar();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [image, setImage] = React.useState(null);
+  const [description, setDescription] = React.useState(newTranslation);
+  const [name, setName] = React.useState(newTranslation);
+  const [ourCost, setOurCost] = React.useState(config.defaultZeroMoney);
+  const [vendor, setVendor] = React.useState(null);
+  const [category, setCategory] = React.useState(null);
+  const maxQuantityPerOffering = React.useRef(1);
+  const maxQuantityPerOrder = React.useRef(1);
+  const { isBusy, busy, notBusy } = useBusy();
+  const { register, handleSubmit } = useForm();
+
+  const submit = () => {
+    busy();
+    api
+      .createCommerceProduct({
+        image,
+        name,
+        description,
+        ourCost,
+        vendorName: vendor?.name,
+        vendorServiceCategorySlug: category?.slug,
+        maxQuantityPerOrder: maxQuantityPerOrder.current.value,
+        maxQuantityPerOffering: maxQuantityPerOffering.current.value,
+      })
+      .then(api.followRedirect(navigate))
+      .tapCatch(notBusy)
+      .catch(enqueueErrorSnackbar);
+  };
+  return (
+    <div style={{ maxWidth: 650 }}>
+      <Typography variant="h4" gutterBottom>
+        Create a Product
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        A product is abstract, it can represent different goods. It is tied to a Vendor
+        and can later be listed with an Offering, a.k.a OfferingProduct. If the Offering
+        and Product are available, product will appear in the Offering list and details
+        page.
+      </Typography>
+      <Box component="form" mt={2} onSubmit={handleSubmit(submit)}>
+        <ImageFileInput image={image} onImageChange={(f) => setImage(f)} />
+        <Stack spacing={2} direction="column">
+          <Stack spacing={2} direction="column">
+            <FormLabel>Name:</FormLabel>
+            <Stack direction={responsiveStackDirection} spacing={2}>
+              <MultiLingualText
+                {...register("name")}
+                label="Name"
+                fullWidth
+                value={name}
+                required
+                onChange={(name) => setName(name)}
+              />
+            </Stack>
+          </Stack>
+          <FormLabel>Description:</FormLabel>
+          <Stack spacing={2}>
+            <MultiLingualText
+              {...register("description")}
+              label="Description"
+              fullWidth
+              value={description}
+              required
+              onChange={(description) => setDescription(description)}
+            />
+          </Stack>
+          <Stack
+            direction={responsiveStackDirection}
+            spacing={2}
+            sx={{ pt: theme.spacing(2) }}
+          >
+            <CurrencyTextField
+              {...register("ourCost")}
+              label="Our Cost"
+              helperText="How much does suma offer this product for?"
+              money={ourCost}
+              required
+              style={{ flex: 1 }}
+              onMoneyChange={setOurCost}
+            />
+            <VendorSelect
+              {...register("vendor")}
+              defaultValue={searchParams.get("vendorName")}
+              label="Vendor"
+              helperText="What vendor offers this product?"
+              value={vendor?.name || ""}
+              disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
+              title={vendor?.name}
+              style={{ flex: 1 }}
+              onChange={(_, vendorObj) => setVendor(vendorObj)}
+            />
+            <VendorServiceCategorySelect
+              {...register("category")}
+              defaultValue={searchParams.get("vendorServiceCategorySlug")}
+              label="Category"
+              helperText="What can this be used for?"
+              value={category?.slug || ""}
+              disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
+              title={category?.label}
+              style={{ flex: 1 }}
+              onChange={(_, categoryObj) => setCategory(categoryObj)}
+              required
+            />
+          </Stack>
+          <Typography variant="h6">Inventory</Typography>
+          <Stack direction={responsiveStackDirection} spacing={2}>
+            <TextField
+              inputRef={maxQuantityPerOffering}
+              type="number"
+              label="Max Quantity Per Offering"
+              helperText="The maximum allowed for this offering per member"
+              fullWidth
+              required
+            />
+            <TextField
+              inputRef={maxQuantityPerOrder}
+              type="number"
+              label="Max Quantity Per Order"
+              helperText="The maximum allowed for each member's order"
+              fullWidth
+              required
+            />
+          </Stack>
+          <FormButtons back loading={isBusy} />
+        </Stack>
+      </Box>
+    </div>
+  );
+}
+
+const newTranslation = { en: "", es: "" };
+
+const responsiveStackDirection = { xs: "column", sm: "row" };

--- a/adminapp/src/pages/ProductCreatePage.jsx
+++ b/adminapp/src/pages/ProductCreatePage.jsx
@@ -13,12 +13,11 @@ import theme from "../theme";
 import { FormLabel, Stack, TextField, Typography } from "@mui/material";
 import React from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function ProductCreatePage() {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const [image, setImage] = React.useState(null);
   const [description, setDescription] = React.useState(newTranslation);
   const [name, setName] = React.useState(newTranslation);
@@ -52,8 +51,8 @@ export default function ProductCreatePage() {
       title="Create a Product"
       subtitle="A product is abstract, it can represent different goods. It is tied to a Vendor
         and can later be listed with an Offering, a.k.a OfferingProduct. If the Offering
-        and Product are available, product will appear in the Offering list and details
-        page."
+        and Product are available on the platform, product will appear in the Food list and details
+        page. Discount price can be set when creating an OfferingProduct."
       onSubmit={handleSubmit(submit)}
     >
       <ImageFileInput image={image} onImageChange={(f) => setImage(f)} />
@@ -98,22 +97,18 @@ export default function ProductCreatePage() {
           />
           <VendorSelect
             {...register("vendor")}
-            defaultValue={searchParams.get("vendorName")}
             label="Vendor"
             helperText="What vendor offers this product?"
             value={vendor?.name || ""}
-            disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
             title={vendor?.name}
             style={{ flex: 1 }}
             onChange={(_, vendorObj) => setVendor(vendorObj)}
           />
           <VendorServiceCategorySelect
             {...register("category")}
-            defaultValue={searchParams.get("vendorServiceCategorySlug")}
             label="Category"
             helperText="What can this be used for?"
             value={category?.slug || ""}
-            disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
             title={category?.label}
             style={{ flex: 1 }}
             onChange={(_, categoryObj) => setCategory(categoryObj)}

--- a/adminapp/src/pages/ProductCreatePage.jsx
+++ b/adminapp/src/pages/ProductCreatePage.jsx
@@ -1,6 +1,7 @@
 import api from "../api";
 import CurrencyTextField from "../components/CurrencyTextField";
 import FormButtons from "../components/FormButtons";
+import FormLayout from "../components/FormLayout";
 import ImageFileInput from "../components/ImageFileInput";
 import MultiLingualText from "../components/MultiLingualText";
 import VendorSelect from "../components/VendorSelect";
@@ -10,7 +11,6 @@ import useBusy from "../hooks/useBusy";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import theme from "../theme";
 import { FormLabel, Stack, TextField, Typography } from "@mui/material";
-import Box from "@mui/material/Box";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -48,104 +48,100 @@ export default function ProductCreatePage() {
       .catch(enqueueErrorSnackbar);
   };
   return (
-    <div style={{ maxWidth: 650 }}>
-      <Typography variant="h4" gutterBottom>
-        Create a Product
-      </Typography>
-      <Typography variant="body1" gutterBottom>
-        A product is abstract, it can represent different goods. It is tied to a Vendor
+    <FormLayout
+      title="Create a Product"
+      subtitle="A product is abstract, it can represent different goods. It is tied to a Vendor
         and can later be listed with an Offering, a.k.a OfferingProduct. If the Offering
         and Product are available, product will appear in the Offering list and details
-        page.
-      </Typography>
-      <Box component="form" mt={2} onSubmit={handleSubmit(submit)}>
-        <ImageFileInput image={image} onImageChange={(f) => setImage(f)} />
+        page."
+      onSubmit={handleSubmit(submit)}
+    >
+      <ImageFileInput image={image} onImageChange={(f) => setImage(f)} />
+      <Stack spacing={2} direction="column">
         <Stack spacing={2} direction="column">
-          <Stack spacing={2} direction="column">
-            <FormLabel>Name:</FormLabel>
-            <Stack direction={responsiveStackDirection} spacing={2}>
-              <MultiLingualText
-                {...register("name")}
-                label="Name"
-                fullWidth
-                value={name}
-                required
-                onChange={(name) => setName(name)}
-              />
-            </Stack>
-          </Stack>
-          <FormLabel>Description:</FormLabel>
-          <Stack spacing={2}>
-            <MultiLingualText
-              {...register("description")}
-              label="Description"
-              fullWidth
-              value={description}
-              required
-              onChange={(description) => setDescription(description)}
-            />
-          </Stack>
-          <Stack
-            direction={responsiveStackDirection}
-            spacing={2}
-            sx={{ pt: theme.spacing(2) }}
-          >
-            <CurrencyTextField
-              {...register("ourCost")}
-              label="Our Cost"
-              helperText="How much does suma offer this product for?"
-              money={ourCost}
-              required
-              style={{ flex: 1 }}
-              onMoneyChange={setOurCost}
-            />
-            <VendorSelect
-              {...register("vendor")}
-              defaultValue={searchParams.get("vendorName")}
-              label="Vendor"
-              helperText="What vendor offers this product?"
-              value={vendor?.name || ""}
-              disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
-              title={vendor?.name}
-              style={{ flex: 1 }}
-              onChange={(_, vendorObj) => setVendor(vendorObj)}
-            />
-            <VendorServiceCategorySelect
-              {...register("category")}
-              defaultValue={searchParams.get("vendorServiceCategorySlug")}
-              label="Category"
-              helperText="What can this be used for?"
-              value={category?.slug || ""}
-              disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
-              title={category?.label}
-              style={{ flex: 1 }}
-              onChange={(_, categoryObj) => setCategory(categoryObj)}
-              required
-            />
-          </Stack>
-          <Typography variant="h6">Inventory</Typography>
+          <FormLabel>Name:</FormLabel>
           <Stack direction={responsiveStackDirection} spacing={2}>
-            <TextField
-              inputRef={maxQuantityPerOffering}
-              type="number"
-              label="Max Quantity Per Offering"
-              helperText="The maximum allowed for this offering per member"
+            <MultiLingualText
+              {...register("name")}
+              label="Name"
               fullWidth
+              value={name}
               required
-            />
-            <TextField
-              inputRef={maxQuantityPerOrder}
-              type="number"
-              label="Max Quantity Per Order"
-              helperText="The maximum allowed for each member's order"
-              fullWidth
-              required
+              onChange={(name) => setName(name)}
             />
           </Stack>
-          <FormButtons back loading={isBusy} />
         </Stack>
-      </Box>
-    </div>
+        <FormLabel>Description:</FormLabel>
+        <Stack spacing={2}>
+          <MultiLingualText
+            {...register("description")}
+            label="Description"
+            fullWidth
+            value={description}
+            required
+            onChange={(description) => setDescription(description)}
+          />
+        </Stack>
+        <Stack
+          direction={responsiveStackDirection}
+          spacing={2}
+          sx={{ pt: theme.spacing(2) }}
+        >
+          <CurrencyTextField
+            {...register("ourCost")}
+            label="Our Cost"
+            helperText="How much does suma offer this product for?"
+            money={ourCost}
+            required
+            style={{ flex: 1 }}
+            onMoneyChange={setOurCost}
+          />
+          <VendorSelect
+            {...register("vendor")}
+            defaultValue={searchParams.get("vendorName")}
+            label="Vendor"
+            helperText="What vendor offers this product?"
+            value={vendor?.name || ""}
+            disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
+            title={vendor?.name}
+            style={{ flex: 1 }}
+            onChange={(_, vendorObj) => setVendor(vendorObj)}
+          />
+          <VendorServiceCategorySelect
+            {...register("category")}
+            defaultValue={searchParams.get("vendorServiceCategorySlug")}
+            label="Category"
+            helperText="What can this be used for?"
+            value={category?.slug || ""}
+            disabled={Boolean(searchParams.get("vendorServiceCategorySlug"))}
+            title={category?.label}
+            style={{ flex: 1 }}
+            onChange={(_, categoryObj) => setCategory(categoryObj)}
+            required
+          />
+        </Stack>
+        <Typography variant="h6">Inventory</Typography>
+        <Stack direction={responsiveStackDirection} spacing={2}>
+          <TextField
+            inputRef={maxQuantityPerOffering}
+            type="number"
+            label="Max Quantity Per Offering"
+            helperText="The maximum allowed for this offering per member"
+            fullWidth
+            required
+          />
+          <TextField
+            inputRef={maxQuantityPerOrder}
+            type="number"
+            label="Max Quantity Per Order"
+            helperText="The maximum allowed for each member's order"
+            fullWidth
+            required
+          />
+        </Stack>
+        <FormButtons back loading={isBusy} />
+      </Stack>
+    </FormLayout>
   );
 }
 

--- a/adminapp/src/pages/ProductListPage.jsx
+++ b/adminapp/src/pages/ProductListPage.jsx
@@ -1,5 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import FabAdd from "../components/FabAdd";
+import Link from "../components/Link";
 import ResourceTable from "../components/ResourceTable";
 import { dayjs } from "../modules/dayConfig";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
@@ -28,45 +30,48 @@ export default function ProductListPage() {
     }
   );
   return (
-    <ResourceTable
-      page={page}
-      perPage={perPage}
-      search={search}
-      order={order}
-      orderBy={orderBy}
-      title="Products"
-      listResponse={listResponse}
-      listLoading={listLoading}
-      tableProps={{ sx: { minWidth: 650 }, size: "small" }}
-      onParamsChange={setListQueryParams}
-      columns={[
-        {
-          id: "id",
-          label: "ID",
-          align: "center",
-          sortable: true,
-          render: (c) => <AdminLink model={c} />,
-        },
-        {
-          id: "created_at",
-          label: "Created",
-          align: "left",
-          sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
-        },
-        {
-          id: "name",
-          label: "Name",
-          align: "left",
-          render: (c) => <AdminLink model={c}>{c.name}</AdminLink>,
-        },
-        {
-          id: "vendor",
-          label: "Vendor",
-          align: "left",
-          render: (c) => c.vendor.name,
-        },
-      ]}
-    />
+    <>
+      <FabAdd component={Link} href={"/product/new"} />
+      <ResourceTable
+        page={page}
+        perPage={perPage}
+        search={search}
+        order={order}
+        orderBy={orderBy}
+        title="Products"
+        listResponse={listResponse}
+        listLoading={listLoading}
+        tableProps={{ sx: { minWidth: 650 }, size: "small" }}
+        onParamsChange={setListQueryParams}
+        columns={[
+          {
+            id: "id",
+            label: "ID",
+            align: "center",
+            sortable: true,
+            render: (c) => <AdminLink model={c} />,
+          },
+          {
+            id: "created_at",
+            label: "Created",
+            align: "left",
+            sortable: true,
+            render: (c) => dayjs(c.createdAt).format("lll"),
+          },
+          {
+            id: "name",
+            label: "Name",
+            align: "left",
+            render: (c) => <AdminLink model={c}>{c.name}</AdminLink>,
+          },
+          {
+            id: "vendor",
+            label: "Vendor",
+            align: "left",
+            render: (c) => c.vendor.name,
+          },
+        ]}
+      />
+    </>
   );
 }

--- a/lib/suma/admin_api/commerce_products.rb
+++ b/lib/suma/admin_api/commerce_products.rb
@@ -24,6 +24,45 @@ class Suma::AdminAPI::CommerceProducts < Suma::AdminAPI::V1
       present_collection ds, with: ProductEntity
     end
 
+    params do
+      requires :image, type: File
+      requires :name, type: JSON do
+        use :translated_text
+      end
+      requires :description, type: JSON do
+        use :translated_text
+      end
+      requires :our_cost, allow_blank: false, type: JSON do
+        use :funding_money
+      end
+      requires :vendor_name, type: String
+      requires :vendor_service_category_slug, type: String
+      requires :max_quantity_per_order, type: Integer
+      requires :max_quantity_per_offering, type: Integer
+    end
+    post :create do
+      (vendor = Suma::Vendor[name: params[:vendor_name]]) or forbidden!
+      (vsc = Suma::Vendor::ServiceCategory[slug: params[:vendor_service_category_slug]]) or forbidden!
+      product = Suma::Commerce::Product.create(
+        name: Suma::TranslatedText.find_or_create(**params[:name]),
+        description: Suma::TranslatedText.find_or_create(**params[:description]),
+        our_cost: params[:our_cost],
+        vendor:,
+      )
+      product.add_vendor_service_category(vsc)
+      uploaded_file = Suma::UploadedFile.create_from_multipart(params[:image])
+      product.add_image({uploaded_file:})
+
+      Suma::Commerce::ProductInventory.create(
+        product:,
+        max_quantity_per_order: params[:max_quantity_per_order],
+        max_quantity_per_offering: params[:max_quantity_per_offering],
+      )
+      created_resource_headers(product.id, product.admin_link)
+      status 200
+      present product, with: DetailedProductEntity
+    end
+
     route_param :id, type: Integer do
       helpers do
         def lookup

--- a/lib/suma/admin_api/meta.rb
+++ b/lib/suma/admin_api/meta.rb
@@ -26,6 +26,12 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
       present result
     end
 
+    get :vendors do
+      use_http_expires_caching 12.hours
+      v = Suma::Vendor.dataset.order(:name).all
+      present_collection v, with: VendorCollectionEntity
+    end
+
     get :vendor_service_categories do
       use_http_expires_caching 12.hours
       sc = Suma::Vendor::ServiceCategory.dataset.order(:name).all
@@ -43,6 +49,10 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
   class CurrencyEntity < BaseEntity
     expose :symbol
     expose :code
+  end
+
+  class VendorCollectionEntity < BaseEntity
+    expose :name
   end
 
   class HierarchicalCategoryEntity < BaseEntity

--- a/spec/suma/admin_api/commerce_products_spec.rb
+++ b/spec/suma/admin_api/commerce_products_spec.rb
@@ -63,6 +63,32 @@ RSpec.describe Suma::AdminAPI::CommerceProducts, :db do
     end
   end
 
+  describe "GET /v1/commerce_products/create" do
+    it "creates the offering" do
+      photo_file = File.open("spec/data/images/photo.png", "rb")
+      image = Rack::Test::UploadedFile.new(photo_file, "image/png", true)
+      cat = Suma::Fixtures.vendor_service_category.food.create
+      vs = Suma::Fixtures.vendor_service.create
+
+      post "/v1/commerce_products/create",
+           image: image,
+           name: {en: "EN name", es: "ES name"},
+           description: {en: "EN description", es: "ES description"},
+           our_cost: {cents: 2400},
+           vendor_name: vs.vendor.name,
+           vendor_service_category_slug: cat.slug,
+           max_quantity_per_order: 500,
+           max_quantity_per_offering: 500
+
+      expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Created-Resource-Admin")
+      p = Suma::Commerce::Product.first
+      expect(Suma::Commerce::Product.all).to have_length(1)
+      expect(p).to have_attributes(our_cost: cost("$24"))
+      expect(p.inventory).to have_attributes(product: p)
+    end
+  end
+
   describe "GET /v1/commerce_products/:id" do
     it "returns the product" do
       x = Suma::Fixtures.product.create

--- a/spec/suma/admin_api/meta_spec.rb
+++ b/spec/suma/admin_api/meta_spec.rb
@@ -48,6 +48,23 @@ RSpec.describe Suma::AdminAPI::Meta, :db do
     end
   end
 
+  describe "GET /v1/meta/vendors" do
+    it "returns vendors" do
+      Suma::Fixtures.vendor(name: "A").create
+      Suma::Fixtures.vendor.create(name: "B")
+
+      get "/v1/meta/vendors"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        items: [
+          {name: "A"},
+          {name: "B"},
+        ],
+      )
+    end
+  end
+
   describe "GET /v1/meta/vendor_service_categories" do
     it "returns categories" do
       a = Suma::Fixtures.vendor_service_category(name: "A").create


### PR DESCRIPTION
Fixes #525 

- Create POST (form) `/adminapi/v1/commerce_products/create` endpoint and test
- Create GET `/adminapi/v1/meta/vendors` endpoint and test
Create a product create page:
- Create a Vendor select reusable component
- Create a ImageFileInput reusable component
- Use it in the admin UI to fetch and select a product vendor
- Make UI mobile responsive
- Create and use Form Layout reusable component everywhere

### Admin Product create page
![image](https://github.com/lithictech/suma/assets/66847768/3ca03756-066c-4506-9ced-7f3c6c56d92a)

### Admin Product list FabAdd button
<img width="696" alt="Screenshot 2023-10-25 at 3 47 54 PM" src="https://github.com/lithictech/suma/assets/66847768/13fa880e-539f-4d18-a319-5d5fe1c05457">
