### PR TITLE
Add eligibility constraint names column to member download

### DIFF
--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -21,7 +21,7 @@ class Suma::Member::Exporter
     ["Zip", ->(m) { m.legal_entity.address&.postal_code }],
     ["Country", ->(m) { m.legal_entity.address&.country }],
     ["Verified", ->(m) { m.onboarding_verified_at ? true : false }],
-    ["Eligibility Constraints", ->(m) { m.verified_eligibility_constraints.map(&:name).join(" | ") }],
+    ["Eligibility Constraints", ->(m) { m.verified_eligibility_constraints.map(&:name).join("|") }],
     ["Deleted", ->(m) { m.soft_deleted_at ? true : false }],
     ["Timezone", ->(m) { m.timezone }],
   ].freeze

--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -21,7 +21,7 @@ class Suma::Member::Exporter
     ["Zip", ->(m) { m.legal_entity.address&.postal_code }],
     ["Country", ->(m) { m.legal_entity.address&.country }],
     ["Verified", ->(m) { m.onboarding_verified_at ? true : false }],
-    ["Eligibility Constraints", ->(m) { m.verified_eligibility_constraints.map(&:name).join(" - ") }],
+    ["Eligibility Constraints", ->(m) { m.verified_eligibility_constraints.map(&:name).join(" | ") }],
     ["Deleted", ->(m) { m.soft_deleted_at ? true : false }],
     ["Timezone", ->(m) { m.timezone }],
   ].freeze

--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -21,6 +21,7 @@ class Suma::Member::Exporter
     ["Zip", ->(m) { m.legal_entity.address&.postal_code }],
     ["Country", ->(m) { m.legal_entity.address&.country }],
     ["Verified", ->(m) { m.onboarding_verified_at ? true : false }],
+    ["Eligibility Constraints", ->(m) { m.verified_eligibility_constraints.map(&:name).join(" - ") }],
     ["Deleted", ->(m) { m.soft_deleted_at ? true : false }],
     ["Timezone", ->(m) { m.timezone }],
   ].freeze

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Suma::Member::Exporter, :db do
     csv = described_class.new(Suma::Member.dataset).to_csv
     lines = <<~LINES
       Id,Name,Lang,Channel,Event,Phone,IntlPhone,Email,Address1,Address2,City,State,Zip,Country,Verified,Eligibility Constraints,Deleted,Timezone
-      #{allfields.id},ABC,en,chan,ev,(222) 333-4444,12223334444,a@b.c,123 Main,"",Portland,Oregon,97214,US,true,"Homes, Oregon - Casa, Oregon",false,America/Los_Angeles
+      #{allfields.id},ABC,en,chan,ev,(222) 333-4444,12223334444,a@b.c,123 Main,"",Portland,Oregon,97214,US,true,"Homes, Oregon | Casa, Oregon",false,America/Los_Angeles
       #{plain.id},XYZ,,,,(222) 333-9999,12223339999,x@y.z,,,,,,,false,"",true,America/Los_Angeles
     LINES
     expect(csv).to eq(lines)

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Suma::Member::Exporter, :db do
     csv = described_class.new(Suma::Member.dataset).to_csv
     lines = <<~LINES
       Id,Name,Lang,Channel,Event,Phone,IntlPhone,Email,Address1,Address2,City,State,Zip,Country,Verified,Eligibility Constraints,Deleted,Timezone
-      #{allfields.id},ABC,en,chan,ev,(222) 333-4444,12223334444,a@b.c,123 Main,"",Portland,Oregon,97214,US,true,"Homes, Oregon | Casa, Oregon",false,America/Los_Angeles
+      #{allfields.id},ABC,en,chan,ev,(222) 333-4444,12223334444,a@b.c,123 Main,"",Portland,Oregon,97214,US,true,"Homes, Oregon|Casa, Oregon",false,America/Los_Angeles
       #{plain.id},XYZ,,,,(222) 333-9999,12223339999,x@y.z,,,,,,,false,"",true,America/Los_Angeles
     LINES
     expect(csv).to eq(lines)

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -12,13 +12,21 @@ RSpec.describe Suma::Member::Exporter, :db do
     allfields.legal_entity.update(address:)
     allfields.message_preferences!
 
+    eligibility_constraints = [
+      Suma::Fixtures.eligibility_constraint.create(name: "Homes, Oregon"),
+      Suma::Fixtures.eligibility_constraint.create(name: "Casa, Oregon"),
+    ]
+    eligibility_constraints.each do |constraint|
+      allfields.add_verified_eligibility_constraint(constraint)
+    end
+
     plain = Suma::Fixtures.member.create(name: "XYZ", phone: "12223339999", email: "x@y.z", soft_deleted_at: Time.at(5))
 
     csv = described_class.new(Suma::Member.dataset).to_csv
     lines = <<~LINES
-      Id,Name,Lang,Channel,Event,Phone,IntlPhone,Email,Address1,Address2,City,State,Zip,Country,Verified,Deleted,Timezone
-      #{allfields.id},ABC,en,chan,ev,(222) 333-4444,12223334444,a@b.c,123 Main,"",Portland,Oregon,97214,US,true,false,America/Los_Angeles
-      #{plain.id},XYZ,,,,(222) 333-9999,12223339999,x@y.z,,,,,,,false,true,America/Los_Angeles
+      Id,Name,Lang,Channel,Event,Phone,IntlPhone,Email,Address1,Address2,City,State,Zip,Country,Verified,Eligibility Constraints,Deleted,Timezone
+      #{allfields.id},ABC,en,chan,ev,(222) 333-4444,12223334444,a@b.c,123 Main,"",Portland,Oregon,97214,US,true,"Homes, Oregon - Casa, Oregon",false,America/Los_Angeles
+      #{plain.id},XYZ,,,,(222) 333-9999,12223339999,x@y.z,,,,,,,false,"",true,America/Los_Angeles
     LINES
     expect(csv).to eq(lines)
   end


### PR DESCRIPTION
Fixes #543 
Add "Eligibility Constraints" column to member CSV download in the Admin portal, this lists all the names separated by a dash (-).