### PR TITLE
Add a topic shim job

### DIFF
--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -34,6 +34,7 @@ module Suma::Async
     "suma/async/stripe_refunds_backfiller",
     "suma/async/sync_lime_free_bike_status_gbfs",
     "suma/async/sync_lime_geofencing_zones_gbfs",
+    "suma/async/topic_shim",
     "suma/async/upsert_frontapp_contact",
   ].freeze
 

--- a/lib/suma/async/topic_shim.rb
+++ b/lib/suma/async/topic_shim.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "suma/async"
+
+# Re-publish certain events as other events.
+# Used to shim other parts of the backend, like turning a suma.member.updated event
+# of the onboarding_verified_at field, into a suma.member.verified event.
+class Suma::Async::TopicShim
+  extend Amigo::Job
+
+  on "*"
+
+  def _perform(event)
+    case event.name
+        when "suma.member.updated"
+          member = self.lookup_model(Suma::Member, event)
+          case event.payload[1]
+              when changed(:onboarding_verified_at, from: nil)
+                Amigo.publish("suma.member.verified", member.id)
+            end
+      end
+  end
+end

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -321,4 +321,16 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
       expect(Suma::AnonProxy::MessageHandler::Fake.handled).to have_length(1)
     end
   end
+
+  describe "TopicShim" do
+    it "shims onboarding verified" do
+      u = Suma::Fixtures.member.create
+      expect do
+        u.onboarding_verified_at = Time.now
+        expect do
+          u.save_changes
+        end.to publish("suma.member.verified", [u.id])
+      end.to perform_async_job(Suma::Async::TopicShim)
+    end
+  end
 end


### PR DESCRIPTION
In some cases we want to use simpler events,
like `suma.member.verified`. This shim job looks at all jobs and emits an event based on custom logic.

This is sort of a gross workaround,
but it's needed for automation triggers to avoid making them way more complex. Once we get rid of automation triggers, we should look at eliminating this job as well.