### PR TITLE
Removes from fulfillment pending quantity on order cancel

### DIFF
--- a/lib/suma/commerce/order.rb
+++ b/lib/suma/commerce/order.rb
@@ -63,6 +63,10 @@ class Suma::Commerce::Order < Suma::Postgres::Model(:commerce_orders)
   state_machine :order_status, initial: :open do
     state :open, :completed, :canceled
 
+    event :cancel do
+      transition open: :canceled
+    end
+
     after_transition(&:commit_audit_log)
     after_failure(&:commit_audit_log)
   end
@@ -118,6 +122,18 @@ class Suma::Commerce::Order < Suma::Postgres::Model(:commerce_orders)
   # charges to orders, so we keep track of this additional data via associated_funding_transaction.
   def funded_amount
     return self.charges.map(&:associated_funding_transactions).flatten.sum(Money.new(0), &:amount)
+  end
+
+  def cancel
+    transitioning = super
+    return unless transitioning
+    if self.fulfillment_status == "unfulfilled"
+      self.limited_quantity_items.each do |ci|
+        ci.offering_product.product.inventory.quantity_pending_fulfillment -= ci.quantity
+        ci.offering_product.product.inventory.save_changes
+      end
+    end
+    return true
   end
 
   def admin_status_label

--- a/spec/suma/commerce/order_spec.rb
+++ b/spec/suma/commerce/order_spec.rb
@@ -105,6 +105,13 @@ RSpec.describe "Suma::Commerce::Order", :db do
       ) # Assert has no changed, since the quantity modification has not been applied yet
     end
 
+    it "removes from quantity pending fulfillment when canceling an open order" do
+      expect(order).to transition_on(:cancel).to("canceled")
+      expect(limited_product.inventory.refresh).to have_attributes(
+        quantity_on_hand: 4, quantity_pending_fulfillment: 1,
+      )
+    end
+
     it "can claim claimable orders" do
       expect(order).to not_transition_on(:claim)
       expect(order).to transition_on(:begin_fulfillment).to("fulfilling")


### PR DESCRIPTION
Fixes #560 

- Use an order's state_machine "cancel" event to remove from fulfillment pending quantity when an order is cancelled
- Test