### PR TITLE
Fixes regarding SMS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "sidekiq-unique-jobs"
 gem "signalwire"
 gem "state_machines"
 gem "stripe"
+gem "twilio-ruby", "~> 5.74"
 gem "warden"
 gem "yajl-ruby"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,7 @@ DEPENDENCIES
   state_machines
   stripe
   timecop
+  twilio-ruby (~> 5.74)
   warden
   webmock
   yajl-ruby

--- a/adminapp/src/pages/EligibilityConstraintDetailPage.jsx
+++ b/adminapp/src/pages/EligibilityConstraintDetailPage.jsx
@@ -31,7 +31,7 @@ export default function EligibilityConstraintDetailPage() {
               </AdminLink>,
               dayjs(row.createdAt).format("lll"),
               <AdminLink key={row.id} model={row}>
-                {row.description}
+                {row.description.en}
               </AdminLink>,
               dayjs(row.opensAt).format("lll"),
               dayjs(row.closesAt).format("lll"),

--- a/adminapp/src/pages/OrderDetailPage.jsx
+++ b/adminapp/src/pages/OrderDetailPage.jsx
@@ -63,8 +63,12 @@ export default function OrderDetailPage() {
               { label: "Total", value: <Money>{checkout.total}</Money> },
               { label: "Instrument", value: checkout.paymentInstrument.adminLabel },
               {
-                label: "Fulfillment",
-                value: <Fulfillment f={checkout.fulfillmentOption} />,
+                label: "Fulfillment (En)",
+                value: checkout.fulfillmentOption.description.en,
+              },
+              {
+                label: "Fulfillment (Es)",
+                value: checkout.fulfillmentOption.description.es,
               },
             ]}
           />
@@ -96,8 +100,4 @@ export default function OrderDetailPage() {
       )}
     </>
   );
-}
-
-function Fulfillment({ f }) {
-  return `${f.description}`;
 }

--- a/data/messages/templates/offerings/2023-12-holiday-confirmation.en.sms.liquid
+++ b/data/messages/templates/offerings/2023-12-holiday-confirmation.en.sms.liquid
@@ -1,1 +1,1 @@
-Thanks for your order! We'll reach out by December 15 with information about pickup. Respond to this text or email apphelp@mysuma.org if you need help. - suma
+suma: Thanks for your order! We'll reach out by December 15 with information about pickup. Reply HELP if you have questions. Reply STOP to unsubscribe.

--- a/data/messages/templates/offerings/2023-12-holiday-confirmation.es.sms.liquid
+++ b/data/messages/templates/offerings/2023-12-holiday-confirmation.es.sms.liquid
@@ -1,1 +1,1 @@
-¡Gracias por tu pedido! Nos pondremos en contacto antes del 15 de diciembre con información sobre la recogida. Responda a este texto o envíe un correo electrónico a apphelp@mysuma.org si necesita ayuda. - suma
+suma: ¡Gracias por tu pedido! Nos pondremos en contacto antes del 15 de diciembre con información sobre la recogida. Responde HELP si tienes preguntas. Responda STOP para cancelar la suscripción.

--- a/lib/suma/message/sms_transport.rb
+++ b/lib/suma/message/sms_transport.rb
@@ -4,6 +4,7 @@ require "appydays/configurable"
 require "appydays/loggable"
 require "suma/message/transport"
 require "suma/signalwire"
+require "suma/twilio"
 
 class Suma::Message::SmsTransport < Suma::Message::Transport
   include Appydays::Configurable
@@ -65,9 +66,21 @@ class Suma::Message::SmsTransport < Suma::Message::Transport
 
     body = delivery.bodies.first.content
     begin
-      self.logger.info("send_twilio_sms", to: to_phone, message_preview: body.slice(0, 20))
-      response = Suma::Signalwire.send_sms(from_phone, to_phone, body)
-      sid = response.sid
+      if delivery.template == self.class.verification_template
+        self.logger.info("send_verification_sms", to: to_phone)
+        rmatch = Regexp.new(self.class.verification_code_regex).match(body.strip)
+        raise "Cannot extract verification code from '#{body}' using '#{self.class.verification_code_regex}'" if
+          rmatch.nil?
+        response = Suma::Twilio.send_verification(to_phone, code: rmatch[1], locale: delivery.template_language)
+        # If we send the reset code multiple times with multiple deliveries,
+        # we get the same SID/message id, but different attempts. Disambiguate them,
+        # since we expect message ids to be empty.
+        sid = "#{response.sid}-#{response.send_code_attempts.length}"
+      else
+        self.logger.info("send_twilio_sms", to: to_phone, message_preview: body.slice(0, 20))
+        response = Suma::Signalwire.send_sms(from_phone, to_phone, body)
+        sid = response.sid
+      end
     rescue Twilio::REST::RestError => e
       if (logmsg = FATAL_SIGNALWIRE_ERROR_CODES[e.code])
         self.logger.warn(logmsg, phone: to_phone, body:, error: e.response.body)

--- a/lib/suma/twilio.rb
+++ b/lib/suma/twilio.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "twilio-ruby"
+
+require "appydays/configurable"
+require "appydays/loggable"
+
+module Suma::Twilio
+  include Appydays::Configurable
+  include Appydays::Loggable
+
+  configurable(:twilio) do
+    setting :account_sid, "AC444test"
+    setting :secret_id, "twilapikey_sid"
+    setting :secret, "twilsecret"
+    setting :verification_sid, "VA555test"
+
+    after_configured do
+      @client = Twilio::REST::Client.new(self.secret_id, self.secret, self.account_sid, nil, nil, self.logger)
+    end
+  end
+
+  class << self
+    attr_accessor :client
+  end
+
+  def self.send_verification(to, code:, locale:, channel: "sms")
+    return self.client.verify.
+        v2.
+        services(self.verification_sid).
+        verifications.
+        create(to:, channel:, custom_code: code, locale:)
+  end
+
+  # Update the verification. Usually used to change the status (status: 'canceled' or 'approved') of reset codes.
+  def self.update_verification(ve_id, kw)
+    return self.client.verify.
+        v2.
+        services(self.verification_sid).
+        verifications(ve_id).
+        update(**kw)
+  end
+end

--- a/spec/data/twilio/post_verification.json
+++ b/spec/data/twilio/post_verification.json
@@ -1,0 +1,23 @@
+{
+  "sid": "VE123",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+15017122661",
+  "channel": "sms",
+  "status": "pending",
+  "valid": false,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "lookup": {},
+  "amount": null,
+  "payee": null,
+  "send_code_attempts": [
+    {
+      "time": "2015-07-30T20:00:00Z",
+      "channel": "SMS",
+      "attempt_sid": "VLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    }
+  ],
+  "sna": null,
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications/VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}

--- a/spec/suma/message/sms_transport_spec.rb
+++ b/spec/suma/message/sms_transport_spec.rb
@@ -80,6 +80,30 @@ RSpec.describe Suma::Message::SmsTransport, :db, reset_configuration: Suma::Mess
         described_class.new.send!(delivery)
       end.to raise_error(/extract/)
     end
+
+    describe "with sms provider disabled", reset_configuration: described_class do
+      before(:each) do
+        described_class.provider_disabled = true
+      end
+
+      it "sends verification messages via twilio verify" do
+        req = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/Verifications").
+          to_return(status: 200, body: load_fixture_data("twilio/post_verification", raw: true))
+        delivery = Suma::Fixtures.message_delivery.
+          sms("+15554443210", "Your suma verification code is: 12345").
+          create(template: "verification", template_language: "es")
+        result = described_class.new.send!(delivery)
+        expect(result).to eq("VE123-1")
+        expect(req).to have_been_made
+      end
+
+      it "raises undeliverable for other SMS" do
+        delivery = Suma::Fixtures.message_delivery.sms("+15554443210", "hello").create
+        expect do
+          described_class.new.send!(delivery)
+        end.to raise_error(Suma::Message::Transport::UndeliverableRecipient, /SMS provider disabled/)
+      end
+    end
   end
 
   describe "add_bodies" do

--- a/spec/suma/message/sms_transport_spec.rb
+++ b/spec/suma/message/sms_transport_spec.rb
@@ -59,6 +59,27 @@ RSpec.describe Suma::Message::SmsTransport, :db, reset_configuration: Suma::Mess
       end.to raise_error(Suma::Message::Transport::UndeliverableRecipient, /signalwire_invalid_phone_number/)
       expect(req).to have_been_made
     end
+
+    it "sends verification messages via twilio verify" do
+      req = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/Verifications").
+        with(body: {"Channel" => "sms", "CustomCode" => "12345", "To" => "+15554443210", "Locale" => "es"}).
+        to_return(status: 200, body: load_fixture_data("twilio/post_verification", raw: true))
+      delivery = Suma::Fixtures.message_delivery.
+        sms("+15554443210", "Your suma verification code is: 12345").
+        create(template: "verification", template_language: "es")
+      result = described_class.new.send!(delivery)
+      expect(result).to eq("VE123-1")
+      expect(req).to have_been_made
+    end
+
+    it "errors if the verification template is used but no code can be extracted" do
+      delivery = Suma::Fixtures.message_delivery.
+        sms("+15554443210", "Your suma verification code is: abcd").
+        create(template: "verification", template_language: "es")
+      expect do
+        described_class.new.send!(delivery)
+      end.to raise_error(/extract/)
+    end
   end
 
   describe "add_bodies" do

--- a/spec/suma/twilio_spec.rb
+++ b/spec/suma/twilio_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "suma/twilio"
+
+RSpec.describe Suma::Twilio, :db do
+  describe "send_verification" do
+    it "sends the message" do
+      req = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/Verifications").
+        with(body: {"Channel" => "sms", "CustomCode" => "123", "To" => "+15554443210", "Locale" => "es"}).
+        to_return(status: 200, body: load_fixture_data("twilio/post_verification", raw: true))
+      result = described_class.send_verification("+15554443210", code: "123", locale: "es")
+      expect(req).to have_been_made
+      expect(result).to have_attributes(sid: "VE123")
+    end
+  end
+end

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -1,6 +1,7 @@
 {
   "auth": {
-    "sign_up_agreement": "By clicking {{ buttonLabel }}, you accept and agree to our [Terms of Use](/terms-of-use) and [Privacy Policy](/privacy-policy). You agree to receive periodic SMS and/or MMS messages from suma. Message and data rates may apply. Message frequency may vary depending on your activity and settings. Text HELP for more information. Text STOP to stop receiving messages."
+    "agree_aria_label": "Agree to terms",
+    "sign_up_agreement": "I accept and agree to suma’s [Terms of Use](/terms-of-use) and [Privacy Policy](/privacy-policy). I also agree to receive periodic SMS and/or MMS messages from suma. Message and data rates may apply. Message frequency may vary depending on your activity and settings. Text HELP for more information. Text STOP to stop receiving messages."
   },
   "common": {
     "add_money_to_account": "Press here to add money to your account",

--- a/webapp/public/locale/es/strings.json
+++ b/webapp/public/locale/es/strings.json
@@ -1,6 +1,7 @@
 {
   "auth": {
-    "sign_up_agreement": "Al hacer clic en {{ buttonLabel }}, aceptas y estás de acuerdo con nuestros [Términos de uso](/términos-de-uso) y [Política de privacidad](/privacy-policy). Aceptas recibir SMS y/o MMS periódicos de suma. Se pueden aplicar tarifas de mensajes y datos. La frecuencia de los mensajes puede variar según su actividad y configuración. Envíe HELP para obtener más información. Envíe STOP para dejar de recibir mensajes."
+    "agree_aria_label": "Aceptar los terminos",
+    "sign_up_agreement": "Acepto y estoy de acuerdo con suma's [Términos de uso](/términos-de-uso) y [Política de privacidad](/privacy-policy). También acepto recibir SMS y/o MMS periódicos de suma. Se pueden aplicar tarifas de mensajes y datos. La frecuencia de los mensajes puede variar según su actividad y configuración. Envíe HELP para obtener más información. Envíe STOP para dejar de recibir mensajes."
   },
   "common": {
     "add_money_to_account": "Haz click aquí para añadir fondos a tu cuenta",

--- a/webapp/src/components/SignupAgreement.jsx
+++ b/webapp/src/components/SignupAgreement.jsx
@@ -1,0 +1,20 @@
+import { mdp, t } from "../localization";
+import React from "react";
+import Form from "react-bootstrap/Form";
+
+export default function SignupAgreement({ checked, onCheckedChanged, ...rest }) {
+  return (
+    <div className="d-flex">
+      <Form.Check
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onCheckedChanged(e.target.checked)}
+        aria-label={t("auth:agree_aria_label")}
+        {...rest}
+      />
+      <div id="signup-agreement" className="ms-2 text-secondary small">
+        {mdp("auth:sign_up_agreement", { buttonLabel: t("forms:continue") })}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/modules/externalLinks.js
+++ b/webapp/src/modules/externalLinks.js
@@ -1,6 +1,5 @@
 const externalLinks = {
   safeHosts: ["https://mysuma.org"],
-  mobilityInfoLink: "https://mysuma.org/sumaplatform#mobility",
   sumaIntroLink: "https://mysuma.org/",
   privacyPolicy: "https://app.mysuma.org/privacy-policy",
 };

--- a/webapp/src/pages/ContactListAdd.jsx
+++ b/webapp/src/pages/ContactListAdd.jsx
@@ -3,7 +3,8 @@ import ContactListTags from "../components/ContactListTags";
 import FormButtons from "../components/FormButtons";
 import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
-import { md, mdp, t } from "../localization";
+import SignupAgreement from "../components/SignupAgreement";
+import { mdp, t } from "../localization";
 import useI18Next from "../localization/useI18Next";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
@@ -34,6 +35,7 @@ export default function ContactListAdd() {
   const [name, setName] = React.useState("");
   const [phone, setPhone] = React.useState("");
   const [referral, setReferral] = React.useState("");
+  const [agreementChecked, setAgreementChecked] = React.useState(false);
   const handleFormSubmit = () => {
     api
       .authContactList({
@@ -121,14 +123,15 @@ export default function ContactListAdd() {
             ))}
           </FormControlGroup>
         </Row>
+        <SignupAgreement
+          checked={agreementChecked}
+          onCheckedChanged={setAgreementChecked}
+        />
         <FormError error={error} />
-        <p className="text-secondary">
-          {md("auth:sign_up_agreement", { buttonLabel: t("forms:submit") })}
-        </p>
         <FormButtons
           variant="outline-primary"
           back
-          primaryProps={{ children: t("forms:submit") }}
+          primaryProps={{ children: t("forms:submit"), disabled: !agreementChecked }}
         />
       </Form>
       <ContactListTags />

--- a/webapp/src/pages/Mobility.jsx
+++ b/webapp/src/pages/Mobility.jsx
@@ -13,13 +13,7 @@ export default function Mobility() {
     <>
       <LayoutContainer top gutters>
         <h5>{t("mobility:title")}</h5>
-        <p className="text-secondary">
-          {t("mobility:intro")}
-          <br />
-          <ExternalLink href={externalLinks.mobilityInfoLink}>
-            {t("common:learn_more")}
-          </ExternalLink>
-        </p>
+        <p className="text-secondary">{t("mobility:intro")}</p>
       </LayoutContainer>
       <Map />
     </>
@@ -30,14 +24,7 @@ export default function Mobility() {
         imgSrc={mobilityHeaderImage}
         imgAlt="Scooter Mobility"
         title={t("mobility:title")}
-        text={
-          <>
-            <span className="pe-2">{t("mobility:intro")}</span>
-            <ExternalLink href={externalLinks.mobilityInfoLink}>
-              {t("common:learn_more")}
-            </ExternalLink>
-          </>
-        }
+        text={t("mobility:intro")}
       />
     </div>
   );

--- a/webapp/src/pages/Start.jsx
+++ b/webapp/src/pages/Start.jsx
@@ -2,7 +2,8 @@ import api from "../api";
 import FormButtons from "../components/FormButtons";
 import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
-import { mdp, t } from "../localization";
+import SignupAgreement from "../components/SignupAgreement";
+import { t } from "../localization";
 import useI18Next from "../localization/useI18Next";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
@@ -19,6 +20,7 @@ export default function Start() {
   const navigate = useNavigate();
   const submitDisabled = useToggle(false);
   const inputDisabled = useToggle(false);
+  const [agreementChecked, setAgreementChecked] = React.useState(false);
   const [error, setError] = useError();
   const [phone, setPhone] = useState("");
 
@@ -87,16 +89,16 @@ export default function Start() {
           required
           onChange={handlePhoneChange}
         />
-
-        <div className="text-secondary small">
-          {mdp("auth:sign_up_agreement", { buttonLabel: t("forms:continue") })}
-        </div>
+        <SignupAgreement
+          checked={agreementChecked}
+          onCheckedChanged={setAgreementChecked}
+        />
         <FormError error={error} />
         <FormButtons
           back
           primaryProps={{
             children: t("forms:continue"),
-            disabled: submitDisabled.isOn,
+            disabled: submitDisabled.isOn || !agreementChecked,
           }}
         />
       </Form>


### PR DESCRIPTION
Add checkbox to signup/phone form

SignalWire is requiring this for our campaign verification.
In theory we cannot require this checkbox,
but in practice that would make no sense
since we need to send transactional messages.

---

Support disabling SMS

We want to turn off general-purpose SMS while keeping verifications
enabled.

---

Send verification SMS through Twilio again

Signalwire failed once we tried in production.
Keep using Twilio as it's more reliable for now.

---

Fix eligibility constraint detail page