### PR TITLE
Refactor unnecessary markdown method usage

### DIFF
--- a/webapp/public/locale/en/privacy-policy-strings.json
+++ b/webapp/public/locale/en/privacy-policy-strings.json
@@ -90,7 +90,7 @@
     },
     "third_party_access": {
       "list": {
-        "personal_information": "For details on how we share certain personal information with platform vendors or subsidy providers, and how we may share certain personal information to comply with the law or resolve disputes, refer to ",
+        "personal_information": "For details on how we share certain personal information with platform vendors or subsidy providers, and how we may share certain personal information to comply with the law or resolve disputes, refer to",
         "service_providers": "**Service providers:** These are providers who help us operate the suma platform, and include payment",
         "with_your_consent": "**With your consent:** We may share your personal information to additional third parties if we notify you and you consent to the sharing"
       },
@@ -101,7 +101,7 @@
   },
   "subsections": {
     "communicate_with_you": {
-      "paragraph": "We may use your information to respond to your communications, reach out to you about your transactions or account, market the platform, provide other relevant information, or request information or feedback. For more information about how we communicate with you, ",
+      "paragraph": "We may use your information to respond to your communications, reach out to you about your transactions or account, market the platform, provide other relevant information, or request information or feedback. For more information about how we communicate with you,",
       "see_communications": "see communications.",
       "title": "Communicate with you"
     },

--- a/webapp/public/locale/es/privacy-policy-strings.json
+++ b/webapp/public/locale/es/privacy-policy-strings.json
@@ -90,7 +90,7 @@
     },
     "third_party_access": {
       "list": {
-        "personal_information": "Para obtener detalles sobre cómo compartimos cierta información personal con proveedores de plataformas o proveedores de subsidios, y cómo podemos compartir cierta información personal para cumplir con la ley o resolver disputas, consulte ",
+        "personal_information": "Para obtener detalles sobre cómo compartimos cierta información personal con proveedores de plataformas o proveedores de subsidios, y cómo podemos compartir cierta información personal para cumplir con la ley o resolver disputas, consulte",
         "service_providers": "**Proveedores de servicio** Estos son proveedores que nos ayudan a operar la plataforma suma e incluyen procesadores y facilitadores de pago y servicios de alojamiento en la nube",
         "with_your_consent": "**Con su consentimiento** Podemos compartir su información personal con terceros adicionales si le notificamos y usted da su consentimiento para compartirla"
       },
@@ -101,7 +101,7 @@
   },
   "subsections": {
     "communicate_with_you": {
-      "paragraph": "Podemos utilizar tu información para responder a tus comunicaciones, para comunicarnos contigo sobre las transacciones o tu cuenta, para promocionar la plataforma, para proporcionar otra información relevante o para solicitar información y comentarios. Para obtener más información sobre cómo nos comunicamos contigo, ",
+      "paragraph": "Podemos utilizar tu información para responder a tus comunicaciones, para comunicarnos contigo sobre las transacciones o tu cuenta, para promocionar la plataforma, para proporcionar otra información relevante o para solicitar información y comentarios. Para obtener más información sobre cómo nos comunicamos contigo,",
       "see_communications": "ver comunicaciones.",
       "title": "Para comunícarnos contigo"
     },

--- a/webapp/src/components/OrderDetail.jsx
+++ b/webapp/src/components/OrderDetail.jsx
@@ -3,7 +3,7 @@ import AnimatedCheckmark from "../components/AnimatedCheckmark";
 import FormSaveCancel from "../components/FormSaveCancel";
 import LayoutContainer from "../components/LayoutContainer";
 import SumaImage from "../components/SumaImage";
-import { md, mdx, t } from "../localization";
+import { mdx, t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import Money from "../shared/react/Money";
 import useToggle from "../shared/react/useToggle";
@@ -78,7 +78,7 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
             <Stack key={i} className="justify-content-between align-items-start" gap={1}>
               <div className="lead">{name}</div>
               <div>
-                {md("food:price_times_quantity", {
+                {t("food:price_times_quantity", {
                   price: customerPrice,
                   quantity,
                 })}

--- a/webapp/src/components/PrivacyPolicyContent.jsx
+++ b/webapp/src/components/PrivacyPolicyContent.jsx
@@ -203,7 +203,7 @@ export default function PrivacyPolicyContent({ mobile }) {
                 title={t("subsections:communicate_with_you:title")}
                 p={
                   <>
-                    {md("subsections:communicate_with_you:paragraph")}
+                    {t("subsections:communicate_with_you:paragraph")}
                     <a href="#communications">
                       {t("subsections:communicate_with_you:see_communications")}
                     </a>
@@ -242,7 +242,7 @@ export default function PrivacyPolicyContent({ mobile }) {
                 md("sections:third_party_access:list:service_providers"),
                 md("sections:third_party_access:list:with_your_consent"),
                 <>
-                  {md("sections:third_party_access:list:personal_information")}
+                  {t("sections:third_party_access:list:personal_information")}
                   <a href="#methodsOfInformationUsage">
                     {t("sections:methods_of_information_usage:title")}
                   </a>

--- a/webapp/src/components/mobilitymap/ReservationCard.jsx
+++ b/webapp/src/components/mobilitymap/ReservationCard.jsx
@@ -45,9 +45,11 @@ export default function ReservationCard({
   if (vehicle.gotoPrivateAccount) {
     action = (
       <>
-        {mdp("mobility:setup_private_account_with_vendor", {
-          vendorName: vehicle.vendorService.vendorName,
-        })}
+        <p>
+          {t("mobility:setup_private_account_with_vendor", {
+            vendorName: vehicle.vendorService.vendorName,
+          })}
+        </p>
         <Button
           size="sm"
           variant="outline-primary"

--- a/webapp/src/pages/ContactListAdd.jsx
+++ b/webapp/src/pages/ContactListAdd.jsx
@@ -4,7 +4,7 @@ import FormButtons from "../components/FormButtons";
 import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
 import SignupAgreement from "../components/SignupAgreement";
-import { mdp, t } from "../localization";
+import { t } from "../localization";
 import useI18Next from "../localization/useI18Next";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
@@ -74,7 +74,7 @@ export default function ContactListAdd() {
   return (
     <>
       <h2 className="page-header">{t("contact_list:signup_title")}</h2>
-      {mdp("contact_list:signup_intro")}
+      <p>{t("contact_list:signup_intro")}</p>
       <Form noValidate onSubmit={handleSubmit(handleFormSubmit)}>
         <FormControlGroup
           className="mb-3"

--- a/webapp/src/pages/FoodCart.jsx
+++ b/webapp/src/pages/FoodCart.jsx
@@ -74,7 +74,7 @@ export default function FoodCart() {
             })}
           </Stack>
         ) : (
-          <span className="">{md("food:no_cart_items")}</span>
+          <span>{t("food:no_cart_items")}</span>
         )}
       </LayoutContainer>
       <hr className="my-4" />
@@ -128,7 +128,7 @@ function CartItem({ offeringId, product, vendor }) {
   } = product;
   return (
     <Stack direction="horizontal" gap={3} className="align-items-start">
-      <Link to={`/product/${offeringId}/${productId}`} className="">
+      <Link to={`/product/${offeringId}/${productId}`}>
         <SumaImage image={images[0]} alt={name} className="w-100" w={100} h={100} />
       </Link>
       <div>

--- a/webapp/src/pages/FoodCheckoutConfirmation.jsx
+++ b/webapp/src/pages/FoodCheckoutConfirmation.jsx
@@ -5,7 +5,7 @@ import LayoutContainer from "../components/LayoutContainer";
 import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
 import SumaImage from "../components/SumaImage";
-import { mdp, t } from "../localization";
+import { t } from "../localization";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import React from "react";
 import Alert from "react-bootstrap/Alert";
@@ -61,7 +61,7 @@ export default function FoodCheckoutConfirmation() {
       </LayoutContainer>
       <hr />
       <LayoutContainer gutters>
-        {mdp("food:confirmation_message")}
+        <p>{t("food:confirmation_message")}</p>
         <FormButtons
           className="mt-2"
           primaryProps={{

--- a/webapp/src/pages/Mobility.jsx
+++ b/webapp/src/pages/Mobility.jsx
@@ -1,11 +1,9 @@
 import mobilityHeaderImage from "../assets/images/onboarding-mobility.jpg";
-import ExternalLink from "../components/ExternalLink";
 import LayoutContainer from "../components/LayoutContainer";
 import WaitingListPage from "../components/WaitingListPage";
 import Map from "../components/mobilitymap/Map";
 import config from "../config";
 import { t } from "../localization";
-import externalLinks from "../modules/externalLinks";
 import React from "react";
 
 export default function Mobility() {

--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -76,12 +76,10 @@ export default function PrivateAccountsList() {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <div className="mt-4 d-flex justify-content-center align-items-center flex-column">
+          <div className="d-flex justify-content-center align-items-center flex-column m-2">
             <ScrollTopOnMount />
-            <div className="mt-2 mx-2">
-              <SumaMarkdown>{modalAccount?.instructions}</SumaMarkdown>
-            </div>
-            <div className="d-flex justify-content-end my-2">
+            <SumaMarkdown>{modalAccount?.instructions}</SumaMarkdown>
+            <div className="d-flex justify-content-end mt-2">
               <Button variant="outline-primary" onClick={() => setModalAccount(null)}>
                 {t("common:close")}
               </Button>

--- a/webapp/src/pages/UnclaimedOrderList.jsx
+++ b/webapp/src/pages/UnclaimedOrderList.jsx
@@ -8,7 +8,7 @@ import OrderDetail from "../components/OrderDetail";
 import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
 import SumaImage from "../components/SumaImage";
-import { md, mdp, t } from "../localization";
+import { mdp, t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import ScrollTopOnMount from "../shared/ScrollToTopOnMount";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
@@ -120,7 +120,7 @@ function ClaimedOrderModal({ claimedOrder, onHide }) {
                     <div className="text-align-start">
                       <div className="lead">{name}</div>
                       <Badge bg="secondary" className="fs-6">
-                        {md("food:price_times_quantity", {
+                        {t("food:price_times_quantity", {
                           price: customerPrice,
                           quantity,
                         })}


### PR DESCRIPTION
Fixes #575 

- Remove unnecessary markdown usage, replace with normal `t` method
- Remove spaces in localization strings (fools markdown methods to act as markdown)
- Format and fix lint
- Fix private-account modal spacing