### PR TITLE
Make offering product pricing immutable

### DIFF
--- a/adminapp/src/pages/OfferingProductDetailPage.jsx
+++ b/adminapp/src/pages/OfferingProductDetailPage.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
 import Money from "../shared/react/Money";
@@ -39,6 +40,24 @@ export default function OfferingProductDetailPage() {
           value: <Money>{model.undiscountedPrice}</Money>,
         },
       ]}
-    />
+    >
+      {(model) => (
+        <RelatedList
+          title={`Orders (${model.orders.length})`}
+          rows={model.orders}
+          headers={["Id", "Created", "Member", "Items", "Status"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            dayjs(row.createdAt).format("lll"),
+            <AdminLink key="mem" model={row.member}>
+              {row.member.name}
+            </AdminLink>,
+            row.totalItemCount,
+            row.statusLabel,
+          ]}
+        />
+      )}
+    </ResourceDetail>
   );
 }

--- a/lib/suma/admin_api/common_endpoints.rb
+++ b/lib/suma/admin_api/common_endpoints.rb
@@ -126,7 +126,7 @@ module Suma::AdminAPI::CommonEndpoints
         yield
         post do
           model_type.db.transaction do
-            m = model_type[params[:id]]
+            (m = model_type[params[:id]]) or forbidden!
             update_model(
               m,
               params,

--- a/spec/suma/api/commerce_spec.rb
+++ b/spec/suma/api/commerce_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe Suma::API::Commerce, :db do
     end
 
     it "does not require payment instrument if chargeable total is zero" do
-      offering_product.update(customer_price_cents: 0, undiscounted_price: 0)
+      offering_product.update_without_validate(customer_price_cents: 0, undiscounted_price: 0)
       checkout.update(payment_instrument: nil)
 
       post "/v1/commerce/checkouts/#{checkout.id}/complete"

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       Suma::Payment.ensure_cash_ledger(member)
       expect(checkout).to be_requires_payment_instrument
 
-      offering_product.update(customer_price_cents: 0)
+      offering_product.update_without_validate(customer_price_cents: 0)
 
       checkout.refresh
       expect(checkout.chargeable_total).to cost(0)
@@ -73,7 +73,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     it "is :charging_prohibited if charging is prohibited and there is a chargeable amount" do
       offering.update(prohibit_charge_at_checkout: true)
       expect(checkout.checkout_prohibited_reason(now)).to eq(:charging_prohibited)
-      cart.items.first.offering_product.update(customer_price: Money.new(0))
+      cart.items.first.offering_product.update_without_validate(customer_price: Money.new(0))
       checkout.refresh
       expect(checkout.checkout_prohibited_reason(now)).to eq(nil)
     end
@@ -86,7 +86,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     it "is :requires_payment_instrument if an instrument is required and not set" do
       checkout.payment_instrument = nil
       expect(checkout.checkout_prohibited_reason(now)).to eq(:requires_payment_instrument)
-      cart.items.first.offering_product.update(customer_price: Money.new(0))
+      cart.items.first.offering_product.update_without_validate(customer_price: Money.new(0))
       checkout.refresh
       expect(checkout.checkout_prohibited_reason(now)).to eq(nil)
     end
@@ -145,7 +145,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
 
     it "prevents soft deleting payment instrument if it is not required" do
       checkout.update(payment_instrument: nil)
-      offering_product.update(customer_price_cents: 0)
+      offering_product.update_without_validate(customer_price_cents: 0)
       # Ensure payment is not required
       expect(checkout).to_not be_requires_payment_instrument
       checkout.create_order

--- a/spec/suma/commerce/offering_product_spec.rb
+++ b/spec/suma/commerce/offering_product_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::Commerce::OfferingProduct", :db do
+  let(:described_class) { Suma::Commerce::OfferingProduct }
+
+  it "has an association to orders" do
+    order = Suma::Fixtures.order.as_purchased_by(Suma::Fixtures.member.create).create
+    op = order.checkout.items.first.offering_product
+    expect(op.refresh.orders).to contain_exactly(be === order)
+  end
+
+  it "knows when it is discounted" do
+    op = Suma::Fixtures.offering_product.create
+    op.undiscounted_price = op.customer_price
+    expect(op).to_not be_discounted
+    op.undiscounted_price = op.customer_price + Money.new(1)
+    expect(op).to be_discounted
+    op.undiscounted_price = op.customer_price - Money.new(1)
+    expect(op).to_not be_discounted
+  end
+
+  it "knows when it is available/closed" do
+    op = Suma::Fixtures.offering_product.create
+    expect(op).to be_available
+    expect(op).to_not be_closed
+    op.closed_at = Time.now
+    expect(op).to_not be_available
+    expect(op).to be_closed
+  end
+
+  it "errors if changing the customer price" do
+    op = Suma::Fixtures.offering_product.costing("$1", "$2").create
+    op.update(undiscounted_price: Money.new(500))
+    expect { op.update(customer_price: Money.new(400)) }.to raise_error(Sequel::ValidationFailed, /customer_price/)
+    op.refresh
+    op.customer_price_currency = "EUR"
+    expect { op.save_changes }.to raise_error(Sequel::ValidationFailed, /customer_price/)
+  end
+
+  describe "with_changes" do
+    it "creates a clone of itself with a new price, closing the receiver" do
+      orig = Suma::Fixtures.offering_product.costing("$1", "$2").create
+      new_disc = orig.with_changes(undiscounted_price: Money.new(500))
+      expect(orig).to be_closed
+      expect(new_disc).to be_available
+      expect(new_disc).to have_attributes(undiscounted_price: cost("$5"), customer_price: cost("$1"))
+      new_cust = new_disc.with_changes(customer_price: Money.new(400))
+      expect(new_disc).to be_closed
+      expect(new_cust).to be_available
+      expect(new_cust).to have_attributes(undiscounted_price: cost("$5"), customer_price: cost("$4"))
+    end
+
+    it "errors if no price is passed, or the passed price is the same value" do
+      op = Suma::Fixtures.offering_product.create
+      expect { op.with_changes }.to raise_error(ArgumentError)
+      expect { op.with_changes(undiscounted_price: op.undiscounted_price) }.to raise_error(ArgumentError)
+      expect { op.with_changes(customer_price: op.customer_price) }.to raise_error(ArgumentError)
+      expect do
+        op.with_changes(customer_price: op.customer_price, undiscounted_price: Money.new(1))
+      end.to_not raise_error
+    end
+
+    it "errors if the receiver is already closed (since it would likely cause a UniqueConstraintViolation on save)" do
+      op = Suma::Fixtures.offering_product.closed.create
+      expect { op.with_changes(undiscounted_price: Money.new(500)) }.to raise_error(Suma::InvalidPrecondition)
+    end
+  end
+
+  it "errors if more than one offering product is open for a given offering and product" do
+    op1 = Suma::Fixtures.offering_product.create
+    Suma::Fixtures.offering_product.create(offering: op1.offering)
+    Suma::Fixtures.offering_product.create(product: op1.product)
+    expect do
+      Suma::Fixtures.offering_product.create(offering: op1.offering, product: op1.product)
+    end.to raise_error(Sequel::UniqueConstraintViolation)
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/lithictech/suma/issues/567

When changing the pricing of an offering product,
create a new one and close the old one.
Offering products should rarely have pricing information change, as they're designed to be immutable (it would change historical orders if we updated pricing).

Also adds an 'orders' table to the offering products view in admin.