### PR TITLE
Fix order update function typo and state

### DIFF
--- a/webapp/src/components/OrderDetail.jsx
+++ b/webapp/src/components/OrderDetail.jsx
@@ -5,6 +5,7 @@ import LayoutContainer from "../components/LayoutContainer";
 import SumaImage from "../components/SumaImage";
 import { mdx, t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
+import ScrollTopOnMount from "../shared/ScrollToTopOnMount";
 import Money from "../shared/react/Money";
 import useToggle from "../shared/react/useToggle";
 import useErrorToast from "../state/useErrorToast";
@@ -20,28 +21,27 @@ import Card from "react-bootstrap/Card";
 import Form from "react-bootstrap/Form";
 import Stack from "react-bootstrap/Stack";
 
-export default function OrderDetail({ state, onOrderClaim, gutters }) {
-  const [order, setOrder] = React.useState(state);
+export default function OrderDetail({ order, setOrder, gutters }) {
   return (
     <>
       <LayoutContainer gutters={gutters}>
         <Stack gap={3}>
           <div>
-            <h3 className="mb-1">{t("food:order_serial", { serial: state.serial })}</h3>
-            {dayjs(state.createdAt).format("lll")}
+            <h3 className="mb-1">{t("food:order_serial", { serial: order.serial })}</h3>
+            {dayjs(order.createdAt).format("lll")}
           </div>
           <p className="mb-0">
-            {t("food:labels:price", { price: state.customerCost })}
-            {state.customerCost.cents !== state.undiscountedCost.cents && (
+            {t("food:labels:price", { price: order.customerCost })}
+            {order.customerCost.cents !== order.undiscountedCost.cents && (
               <Money as="del" className="text-secondary ms-2">
-                {state.undiscountedCost}
+                {order.undiscountedCost}
               </Money>
             )}
             <br />
-            {t("food:labels:fees_and_taxes", { fees: state.handling, taxes: state.tax })}
+            {t("food:labels:fees_and_taxes", { fees: order.handling, taxes: order.tax })}
             <br />
-            {t("food:labels:total", { total: state.total })}
-            {state.fundingTransactions.map(({ label, amount }) => (
+            {t("food:labels:total", { total: order.total })}
+            {order.fundingTransactions.map(({ label, amount }) => (
               <React.Fragment key={label}>
                 <br />
                 {label}: <Money>{amount}</Money>
@@ -52,11 +52,12 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
           <div>
             <FulfillmentOption order={order} onOrderUpdated={setOrder} />
           </div>
-          {!state.canClaim && state.fulfilledAt && (
+          {!order.canClaim && order.fulfilledAt && (
             <Alert variant="info" className="mb-0">
+              <ScrollTopOnMount />
               <Stack direction="horizontal" gap={3}>
                 {t("food:claimed_on", {
-                  fulfilledAt: dayjs(state.fulfilledAt).format("lll"),
+                  fulfilledAt: dayjs(order.fulfilledAt).format("lll"),
                 })}
                 <div className="ms-auto">
                   <AnimatedCheckmark />
@@ -65,16 +66,16 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
             </Alert>
           )}
           <SumaImage
-            image={state.image}
+            image={order.image}
             w={350}
             height={150}
             className="rounded responsive-wide-image"
           />
           <hr className="my-0" />
           <Card.Text className="h4 mb-0">
-            {t("food:labels:items_count", { itemCount: state.items.length })}
+            {t("food:labels:items_count", { itemCount: order.items.length })}
           </Card.Text>
-          {state.items.map(({ name, description, customerPrice, quantity }, i) => (
+          {order.items.map(({ name, description, customerPrice, quantity }, i) => (
             <Stack key={i} className="justify-content-between align-items-start" gap={1}>
               <div className="lead">{name}</div>
               <div>
@@ -88,10 +89,10 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
           ))}
         </Stack>
         <PressAndHoldToClaim
-          id={state.id}
-          canClaim={state.canClaim}
-          fulfilledAt={state.fulfilledAt}
-          onOrderClaim={(o) => onOrderClaim(o)}
+          id={order.id}
+          canClaim={order.canClaim}
+          fulfilledAt={order.fulfilledAt}
+          onOrderClaim={(o) => setOrder(o)}
         />
       </LayoutContainer>
     </>

--- a/webapp/src/components/OrderDetail.jsx
+++ b/webapp/src/components/OrderDetail.jsx
@@ -21,7 +21,7 @@ import Form from "react-bootstrap/Form";
 import Stack from "react-bootstrap/Stack";
 
 export default function OrderDetail({ state, onOrderClaim, gutters }) {
-  const [orderForFulfillment, setOrderForFulfillment] = React.useState(state);
+  const [order, setOrder] = React.useState(state);
   return (
     <>
       <LayoutContainer gutters={gutters}>
@@ -50,10 +50,7 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
             <br />
           </p>
           <div>
-            <FulfillmentOption
-              order={orderForFulfillment}
-              onOrderUpdated={setOrderForFulfillment}
-            />
+            <FulfillmentOption order={order} onOrderUpdated={setOrder} />
           </div>
           {!state.canClaim && state.fulfilledAt && (
             <Alert variant="info" className="mb-0">

--- a/webapp/src/components/OrderDetail.jsx
+++ b/webapp/src/components/OrderDetail.jsx
@@ -21,27 +21,27 @@ import Form from "react-bootstrap/Form";
 import Stack from "react-bootstrap/Stack";
 
 export default function OrderDetail({ state, onOrderClaim, gutters }) {
-  const [order, setOrder] = React.useState(state);
+  const [orderForFulfillment, setOrderForFulfillment] = React.useState(state);
   return (
     <>
       <LayoutContainer gutters={gutters}>
         <Stack gap={3}>
           <div>
-            <h3 className="mb-1">{t("food:order_serial", { serial: order.serial })}</h3>
-            {dayjs(order.createdAt).format("lll")}
+            <h3 className="mb-1">{t("food:order_serial", { serial: state.serial })}</h3>
+            {dayjs(state.createdAt).format("lll")}
           </div>
           <p className="mb-0">
-            {t("food:labels:price", { price: order.customerCost })}
-            {order.customerCost.cents !== order.undiscountedCost.cents && (
+            {t("food:labels:price", { price: state.customerCost })}
+            {state.customerCost.cents !== state.undiscountedCost.cents && (
               <Money as="del" className="text-secondary ms-2">
-                {order.undiscountedCost}
+                {state.undiscountedCost}
               </Money>
             )}
             <br />
-            {t("food:labels:fees_and_taxes", { fees: order.handling, taxes: order.tax })}
+            {t("food:labels:fees_and_taxes", { fees: state.handling, taxes: state.tax })}
             <br />
-            {t("food:labels:total", { total: order.total })}
-            {order.fundingTransactions.map(({ label, amount }) => (
+            {t("food:labels:total", { total: state.total })}
+            {state.fundingTransactions.map(({ label, amount }) => (
               <React.Fragment key={label}>
                 <br />
                 {label}: <Money>{amount}</Money>
@@ -50,13 +50,16 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
             <br />
           </p>
           <div>
-            <FulfillmentOption order={order} onOrderUpdated={(o) => setOrder(o)} />
+            <FulfillmentOption
+              order={orderForFulfillment}
+              onOrderUpdated={setOrderForFulfillment}
+            />
           </div>
-          {!order.canClaim && order.fulfilledAt && (
+          {!state.canClaim && state.fulfilledAt && (
             <Alert variant="info" className="mb-0">
               <Stack direction="horizontal" gap={3}>
                 {t("food:claimed_on", {
-                  fulfilledAt: dayjs(order.fulfilledAt).format("lll"),
+                  fulfilledAt: dayjs(state.fulfilledAt).format("lll"),
                 })}
                 <div className="ms-auto">
                   <AnimatedCheckmark />
@@ -65,16 +68,16 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
             </Alert>
           )}
           <SumaImage
-            image={order.image}
+            image={state.image}
             w={350}
             height={150}
             className="rounded responsive-wide-image"
           />
           <hr className="my-0" />
           <Card.Text className="h4 mb-0">
-            {t("food:labels:items_count", { itemCount: order.items.length })}
+            {t("food:labels:items_count", { itemCount: state.items.length })}
           </Card.Text>
-          {order.items.map(({ name, description, customerPrice, quantity }, i) => (
+          {state.items.map(({ name, description, customerPrice, quantity }, i) => (
             <Stack key={i} className="justify-content-between align-items-start" gap={1}>
               <div className="lead">{name}</div>
               <div>
@@ -88,9 +91,9 @@ export default function OrderDetail({ state, onOrderClaim, gutters }) {
           ))}
         </Stack>
         <PressAndHoldToClaim
-          id={order.id}
-          canClaim={order.canClaim}
-          fulfilledAt={order.fulfilledAt}
+          id={state.id}
+          canClaim={state.canClaim}
+          fulfilledAt={state.fulfilledAt}
           onOrderClaim={(o) => onOrderClaim(o)}
         />
       </LayoutContainer>

--- a/webapp/src/pages/OrderHistoryDetail.jsx
+++ b/webapp/src/pages/OrderHistoryDetail.jsx
@@ -34,7 +34,7 @@ export default function OrderHistoryDetail() {
       <LayoutContainer top gutters>
         <LinearBreadcrumbs back />
       </LayoutContainer>
-      <OrderDetail state={state} onOrderClaim={replaceState} gutters />
+      <OrderDetail order={state} setOrder={replaceState} gutters />
     </>
   );
 }

--- a/webapp/src/pages/OrderHistoryDetail.jsx
+++ b/webapp/src/pages/OrderHistoryDetail.jsx
@@ -34,7 +34,7 @@ export default function OrderHistoryDetail() {
       <LayoutContainer top gutters>
         <LinearBreadcrumbs back />
       </LayoutContainer>
-      <OrderDetail state={state} onOrderClaimed={replaceState} gutters />
+      <OrderDetail state={state} onOrderClaim={replaceState} gutters />
     </>
   );
 }

--- a/webapp/src/pages/UnclaimedOrderList.jsx
+++ b/webapp/src/pages/UnclaimedOrderList.jsx
@@ -61,7 +61,7 @@ export default function UnclaimedOrderList() {
                 {items.map((o) => (
                   <Card key={o.id} className="p-0">
                     <Card.Body className="px-2 pb-4">
-                      <OrderDetail state={o} onOrderClaim={(o) => handleOrderClaim(o)} />
+                      <OrderDetail order={o} setOrder={(o) => handleOrderClaim(o)} />
                     </Card.Body>
                   </Card>
                 ))}

--- a/webapp/src/pages/UnclaimedOrderList.jsx
+++ b/webapp/src/pages/UnclaimedOrderList.jsx
@@ -8,7 +8,7 @@ import OrderDetail from "../components/OrderDetail";
 import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
 import SumaImage from "../components/SumaImage";
-import { mdp, t } from "../localization";
+import { t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import ScrollTopOnMount from "../shared/ScrollToTopOnMount";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
@@ -74,7 +74,9 @@ export default function UnclaimedOrderList() {
       </LayoutContainer>
       {isEmpty(items) && !loading && (
         <>
-          <LayoutContainer gutters>{mdp("food:no_orders_to_claim")}</LayoutContainer>
+          <LayoutContainer gutters>
+            <p>{t("food:no_orders_to_claim")}</p>
+          </LayoutContainer>
           <hr className="my-4" />
           <LayoutContainer gutters>
             <div className="button-stack">


### PR DESCRIPTION
Fixes #584 

- Fix mistype on the function passed to `OrderDetail` component from `OrderHistoryDetail`
- Fix bug where`OrderHistoryDetail` page does not update state when changed.
- Remove lingering unnecessary markdown usage
- Scroll to top when order is claimed inside of `OrderHistoryDetail`