### PR TITLE
Create Admin anon proxy vendor account pages

### DIFF
--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -35,6 +35,8 @@ import ProductListPage from "./pages/ProductListPage";
 import SignInPage from "./pages/SignInPage";
 import VendorAccountDetailPage from "./pages/VendorAccountDetailPage";
 import VendorAccountListPage from "./pages/VendorAccountListPage";
+import VendorConfigurationDetailPage from "./pages/VendorConfigurationDetailPage";
+import VendorConfigurationListPage from "./pages/VendorConfigurationListPage";
 import VendorCreatePage from "./pages/VendorCreatePage";
 import VendorDetailPage from "./pages/VendorDetailPage";
 import VendorEditPage from "./pages/VendorEditPage";
@@ -314,6 +316,24 @@ function PageSwitch() {
           redirectIfUnauthed,
           withLayout(),
           VendorAccountDetailPage
+        )}
+      />
+      <Route
+        exact
+        path="/vendor-configurations"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          VendorConfigurationListPage
+        )}
+      />
+      <Route
+        exact
+        path="/vendor-configuration/:id"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          VendorConfigurationDetailPage
         )}
       />
       <Route

--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -33,6 +33,8 @@ import ProductDetailPage from "./pages/ProductDetailPage";
 import ProductEditPage from "./pages/ProductEditPage";
 import ProductListPage from "./pages/ProductListPage";
 import SignInPage from "./pages/SignInPage";
+import VendorAccountDetailPage from "./pages/VendorAccountDetailPage";
+import VendorAccountListPage from "./pages/VendorAccountListPage";
 import VendorCreatePage from "./pages/VendorCreatePage";
 import VendorDetailPage from "./pages/VendorDetailPage";
 import VendorEditPage from "./pages/VendorEditPage";
@@ -299,6 +301,20 @@ function PageSwitch() {
         exact
         path="/vendor/:id/edit"
         element={renderWithHocs(redirectIfUnauthed, withLayout(), VendorEditPage)}
+      />
+      <Route
+        exact
+        path="/vendor-accounts"
+        element={renderWithHocs(redirectIfUnauthed, withLayout(), VendorAccountListPage)}
+      />
+      <Route
+        exact
+        path="/vendor-account/:id"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          VendorAccountDetailPage
+        )}
       />
       <Route
         exact

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -119,6 +119,12 @@ export default {
   getVendor: ({ id, ...data }) => get(`/adminapi/v1/vendors/${id}`, data),
   updateVendor: ({ id, ...data }) => post(`/adminapi/v1/vendors/${id}`, data),
 
+  getVendorAccounts: (data) => get("/adminapi/v1/anon_proxy/vendor_accounts", data),
+  createVendorAccounts: (data) =>
+    get("/adminapi/v1/anon_proxy/vendor_accounts/create", data),
+  getVendorAccount: ({ id, data }) =>
+    get(`/adminapi/v1/anon_proxy/vendor_accounts/${id}`, data),
+
   getCommerceOrders: (data) => get(`/adminapi/v1/commerce_orders`, data),
   getCommerceOrder: ({ id, ...data }) => get(`/adminapi/v1/commerce_orders/${id}`, data),
 

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -120,8 +120,6 @@ export default {
   updateVendor: ({ id, ...data }) => post(`/adminapi/v1/vendors/${id}`, data),
 
   getVendorAccounts: (data) => get("/adminapi/v1/anon_proxy/vendor_accounts", data),
-  createVendorAccounts: (data) =>
-    get("/adminapi/v1/anon_proxy/vendor_accounts/create", data),
   getVendorAccount: ({ id, data }) =>
     get(`/adminapi/v1/anon_proxy/vendor_accounts/${id}`, data),
 

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -123,6 +123,13 @@ export default {
   getVendorAccount: ({ id, data }) =>
     get(`/adminapi/v1/anon_proxy/vendor_accounts/${id}`, data),
 
+  getVendorConfigurations: (data) =>
+    get("/adminapi/v1/anon_proxy/vendor_configurations", data),
+  getVendorConfiguration: ({ id, data }) =>
+    get(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data),
+  updateVendorConfigurationEligibilityConstraints: ({ id, ...data }) =>
+    post(`/adminapi/v1/anon_proxy/vendor_configurations/${id}/eligibilities`, data),
+
   getCommerceOrders: (data) => get(`/adminapi/v1/commerce_orders`, data),
   getCommerceOrder: ({ id, ...data }) => get(`/adminapi/v1/commerce_orders/${id}`, data),
 

--- a/adminapp/src/components/Copyable.jsx
+++ b/adminapp/src/components/Copyable.jsx
@@ -18,11 +18,11 @@ export default function Copyable({ text, delay, inline, children }) {
   }
   const sx = inline && { px: "0!important", minWidth: "40px" };
   return (
-    <div>
+    <React.Fragment>
       {children || text}
       <Button title="Copy" variant="link" sx={sx} onClick={onCopy}>
         <ContentCopyIcon />
       </Button>
-    </div>
+    </React.Fragment>
   );
 }

--- a/adminapp/src/components/DetailGrid.jsx
+++ b/adminapp/src/components/DetailGrid.jsx
@@ -28,8 +28,8 @@ export default function DetailGrid({ title, properties }) {
         </Typography>
       )}
       <Grid container spacing={2} alignItems="center" justifyContent="flex-end">
-        {usedProperties.map(({ label, value, children }) => (
-          <React.Fragment key={label}>
+        {usedProperties.map(({ label, value, children }, index) => (
+          <React.Fragment key={index}>
             <Grid item xs={4} sm={3} lg={2} sx={{ paddingTop: "5px!important" }}>
               <Label>{label}</Label>
             </Grid>

--- a/adminapp/src/components/DetailGrid.jsx
+++ b/adminapp/src/components/DetailGrid.jsx
@@ -27,7 +27,7 @@ export default function DetailGrid({ title, properties }) {
           {title}
         </Typography>
       )}
-      <Grid container spacing={2} alignItems="center" justifyContent="flex-end">
+      <Grid container spacing={2} alignItems="start" justifyContent="flex-end">
         {usedProperties.map(({ label, value, children }) => (
           <React.Fragment key={label}>
             <Grid item xs={4} sm={3} lg={2} sx={{ paddingTop: "5px!important" }}>

--- a/adminapp/src/components/DetailGrid.jsx
+++ b/adminapp/src/components/DetailGrid.jsx
@@ -27,7 +27,7 @@ export default function DetailGrid({ title, properties }) {
           {title}
         </Typography>
       )}
-      <Grid container spacing={2} alignItems="start" justifyContent="flex-end">
+      <Grid container spacing={2} alignItems="center" justifyContent="flex-end">
         {usedProperties.map(({ label, value, children }) => (
           <React.Fragment key={label}>
             <Grid item xs={4} sm={3} lg={2} sx={{ paddingTop: "5px!important" }}>

--- a/adminapp/src/components/EligibilityConstraints.jsx
+++ b/adminapp/src/components/EligibilityConstraints.jsx
@@ -1,0 +1,149 @@
+import api from "../api";
+import useErrorSnackbar from "../hooks/useErrorSnackbar";
+import useAsyncFetch from "../shared/react/useAsyncFetch";
+import AdminLink from "./AdminLink";
+import DetailGrid from "./DetailGrid";
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckIcon from "@mui/icons-material/Check";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import SaveIcon from "@mui/icons-material/Save";
+import { MenuItem, Select } from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import _ from "lodash";
+import React from "react";
+
+export default function EligibilityConstraints({
+  constraints,
+  modelId,
+  replaceModelData,
+  makeUpdateRequest,
+}) {
+  const [editing, setEditing] = React.useState(false);
+  const [updatedConstraints, setUpdatedConstraints] = React.useState([]);
+  const [newConstraintId, setNewConstraintId] = React.useState(0);
+  const { enqueueErrorSnackbar } = useErrorSnackbar();
+
+  const { state: eligibilityConstraints, loading: eligibilityConstraintsLoading } =
+    useAsyncFetch(api.getEligibilityConstraintsMeta, {
+      pickData: true,
+    });
+
+  function startEditing() {
+    setEditing(true);
+    setUpdatedConstraints(constraints);
+    setNewConstraintId(eligibilityConstraints[0]?.id);
+  }
+
+  if (!editing) {
+    const properties = [];
+    if (_.isEmpty(constraints)) {
+      properties.push({
+        label: "*",
+        value: "Offering has no constraints. All members can access it.",
+      });
+    } else {
+      constraints.forEach((constraint) =>
+        properties.push({
+          label: <AdminLink model={constraint}>{constraint.name}</AdminLink>,
+          value: <CheckIcon />,
+        })
+      );
+    }
+    return (
+      <div>
+        <DetailGrid
+          title={
+            <>
+              Eligibility Constraints
+              <IconButton onClick={startEditing}>
+                <EditIcon color="info" />
+              </IconButton>
+            </>
+          }
+          properties={properties}
+        />
+      </div>
+    );
+  }
+
+  if (eligibilityConstraintsLoading) {
+    return "Loading...";
+  }
+
+  function discardChanges() {
+    setUpdatedConstraints([]);
+    setEditing(false);
+  }
+
+  function saveChanges() {
+    const constraintIds = updatedConstraints.map((c) => c.id);
+    if (newConstraintId) {
+      constraintIds.push(newConstraintId);
+    }
+    makeUpdateRequest({
+      id: modelId,
+      constraintIds,
+    })
+      .then((r) => {
+        replaceModelData(r.data);
+        setEditing(false);
+      })
+      .catch(enqueueErrorSnackbar);
+  }
+
+  function deleteConstraint(id) {
+    setUpdatedConstraints(updatedConstraints.filter((c) => c.id !== id));
+  }
+
+  const properties = updatedConstraints.map((c) => ({
+    label: c.name,
+    children: (
+      <IconButton onClick={() => deleteConstraint(c.id)}>
+        <DeleteIcon color="error" />
+      </IconButton>
+    ),
+  }));
+
+  const existingConstraintIds = constraints.map((c) => c.id);
+  const availableConstraints = eligibilityConstraints.items.filter(
+    (c) => !existingConstraintIds.includes(c.id)
+  );
+  if (!_.isEmpty(availableConstraints)) {
+    properties.push({
+      label: "Add Constraint",
+      children: (
+        <div>
+          <Select
+            value={newConstraintId || ""}
+            onChange={(e) => setNewConstraintId(Number(e.target.value))}
+          >
+            {availableConstraints.map((c) => (
+              <MenuItem key={c.id} value={c.id}>
+                {c.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </div>
+      ),
+    });
+  }
+  return (
+    <div>
+      <DetailGrid
+        title={
+          <>
+            Eligibility Constraints
+            <IconButton onClick={saveChanges}>
+              <SaveIcon color="success" />
+            </IconButton>
+            <IconButton onClick={discardChanges}>
+              <CancelIcon color="error" />
+            </IconButton>
+          </>
+        }
+        properties={properties}
+      />
+    </div>
+  );
+}

--- a/adminapp/src/modules/navLinks.jsx
+++ b/adminapp/src/modules/navLinks.jsx
@@ -5,6 +5,7 @@ import KeyIcon from "@mui/icons-material/Key";
 import MailIcon from "@mui/icons-material/Mail";
 import ManageAccountsIcon from "@mui/icons-material/ManageAccounts";
 import PersonIcon from "@mui/icons-material/Person";
+import PortraitIcon from "@mui/icons-material/Portrait";
 import SellIcon from "@mui/icons-material/Sell";
 import ShoppingBagIcon from "@mui/icons-material/ShoppingBag";
 import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
@@ -53,6 +54,11 @@ export default [
   {
     label: "Vendor Accounts",
     href: "/vendor-accounts",
+    icon: <PortraitIcon />,
+  },
+  {
+    label: "Vendor Configurations",
+    href: "/vendor-configurations",
     icon: <ManageAccountsIcon />,
   },
   {

--- a/adminapp/src/modules/navLinks.jsx
+++ b/adminapp/src/modules/navLinks.jsx
@@ -3,6 +3,7 @@ import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
 import HomeIcon from "@mui/icons-material/Home";
 import KeyIcon from "@mui/icons-material/Key";
 import MailIcon from "@mui/icons-material/Mail";
+import ManageAccountsIcon from "@mui/icons-material/ManageAccounts";
 import PersonIcon from "@mui/icons-material/Person";
 import SellIcon from "@mui/icons-material/Sell";
 import ShoppingBagIcon from "@mui/icons-material/ShoppingBag";
@@ -48,6 +49,11 @@ export default [
     label: "Vendors",
     href: "/vendors",
     icon: <StorefrontIcon />,
+  },
+  {
+    label: "Vendor Accounts",
+    href: "/vendor-accounts",
+    icon: <ManageAccountsIcon />,
   },
   {
     label: "Orders",

--- a/adminapp/src/pages/EligibilityConstraintDetailPage.jsx
+++ b/adminapp/src/pages/EligibilityConstraintDetailPage.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import BoolCheckmark from "../components/BoolCheckmark";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
@@ -65,7 +66,7 @@ export default function EligibilityConstraintDetailPage() {
               "Enabled",
             ]}
             toCells={(row) => [
-              row.id,
+              <AdminLink model={row} />,
               dayjs(row.createdAt).format("lll"),
               <AdminLink key={row.vendor.name} model={row.vendor}>
                 {row.vendor.name}
@@ -73,9 +74,9 @@ export default function EligibilityConstraintDetailPage() {
               <SafeExternalLink key={1} href={row.appInstallLink}>
                 {row.appInstallLink}
               </SafeExternalLink>,
-              row.usesEmail ? "Yes" : "No",
-              row.usesSms ? "Yes" : "No",
-              row.enabled ? "Yes" : "No",
+              <BoolCheckmark>{row.usesSms}</BoolCheckmark>,
+              <BoolCheckmark>{row.usesEmail}</BoolCheckmark>,
+              <BoolCheckmark>{row.enabled}</BoolCheckmark>,
             ]}
           />
         </>

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -357,6 +357,7 @@ function ResetCodes({ resetCodes }) {
       title="Login Codes"
       headers={["Sent", "Expires", "Token", "Used"]}
       rows={resetCodes}
+      getKey={(row) => row.id}
       toCells={(row) => [
         dayjs(row.createdAt).format("lll"),
         dayjs(row.expireAt).format("lll"),
@@ -472,7 +473,7 @@ function MessageDeliveries({ messageDeliveries }) {
       title="Message Deliveries"
       headers={["Id", "Created", "Sent", "Template", "To"]}
       rows={messageDeliveries}
-      keyRowAttr="id"
+      getKey={(row) => row.id}
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         dayjs(row.createdAt).format("lll"),

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -203,7 +203,7 @@ function EligibilityConstraints({ memberConstraints, memberId, replaceMemberData
     } else {
       memberConstraints.forEach(({ status, constraint }) =>
         properties.push({
-          label: constraint.name,
+          label: <AdminLink model={constraint}>{constraint.name}</AdminLink>,
           value: (
             <Typography variant="span" sx={{ lineHeight: "2.5!important" }}>
               {status}

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -136,6 +136,7 @@ export default function MemberDetailPage() {
           <Charges charges={member.charges} />
           <BankAccounts bankAccounts={member.bankAccounts} />
           <PaymentAccountRelatedLists paymentAccount={member.paymentAccount} />
+          <VendorAccounts vendorAccounts={member.vendorAccounts} />
           <MessagePreferences preferences={member.preferences} />
           <MessageDeliveries messageDeliveries={member.messageDeliveries} />
           <Sessions sessions={member.sessions} />
@@ -480,6 +481,34 @@ function MessageDeliveries({ messageDeliveries }) {
         row.sentAt ? dayjs(row.sentAt).format("lll") : "<unsent>",
         row.template,
         row.to,
+      ]}
+    />
+  );
+}
+
+function VendorAccounts({ vendorAccounts }) {
+  return (
+    <RelatedList
+      title="Vendor Accounts"
+      headers={[
+        "Id",
+        "Created",
+        "Vendor",
+        "Latest Access Code Magic Link",
+        "Latest Access Code",
+      ]}
+      rows={vendorAccounts}
+      getKey={(row) => row.id}
+      toCells={(row) => [
+        <AdminLink key="id" model={row} />,
+        dayjs(row.createdAt).format("lll"),
+        <AdminLink key="id" model={row.vendor}>
+          {row.vendor.name}
+        </AdminLink>,
+        <SafeExternalLink href={row.latestAccessCodeMagicLink}>
+          {row.latestAccessCodeMagicLink}
+        </SafeExternalLink>,
+        row.latestAccessCode,
       ]}
     />
   );

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -340,7 +340,7 @@ function Activities({ activities }) {
       title="Activities"
       headers={["At", "Summary", "Message"]}
       rows={activities}
-      getKey={(row) => row.id}
+      keyRowAttr="id"
       toCells={(row) => [
         dayjs(row.createdAt).format("lll"),
         row.summary,
@@ -358,7 +358,7 @@ function ResetCodes({ resetCodes }) {
       title="Login Codes"
       headers={["Sent", "Expires", "Token", "Used"]}
       rows={resetCodes}
-      getKey={(row) => row.id}
+      keyRowAttr="id"
       toCells={(row) => [
         dayjs(row.createdAt).format("lll"),
         dayjs(row.expireAt).format("lll"),
@@ -450,7 +450,7 @@ function MessagePreferences({ preferences }) {
         title="Message Preferences"
         headers={["Key", "Opted In", "Editable State"]}
         rows={subscriptions}
-        keyRowAttr="id"
+        keyRowAttr="key"
         toCells={(row) => [
           row.key,
           <BoolCheckmark key={2}>{row.optedIn}</BoolCheckmark>,
@@ -474,7 +474,7 @@ function MessageDeliveries({ messageDeliveries }) {
       title="Message Deliveries"
       headers={["Id", "Created", "Sent", "Template", "To"]}
       rows={messageDeliveries}
-      getKey={(row) => row.id}
+      keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         dayjs(row.createdAt).format("lll"),
@@ -498,7 +498,7 @@ function VendorAccounts({ vendorAccounts }) {
         "Latest Access Code",
       ]}
       rows={vendorAccounts}
-      getKey={(row) => row.id}
+      keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         dayjs(row.createdAt).format("lll"),

--- a/adminapp/src/pages/OfferingDetailPage.jsx
+++ b/adminapp/src/pages/OfferingDetailPage.jsx
@@ -1,26 +1,16 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
-import DetailGrid from "../components/DetailGrid";
+import EligibilityConstraints from "../components/EligibilityConstraints";
 import Link from "../components/Link";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import { dayjs } from "../modules/dayConfig";
 import oneLineAddress from "../modules/oneLineAddress";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import Money from "../shared/react/Money";
 import SumaImage from "../shared/react/SumaImage";
-import useAsyncFetch from "../shared/react/useAsyncFetch";
-import CancelIcon from "@mui/icons-material/Cancel";
-import CheckIcon from "@mui/icons-material/Check";
-import DeleteIcon from "@mui/icons-material/Delete";
-import EditIcon from "@mui/icons-material/Edit";
 import ListAltIcon from "@mui/icons-material/ListAlt";
-import SaveIcon from "@mui/icons-material/Save";
-import { MenuItem, Select } from "@mui/material";
-import IconButton from "@mui/material/IconButton";
 import { makeStyles } from "@mui/styles";
-import _ from "lodash";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 
@@ -105,9 +95,10 @@ export default function OfferingDetailPage() {
             ]}
           />
           <EligibilityConstraints
-            offeringConstraints={model.eligibilityConstraints}
-            offeringId={model.id}
-            replaceOfferingData={setModel}
+            constraints={model.eligibilityConstraints}
+            modelId={model.id}
+            replaceModelData={setModel}
+            makeUpdateRequest={api.updateOfferingEligibilityConstraints}
           />
           <RelatedList
             title={`Offering Products (${model.offeringProducts.length})`}
@@ -153,141 +144,6 @@ export default function OfferingDetailPage() {
         </>
       )}
     </ResourceDetail>
-  );
-}
-
-function EligibilityConstraints({
-  offeringConstraints,
-  offeringId,
-  replaceOfferingData,
-}) {
-  const [editing, setEditing] = React.useState(false);
-  const [updatedConstraints, setUpdatedConstraints] = React.useState([]);
-  const [newConstraintId, setNewConstraintId] = React.useState(0);
-  const { enqueueErrorSnackbar } = useErrorSnackbar();
-
-  const { state: eligibilityConstraints, loading: eligibilityConstraintsLoading } =
-    useAsyncFetch(api.getEligibilityConstraintsMeta, {
-      pickData: true,
-    });
-
-  function startEditing() {
-    setEditing(true);
-    setUpdatedConstraints(offeringConstraints);
-    setNewConstraintId(eligibilityConstraints[0]?.id);
-  }
-
-  if (!editing) {
-    const properties = [];
-    if (_.isEmpty(offeringConstraints)) {
-      properties.push({
-        label: "*",
-        value: "Offering has no constraints. All members can access it.",
-      });
-    } else {
-      offeringConstraints.forEach(({ name }) =>
-        properties.push({
-          label: name,
-          value: <CheckIcon />,
-        })
-      );
-    }
-    return (
-      <div>
-        <DetailGrid
-          title={
-            <>
-              Eligibility Constraints
-              <IconButton onClick={startEditing}>
-                <EditIcon color="info" />
-              </IconButton>
-            </>
-          }
-          properties={properties}
-        />
-      </div>
-    );
-  }
-
-  if (eligibilityConstraintsLoading) {
-    return "Loading...";
-  }
-
-  function discardChanges() {
-    setUpdatedConstraints([]);
-    setEditing(false);
-  }
-
-  function saveChanges() {
-    const constraintIds = updatedConstraints.map((c) => c.id);
-    if (newConstraintId) {
-      constraintIds.push(newConstraintId);
-    }
-    api
-      .updateOfferingEligibilityConstraints({
-        id: offeringId,
-        constraintIds,
-      })
-      .then((r) => {
-        replaceOfferingData(r.data);
-        setEditing(false);
-      })
-      .catch(enqueueErrorSnackbar);
-  }
-
-  function deleteConstraint(id) {
-    setUpdatedConstraints(updatedConstraints.filter((c) => c.id !== id));
-  }
-
-  const properties = updatedConstraints.map((c) => ({
-    label: c.name,
-    children: (
-      <IconButton onClick={() => deleteConstraint(c.id)}>
-        <DeleteIcon color="error" />
-      </IconButton>
-    ),
-  }));
-
-  const existingConstraintIds = offeringConstraints.map((c) => c.id);
-  const availableConstraints = eligibilityConstraints.items.filter(
-    (c) => !existingConstraintIds.includes(c.id)
-  );
-  if (!_.isEmpty(availableConstraints)) {
-    properties.push({
-      label: "Add Constraint",
-      children: (
-        <div>
-          <Select
-            value={newConstraintId || ""}
-            onChange={(e) => setNewConstraintId(Number(e.target.value))}
-          >
-            {availableConstraints.map((c) => (
-              <MenuItem key={c.id} value={c.id}>
-                {c.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </div>
-      ),
-    });
-  }
-  return (
-    <div>
-      <DetailGrid
-        title={
-          <>
-            Eligibility Constraints
-            <IconButton onClick={saveChanges}>
-              <SaveIcon color="success" />
-            </IconButton>
-            <IconButton onClick={discardChanges}>
-              <CancelIcon color="error" />
-            </IconButton>
-          </>
-        }
-        properties={properties}
-      />
-    </div>
   );
 }
 

--- a/adminapp/src/pages/OfferingDetailPage.jsx
+++ b/adminapp/src/pages/OfferingDetailPage.jsx
@@ -71,11 +71,25 @@ export default function OfferingDetailPage() {
           label: "Pick/Pack list",
           value: !isEmpty(model.orders) ? (
             <Link to={`/offering/${model.id}/picklist`}>
-              <ListAltIcon sx={{ verticalAlign: "middle", paddingRight: "5px" }} />
+              <ListAltIcon sx={{ verticalAlign: "middle", marginRight: "5px" }} />
               Pick/Pack List
             </Link>
           ) : (
             "-"
+          ),
+        },
+        {
+          label: "Create Offering Product",
+          value: (
+            <Link
+              to={createRelativeUrl(`/offering-product/new`, {
+                offeringId: model.id,
+                offeringLabel: model.description.en,
+              })}
+            >
+              <ListAltIcon sx={{ verticalAlign: "middle", marginRight: "5px" }} />
+              Create Offering Product
+            </Link>
           ),
         },
       ]}
@@ -116,16 +130,6 @@ export default function OfferingDetailPage() {
               <Money key="undiscounted_price">{row.undiscountedPrice}</Money>,
             ]}
           />
-          <Link
-            to={createRelativeUrl(`/offering-product/new`, {
-              offeringId: model.id,
-              offeringLabel: model.description.en,
-            })}
-            sx={{ display: "block", marginTop: "15px" }}
-          >
-            <ListAltIcon sx={{ verticalAlign: "middle", paddingRight: "5px" }} />
-            Create Offering Product
-          </Link>
           <RelatedList
             title={`Orders (${model.orders.length})`}
             rows={model.orders}

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -29,6 +29,7 @@ import {
 } from "@mui/material";
 import Box from "@mui/material/Box";
 import { DateTimePicker } from "@mui/x-date-pickers";
+import isEmpty from "lodash/isEmpty";
 import React from "react";
 
 export default function OfferingForm({
@@ -318,7 +319,9 @@ function OptionAddress({ address, onFieldChange }) {
           <Select
             label="State"
             name="stateOrProvince"
-            value={address.stateOrProvince}
+            value={
+              !isEmpty(supportedGeographies?.provinces) ? address.stateOrProvince : ""
+            }
             onChange={handleChange}
           >
             <MenuItem disabled>Choose state</MenuItem>

--- a/adminapp/src/pages/ProductDetailPage.jsx
+++ b/adminapp/src/pages/ProductDetailPage.jsx
@@ -55,24 +55,24 @@ export default function ProductDetailPage() {
           label: "Quantity Pending Fulfillment",
           value: model.inventory.quantityPendingFulfillment,
         },
+        {
+          label: "Create Offering Product",
+          value: (
+            <Link
+              to={createRelativeUrl(`/offering-product/new`, {
+                productId: model.id,
+                productLabel: model.name.en,
+              })}
+            >
+              <ListAltIcon sx={{ verticalAlign: "middle", marginRight: "5px" }} />
+              Create Offering Product
+            </Link>
+          ),
+        },
       ]}
     >
       {(model) => (
         <>
-          <RelatedList
-            title="Orders"
-            rows={model.orders}
-            headers={["Id", "Created At", "Status", "Member"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              dayjs(row.createdAt).format("lll"),
-              row.orderStatus,
-              <AdminLink key="member" model={row.member}>
-                {row.member.name}
-              </AdminLink>,
-            ]}
-          />
           <RelatedList
             title={`Offering Products`}
             rows={model.offeringProducts}
@@ -90,16 +90,20 @@ export default function ProductDetailPage() {
               row.isClosed ? dayjs(row.closedAt).format("lll") : "",
             ]}
           />
-          <Link
-            to={createRelativeUrl(`/offering-product/new`, {
-              productId: model.id,
-              productLabel: model.name.en,
-            })}
-            sx={{ display: "inline-block", marginTop: "15px" }}
-          >
-            <ListAltIcon sx={{ verticalAlign: "middle", paddingRight: "5px" }} />
-            Create Offering Product
-          </Link>
+          <RelatedList
+            title="Orders"
+            rows={model.orders}
+            headers={["Id", "Created At", "Status", "Member"]}
+            keyRowAttr="id"
+            toCells={(row) => [
+              <AdminLink key="id" model={row} />,
+              dayjs(row.createdAt).format("lll"),
+              row.orderStatus,
+              <AdminLink key="member" model={row.member}>
+                {row.member.name}
+              </AdminLink>,
+            ]}
+          />
         </>
       )}
     </ResourceDetail>

--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -1,10 +1,8 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import DetailGrid from "../components/DetailGrid";
-import ExternalLinks from "../components/ExternalLinks";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import Unavailable from "../components/Unavailable";
 import { dayjs } from "../modules/dayConfig";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import React from "react";
@@ -103,13 +101,34 @@ export default function VendorAccountDetailPage() {
                 { label: "Email", value: model.contact.email },
                 { label: "Phone", value: model.contact.phone },
                 { label: "Relay Key", value: model.contact.relayKey },
-                {
-                  label: "External Links",
-                  value: <ExternalLinks externalLinks={model.contact.externalLinks} />,
-                },
               ]}
             />
           )}
+          <RelatedList
+            title="Messages"
+            rows={model.messages}
+            headers={[
+              "Id",
+              "Created",
+              "Content",
+              "From",
+              "To",
+              "Handler Key",
+              "Relay Key",
+              "Timestamp",
+            ]}
+            keyRowAttr="id"
+            toCells={(row) => [
+              row.id,
+              dayjs(row.createdAt).format("lll"),
+              row.messageContent,
+              row.messageFrom,
+              row.messageTo,
+              row.messageHandlerKey,
+              row.relayKey,
+              dayjs(row.timestamp).format("lll"),
+            ]}
+          />
         </>
       )}
     </ResourceDetail>

--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import BoolCheckmark from "../components/BoolCheckmark";
 import DetailGrid from "../components/DetailGrid";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
@@ -36,9 +37,7 @@ export default function VendorAccountDetailPage() {
         },
         {
           label: "Latest Access Code Set At",
-          value: model.latestAccessCodeRequestedAt
-            ? dayjs(model.latestAccessCodeSetAt)
-            : "",
+          value: model.latestAccessCodeSetAt ? dayjs(model.latestAccessCodeSetAt) : "",
         },
       ]}
     >
@@ -48,7 +47,7 @@ export default function VendorAccountDetailPage() {
             <DetailGrid
               title="Configuration"
               properties={[
-                { label: "ID", value: model.configuration.id },
+                { label: "ID", value: <AdminLink model={model.configuration} /> },
                 {
                   label: "Vendor",
                   value: (
@@ -57,20 +56,6 @@ export default function VendorAccountDetailPage() {
                     </AdminLink>
                   ),
                 },
-                { label: "Auth HTTP Method", value: model.configuration.authHttpMethod },
-                {
-                  label: "Auth URL",
-                  value: (
-                    <SafeExternalLink href={model.configuration.authUrl}>
-                      {model.configuration.authUrl}
-                    </SafeExternalLink>
-                  ),
-                },
-                {
-                  label: "Auth Body Template",
-                  value: model.configuration.authBodyTemplate,
-                },
-                { label: "Auth Header", value: model.configuration.authHeaders },
                 {
                   label: "App Install Link",
                   value: (
@@ -79,9 +64,18 @@ export default function VendorAccountDetailPage() {
                     </SafeExternalLink>
                   ),
                 },
-                { label: "Enabled?", value: model.configuration.enabled },
-                { label: "Uses Email?", value: model.configuration.usesEmail },
-                { label: "Uses SMS?", value: model.configuration.usesSms },
+                {
+                  label: "Uses SMS?",
+                  value: <BoolCheckmark>{model.configuration.usesSms}</BoolCheckmark>,
+                },
+                {
+                  label: "Uses Email?",
+                  value: <BoolCheckmark>{model.configuration.usesEmail}</BoolCheckmark>,
+                },
+                {
+                  label: "Enabled?",
+                  value: <BoolCheckmark>{model.configuration.enabled}</BoolCheckmark>,
+                },
               ]}
             />
           )}

--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -1,0 +1,117 @@
+import api from "../api";
+import AdminLink from "../components/AdminLink";
+import DetailGrid from "../components/DetailGrid";
+import ExternalLinks from "../components/ExternalLinks";
+import RelatedList from "../components/RelatedList";
+import ResourceDetail from "../components/ResourceDetail";
+import Unavailable from "../components/Unavailable";
+import { dayjs } from "../modules/dayConfig";
+import SafeExternalLink from "../shared/react/SafeExternalLink";
+import React from "react";
+
+export default function VendorAccountDetailPage() {
+  return (
+    <ResourceDetail
+      apiGet={api.getVendorAccount}
+      title={(model) => `Vendor Account ${model.id}`}
+      properties={(model) => [
+        { label: "ID", value: model.id },
+        { label: "Created At", value: dayjs(model.createdAt) },
+        {
+          label: "Member",
+          value: <AdminLink model={model.member}>{model.member.name}</AdminLink>,
+        },
+        {
+          label: "Latest Access Code Magic Link",
+          value: (
+            <SafeExternalLink href={model.latestAccessCodeMagicLink}>
+              {model.latestAccessCodeMagicLink}
+            </SafeExternalLink>
+          ),
+        },
+        { label: "Latest Access Code", value: model.latestAccessCode },
+        {
+          label: "Latest Access Code Requested At",
+          value: model.latestAccessCodeRequestedAt
+            ? dayjs(model.latestAccessCodeRequestedAt)
+            : "",
+        },
+        {
+          label: "Latest Access Code Set At",
+          value: model.latestAccessCodeRequestedAt
+            ? dayjs(model.latestAccessCodeSetAt)
+            : "",
+        },
+      ]}
+    >
+      {(model) => (
+        <>
+          {model.configuration && (
+            <DetailGrid
+              title="Configuration"
+              properties={[
+                { label: "ID", value: model.configuration.id },
+                {
+                  label: "Vendor",
+                  value: (
+                    <AdminLink model={model.configuration.vendor}>
+                      {model.configuration.vendor?.name}
+                    </AdminLink>
+                  ),
+                },
+                { label: "Auth HTTP Method", value: model.configuration.authHttpMethod },
+                {
+                  label: "Auth URL",
+                  value: (
+                    <SafeExternalLink href={model.configuration.authUrl}>
+                      {model.configuration.authUrl}
+                    </SafeExternalLink>
+                  ),
+                },
+                {
+                  label: "Auth Body Template",
+                  value: model.configuration.authBodyTemplate,
+                },
+                { label: "Auth Header", value: model.configuration.authHeaders },
+                {
+                  label: "App Install Link",
+                  value: (
+                    <SafeExternalLink href={model.configuration.appInstallLink}>
+                      {model.configuration.appInstallLink}
+                    </SafeExternalLink>
+                  ),
+                },
+                { label: "Enabled?", value: model.configuration.enabled },
+                { label: "Uses Email?", value: model.configuration.usesEmail },
+                { label: "Uses SMS?", value: model.configuration.usesSms },
+              ]}
+            />
+          )}
+          {model.contact && (
+            <DetailGrid
+              title="Member Contact"
+              properties={[
+                { label: "ID", value: model.contact.id },
+                {
+                  label: "Member",
+                  value: (
+                    <AdminLink model={model.contact.member}>
+                      {model.contact.member.name}
+                    </AdminLink>
+                  ),
+                },
+                { label: "Email", value: model.contact.email },
+                { label: "Phone", value: model.contact.phone },
+                { label: "Relay Key", value: model.contact.relayKey },
+                {
+                  label: "External Links",
+                  value: <ExternalLinks externalLinks={model.contact.externalLinks} />,
+                },
+              ]}
+            />
+          )}
+        </>
+      )}
+    </ResourceDetail>
+  );
+}

--- a/adminapp/src/pages/VendorAccountListPage.jsx
+++ b/adminapp/src/pages/VendorAccountListPage.jsx
@@ -9,7 +9,6 @@ export default function VendorAccountListPage() {
   return (
     <ResourceList
       apiList={api.getVendorAccounts}
-      toCreate="/vendor-account/new"
       title="Vendor Accounts"
       canSearch
       columns={[

--- a/adminapp/src/pages/VendorAccountListPage.jsx
+++ b/adminapp/src/pages/VendorAccountListPage.jsx
@@ -1,0 +1,49 @@
+import api from "../api";
+import AdminLink from "../components/AdminLink";
+import ResourceList from "../components/ResourceList";
+import Unavailable from "../components/Unavailable";
+import { dayjs } from "../modules/dayConfig";
+import React from "react";
+
+export default function VendorAccountListPage() {
+  return (
+    <ResourceList
+      apiList={api.getVendorAccounts}
+      toCreate="/vendor-account/new"
+      title="Vendor Accounts"
+      canSearch
+      columns={[
+        {
+          id: "id",
+          label: "ID",
+          align: "center",
+          sortable: true,
+          render: (c) => <AdminLink model={c} />,
+        },
+        {
+          id: "member",
+          label: "Member",
+          align: "left",
+          render: (c) => <AdminLink model={c.member}>{c.member.name}</AdminLink>,
+        },
+        {
+          id: "vendor",
+          label: "Vendor",
+          align: "left",
+          render: (c) => (
+            <AdminLink model={c.configuration.vendor}>
+              {c.configuration.vendor.name || <Unavailable />}
+            </AdminLink>
+          ),
+        },
+        {
+          id: "created_at",
+          label: "Created",
+          align: "left",
+          sortable: true,
+          render: (c) => dayjs(c.createdAt).format("lll"),
+        },
+      ]}
+    />
+  );
+}

--- a/adminapp/src/pages/VendorConfigurationDetailPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationDetailPage.jsx
@@ -1,0 +1,47 @@
+import api from "../api";
+import AdminLink from "../components/AdminLink";
+import BoolCheckmark from "../components/BoolCheckmark";
+import EligibilityConstraints from "../components/EligibilityConstraints";
+import ResourceDetail from "../components/ResourceDetail";
+import { dayjs } from "../modules/dayConfig";
+import SafeExternalLink from "../shared/react/SafeExternalLink";
+import React from "react";
+
+export default function VendorConfigurationDetailPage() {
+  return (
+    <ResourceDetail
+      apiGet={api.getVendorConfiguration}
+      title={(model) => `Vendor Configuration ${model.id}`}
+      properties={(model) => [
+        { label: "ID", value: model.id },
+        { label: "Created At", value: dayjs(model.createdAt) },
+        {
+          label: "Vendor",
+          value: <AdminLink model={model.vendor}>{model.vendor.name}</AdminLink>,
+        },
+        {
+          label: "App Install Link",
+          value: (
+            <SafeExternalLink href={model.appInstallLink}>
+              {model.appInstallLink}
+            </SafeExternalLink>
+          ),
+        },
+        { label: "Uses SMS?", value: <BoolCheckmark>{model.usesSms}</BoolCheckmark> },
+        { label: "Uses Email?", value: <BoolCheckmark>{model.usesEmail}</BoolCheckmark> },
+        { label: "Enabled?", value: <BoolCheckmark>{model.enabled}</BoolCheckmark> },
+      ]}
+    >
+      {(model, setModel) => (
+        <>
+          <EligibilityConstraints
+            constraints={model.eligibilityConstraints}
+            modelId={model.id}
+            replaceModelData={setModel}
+            makeUpdateRequest={api.updateVendorConfigurationEligibilityConstraints}
+          />
+        </>
+      )}
+    </ResourceDetail>
+  );
+}

--- a/adminapp/src/pages/VendorConfigurationListPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationListPage.jsx
@@ -1,0 +1,56 @@
+import api from "../api";
+import AdminLink from "../components/AdminLink";
+import BoolCheckmark from "../components/BoolCheckmark";
+import ResourceList from "../components/ResourceList";
+import { dayjs } from "../modules/dayConfig";
+import React from "react";
+
+export default function VendorConfigurationListPage() {
+  return (
+    <ResourceList
+      apiList={api.getVendorConfigurations}
+      title="Vendor Configurations"
+      canSearch
+      columns={[
+        {
+          id: "id",
+          label: "ID",
+          align: "center",
+          sortable: true,
+          render: (c) => <AdminLink model={c} />,
+        },
+        {
+          id: "vendor",
+          label: "Vendor",
+          align: "left",
+          render: (c) => <AdminLink model={c.vendor}>{c.vendor.name}</AdminLink>,
+        },
+        {
+          id: "uses_sms",
+          label: "Uses SMS?",
+          align: "center",
+          render: (c) => <BoolCheckmark>{c.usesSms}</BoolCheckmark>,
+        },
+        {
+          id: "uses_email",
+          label: "Uses Email?",
+          align: "center",
+          render: (c) => <BoolCheckmark>{c.usesEmail}</BoolCheckmark>,
+        },
+        {
+          id: "enabled",
+          label: "Enabled?",
+          align: "center",
+          render: (c) => <BoolCheckmark>{c.enabled}</BoolCheckmark>,
+        },
+        {
+          id: "created_at",
+          label: "Created",
+          align: "left",
+          sortable: true,
+          render: (c) => dayjs(c.createdAt).format("lll"),
+        },
+      ]}
+    />
+  );
+}

--- a/adminapp/src/pages/VendorDetailPage.jsx
+++ b/adminapp/src/pages/VendorDetailPage.jsx
@@ -1,8 +1,10 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import BoolCheckmark from "../components/BoolCheckmark";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import SafeExternalLink from "../shared/react/SafeExternalLink";
 import theme from "../theme";
 import map from "lodash/map";
 import React from "react";
@@ -39,6 +41,29 @@ export default function VendorDetailPage() {
                   {ec.name}
                 </AdminLink>
               )),
+            ]}
+          />
+          <RelatedList
+            title="Configuration"
+            rows={model.configurations}
+            headers={[
+              "Id",
+              "Vendor",
+              "App Install Link",
+              "Enabled?",
+              "Uses Email?",
+              "Uses SMS?",
+            ]}
+            keyRowAttr="id"
+            toCells={(row) => [
+              <AdminLink key="id" model={row} />,
+              row.vendor.name,
+              <SafeExternalLink href={row.appInstallLink}>
+                {row.appInstallLink}
+              </SafeExternalLink>,
+              <BoolCheckmark>{row.usesSMS}</BoolCheckmark>,
+              <BoolCheckmark>{row.usesEmail}</BoolCheckmark>,
+              <BoolCheckmark>{row.enabled}</BoolCheckmark>,
             ]}
           />
           <RelatedList

--- a/adminapp/src/pages/VendorDetailPage.jsx
+++ b/adminapp/src/pages/VendorDetailPage.jsx
@@ -49,7 +49,7 @@ export default function VendorDetailPage() {
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
               dayjs(row.createdAt).format("lll"),
-              row.name,
+              row.name.en,
               map(row.eligibilityConstraints, "name"),
             ]}
           />

--- a/lib/suma/admin_api/anon_proxy.rb
+++ b/lib/suma/admin_api/anon_proxy.rb
@@ -8,19 +8,17 @@ class Suma::AdminAPI::AnonProxy < Suma::AdminAPI::V1
 
   class VendorAccountMessageEntity < BaseEntity
     include Suma::AdminAPI::Entities
+    expose :id
     expose :message_from
     expose :message_to
     expose :message_content
     expose :message_timestamp
     expose :relay_key
     expose :message_handler_key
-    expose :vendor_account
-    expose :outbound_delivery
   end
 
-  class VendorContactEntity < BaseEntity
+  class MemberContactEntity < BaseEntity
     include Suma::AdminAPI::Entities
-    include AutoExposeDetail
     expose :id
     expose :member, with: MemberEntity
     expose :phone
@@ -58,7 +56,7 @@ class Suma::AdminAPI::AnonProxy < Suma::AdminAPI::V1
     expose :latest_access_code_set_at
     expose :latest_access_code_requested_at
     expose :latest_access_code_magic_link
-    expose :contact, with: VendorContactEntity
+    expose :contact, with: MemberContactEntity
   end
 
   resource :anon_proxy do
@@ -66,13 +64,18 @@ class Suma::AdminAPI::AnonProxy < Suma::AdminAPI::V1
       Suma::AdminAPI::CommonEndpoints.list(
         self,
         Suma::AnonProxy::VendorAccount, AnonProxyVendorAccountEntity,
+        search_params: [:latest_access_code_magic_link, :latest_access_code],
       )
       Suma::AdminAPI::CommonEndpoints.get_one self, Suma::AnonProxy::VendorAccount, DetailedAnonProxyVendorAccountEntity
-      # Suma::AdminAPI::CommonEndpoints.update self, Suma::Eligibility::Constraint, DetailedEligibilityConstraintEntity do
-      #   params do
-      #     optional :name, type: String, allow_blank: false
-      #   end
-      # end
+      Suma::AdminAPI::CommonEndpoints.update self, Suma::AnonProxy::VendorAccount,
+                                             DetailedAnonProxyVendorAccountEntity do
+        params do
+          optional :latest_access_code_magic_link, type: String
+          optional :latest_access_code, type: String
+          optional :latest_access_code_set_at, type: Time
+          optional :latest_access_code_requested_at, type: Time
+        end
+      end
     end
   end
 end

--- a/lib/suma/admin_api/eligibility_constraints.rb
+++ b/lib/suma/admin_api/eligibility_constraints.rb
@@ -6,16 +6,6 @@ require "suma/admin_api"
 class Suma::AdminAPI::EligibilityConstraints < Suma::AdminAPI::V1
   include Suma::AdminAPI::Entities
 
-  class VendorConfigurationEntity < BaseEntity
-    include Suma::AdminAPI::Entities
-    expose :id
-    expose :vendor, with: VendorEntity
-    expose :app_install_link
-    expose :uses_email
-    expose :uses_sms
-    expose :enabled
-  end
-
   class DetailedEligibilityConstraintEntity < EligibilityConstraintEntity
     include Suma::AdminAPI::Entities
     expose :offerings, with: OfferingEntity

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -125,6 +125,16 @@ module Suma::AdminAPI::Entities
     expose :slug
   end
 
+  class VendorConfigurationEntity < BaseEntity
+    include AutoExposeBase
+    expose :id
+    expose :vendor, with: VendorEntity
+    expose :app_install_link
+    expose :uses_email
+    expose :uses_sms
+    expose :enabled
+  end
+
   class ChargeEntity < BaseEntity
     include AutoExposeBase
     expose :opaque_id

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -161,6 +161,14 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :constraint, with: Suma::AdminAPI::Entities::EligibilityConstraintEntity
   end
 
+  class MemberVendorAccountEntity < BaseEntity
+    include Suma::AdminAPI::Entities
+    include AutoExposeBase
+    expose :latest_access_code
+    expose :latest_access_code_magic_link
+    expose :vendor, with: VendorEntity, &self.delegate_to(:configuration, :vendor)
+  end
+
   class PreferencesSubscriptionEntity < BaseEntity
     expose :key
     expose :opted_in
@@ -200,5 +208,6 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :orders, with: MemberOrderEntity
     expose :message_deliveries, with: MessageDeliveryEntity
     expose :preferences!, as: :preferences, with: PreferencesEntity
+    expose :anon_proxy_vendor_accounts, as: :vendor_accounts, with: MemberVendorAccountEntity
   end
 end

--- a/lib/suma/admin_api/vendors.rb
+++ b/lib/suma/admin_api/vendors.rb
@@ -11,6 +11,7 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
     expose :slug
     expose :services, with: VendorServiceEntity
     expose :products, with: ProductEntity
+    expose :configurations, with: VendorConfigurationEntity
   end
 
   resource :vendors do

--- a/lib/suma/anon_proxy/vendor_account.rb
+++ b/lib/suma/anon_proxy/vendor_account.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require "suma/admin_linked"
 require "suma/anon_proxy"
 require "suma/postgres"
 require "suma/eligibility/has_constraints"
 
 class Suma::AnonProxy::VendorAccount < Suma::Postgres::Model(:anon_proxy_vendor_accounts)
+  include Suma::AdminLinked
   RECENT_ACCESS_CODE_CUTOFF = 10.minutes
 
   plugin :timestamps
@@ -129,6 +131,8 @@ class Suma::AnonProxy::VendorAccount < Suma::Postgres::Model(:anon_proxy_vendor_
       body:,
     }
   end
+
+  def rel_admin_link = "/vendor-account/#{self.id}"
 end
 
 # Table: anon_proxy_vendor_accounts

--- a/lib/suma/anon_proxy/vendor_configuration.rb
+++ b/lib/suma/anon_proxy/vendor_configuration.rb
@@ -4,8 +4,10 @@ require "suma/anon_proxy"
 require "suma/eligibility/has_constraints"
 require "suma/postgres"
 require "suma/translated_text"
+require "suma/admin_linked"
 
 class Suma::AnonProxy::VendorConfiguration < Suma::Postgres::Model(:anon_proxy_vendor_configurations)
+  include Suma::AdminLinked
   plugin :timestamps
   plugin :translated_text, :instructions, Suma::TranslatedText
 
@@ -32,6 +34,8 @@ class Suma::AnonProxy::VendorConfiguration < Suma::Postgres::Model(:anon_proxy_v
   def auth_headers_label
     self.auth_headers.to_s
   end
+
+  def rel_admin_link = "/vendor-configuration/#{self.id}"
 end
 
 # Table: anon_proxy_vendor_configurations

--- a/lib/suma/anon_proxy/vendor_configuration.rb
+++ b/lib/suma/anon_proxy/vendor_configuration.rb
@@ -28,6 +28,10 @@ class Suma::AnonProxy::VendorConfiguration < Suma::Postgres::Model(:anon_proxy_v
   def uses_email? = self.uses_email
   def uses_sms? = self.uses_sms
   def enabled? = self.enabled
+
+  def auth_headers_label
+    self.auth_headers.to_s
+  end
 end
 
 # Table: anon_proxy_vendor_configurations

--- a/lib/suma/apps.rb
+++ b/lib/suma/apps.rb
@@ -45,6 +45,7 @@ require "suma/admin_api/payout_transactions"
 require "suma/admin_api/roles"
 require "suma/admin_api/search"
 require "suma/admin_api/vendors"
+require "suma/admin_api/anon_proxy"
 
 module Suma::Apps
   class API < Suma::Service
@@ -65,6 +66,7 @@ module Suma::Apps
   end
 
   class AdminAPI < Suma::Service
+    mount Suma::AdminAPI::AnonProxy
     mount Suma::AdminAPI::Auth
     mount Suma::AdminAPI::BankAccounts
     mount Suma::AdminAPI::BookTransactions

--- a/lib/suma/eligibility/has_constraints.rb
+++ b/lib/suma/eligibility/has_constraints.rb
@@ -35,5 +35,19 @@ module Suma::Eligibility::HasConstraints
       member_ids = member.verified_eligibility_constraints.map(&:id).to_set
       return self.eligibility_constraints.any? { |ec| member_ids.include?(ec.id) }
     end
+
+    def replace_eligibility_constraints(ids)
+      self.db.transaction do
+        to_remove = self.eligibility_constraints_dataset.exclude(id: ids)
+        to_add = Suma::Eligibility::Constraint.where(id: ids).
+          exclude(id: self.eligibility_constraints_dataset.select(:id))
+        to_add.each do |c|
+          self.add_eligibility_constraint(c)
+        end
+        to_remove.each do |c|
+          self.remove_eligibility_constraint(c)
+        end
+      end
+    end
   end
 end

--- a/lib/suma/vendor.rb
+++ b/lib/suma/vendor.rb
@@ -10,6 +10,7 @@ class Suma::Vendor < Suma::Postgres::Model(:vendors)
 
   one_to_one :payment_account, class: "Suma::Payment::Account"
   one_to_many :services, class: "Suma::Vendor::Service"
+  one_to_many :configurations, class: "Suma::AnonProxy::VendorConfiguration"
   one_to_many :images, class: "Suma::Image"
   one_to_many :products, class: "Suma::Commerce::Product"
 

--- a/spec/suma/admin_api/anon_proxy_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "suma/admin_api/anon_proxy"
+require "suma/api/behaviors"
+
+RSpec.describe Suma::AdminAPI::AnonProxy, :db do
+  include Rack::Test::Methods
+
+  let(:app) { described_class.build_app }
+  let(:admin) { Suma::Fixtures.member.admin.create }
+
+  before(:each) do
+    login_as_admin(admin)
+  end
+
+  describe "GET /v1/anon_proxy/vendor_accounts" do
+    it "returns all anon proxy vendor accounts" do
+      objs = Array.new(2) { Suma::Fixtures.anon_proxy_vendor_account.create }
+
+      get "/v1/anon_proxy/vendor_accounts"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.
+        that_includes(items: have_same_ids_as(*objs))
+    end
+  end
+
+  describe "GET /v1/anon_proxy/vendor_account/:id" do
+    it "returns the anon proxy vendor account" do
+      configuration = Suma::Fixtures.anon_proxy_vendor_configuration.create
+      va = Suma::Fixtures.anon_proxy_vendor_account.with_configuration(configuration).create
+      puts va.inspect
+      member_contact = Suma::Fixtures.anon_proxy_member_contact(email: "a@b.c", member: va.member).create
+      va.update(contact: member_contact)
+
+      get "/v1/anon_proxy/vendor_accounts/#{va.id}"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        id: va.id,
+        configuration: include(id: configuration.id),
+        contact: include(id: member_contact.id),
+      )
+    end
+  end
+  #
+  # describe "POST /v1/eligibility_constraints/:id" do
+  #   it "updates the constraint" do
+  #     ec = Suma::Fixtures.eligibility_constraint.create
+  #     post "/v1/eligibility_constraints/#{ec.id}", name: "Test"
+  #
+  #     expect(last_response).to have_status(200)
+  #     expect(last_response.headers).to include("Created-Resource-Admin")
+  #     expect(ec.refresh).to have_attributes(name: "Test")
+  #   end
+  # end
+end

--- a/spec/suma/admin_api/anon_proxy_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_spec.rb
@@ -23,21 +23,57 @@ RSpec.describe Suma::AdminAPI::AnonProxy, :db do
       expect(last_response).to have_json_body.
         that_includes(items: have_same_ids_as(*objs))
     end
+
+    it_behaves_like "an endpoint capable of search" do
+      let(:url) { "/v1/anon_proxy/vendor_accounts" }
+      let(:search_term) { "abc" }
+
+      def make_matching_items
+        return [
+          Suma::Fixtures.anon_proxy_vendor_account.with_access_code("abc123").create,
+        ]
+      end
+
+      def make_non_matching_items
+        return [
+          Suma::Fixtures.anon_proxy_vendor_account.with_access_code("not magic").create,
+        ]
+      end
+    end
+
+    it_behaves_like "an endpoint with pagination" do
+      let(:url) { "/v1/anon_proxy/vendor_accounts" }
+      def make_item(i)
+        # Sorting is newest first, so the first items we create need to the the oldest.
+        created = Time.now - i.days
+        return Suma::Fixtures.anon_proxy_vendor_account.create(created_at: created)
+      end
+    end
+
+    it_behaves_like "an endpoint with member-supplied ordering" do
+      let(:url) { "/v1/anon_proxy/vendor_accounts" }
+      let(:order_by_field) { "id" }
+      def make_item(_i)
+        return Suma::Fixtures.anon_proxy_vendor_account.create(
+          created_at: Time.now + rand(1..100).days,
+        )
+      end
+    end
   end
 
-  describe "GET /v1/anon_proxy/vendor_account/:id" do
+  describe "GET /v1/anon_proxy/vendor_accounts/:id" do
     it "returns the anon proxy vendor account" do
-      configuration = Suma::Fixtures.anon_proxy_vendor_configuration.create
-      va = Suma::Fixtures.anon_proxy_vendor_account.with_configuration(configuration).create
-      member_contact = Suma::Fixtures.anon_proxy_member_contact(email: "a@b.c", member: va.member).create
-      va.update(contact: member_contact)
+      config = Suma::Fixtures.anon_proxy_vendor_configuration.create
+      member = Suma::Fixtures.member.create
+      member_contact = Suma::Fixtures.anon_proxy_member_contact(email: "a@b.c", member:).create
+      va = Suma::Fixtures.anon_proxy_vendor_account.with_configuration(config).with_contact(member_contact).create
 
       get "/v1/anon_proxy/vendor_accounts/#{va.id}"
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
         id: va.id,
-        configuration: include(id: configuration.id),
+        configuration: include(id: config.id),
         contact: include(id: member_contact.id),
       )
     end

--- a/spec/suma/admin_api/anon_proxy_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Suma::AdminAPI::AnonProxy, :db do
     it "returns the anon proxy vendor account" do
       configuration = Suma::Fixtures.anon_proxy_vendor_configuration.create
       va = Suma::Fixtures.anon_proxy_vendor_account.with_configuration(configuration).create
-      puts va.inspect
       member_contact = Suma::Fixtures.anon_proxy_member_contact(email: "a@b.c", member: va.member).create
       va.update(contact: member_contact)
 
@@ -43,15 +42,4 @@ RSpec.describe Suma::AdminAPI::AnonProxy, :db do
       )
     end
   end
-  #
-  # describe "POST /v1/eligibility_constraints/:id" do
-  #   it "updates the constraint" do
-  #     ec = Suma::Fixtures.eligibility_constraint.create
-  #     post "/v1/eligibility_constraints/#{ec.id}", name: "Test"
-  #
-  #     expect(last_response).to have_status(200)
-  #     expect(last_response.headers).to include("Created-Resource-Admin")
-  #     expect(ec.refresh).to have_attributes(name: "Test")
-  #   end
-  # end
 end


### PR DESCRIPTION
- Create `AnonProxy::VendorAccount` API routes for list, details
- Create anon proxy vendor account list, and details pages
- Fix table row key ids bugs in different pages
- Test

### Vendor account navigation tab icon
![Screenshot 2024-01-17 at 12 44 46 PM](https://github.com/lithictech/suma/assets/66847768/d3d8916e-6087-4ff5-b554-9c33b1aea2a2)

### Vendor account list page
![Screenshot 2024-01-17 at 12 44 59 PM](https://github.com/lithictech/suma/assets/66847768/cff9a83b-5856-4ad3-a531-7c21033ce331)

### Vendor account details page
![Screenshot 2024-01-17 at 12 45 17 PM](https://github.com/lithictech/suma/assets/66847768/d998f7ac-0949-4251-8f43-5d364bee6ec4)

### Member details (vendor account section)
![Screenshot 2024-01-17 at 12 44 21 PM](https://github.com/lithictech/suma/assets/66847768/28fa7734-f799-412c-9658-7782a8643e0c)
