### PR TITLE
Send a private account login SMS when we receive a Lime auth email

### DIFF
--- a/data/messages/templates/anon_proxy/lime-deep-link-access-code.en.sms.liquid
+++ b/data/messages/templates/anon_proxy/lime-deep-link-access-code.en.sms.liquid
@@ -1,0 +1,1 @@
+Press this link to access your Lime account through suma: {{ value }}

--- a/data/messages/templates/anon_proxy/lime-deep-link-access-code.es.sms.liquid
+++ b/data/messages/templates/anon_proxy/lime-deep-link-access-code.es.sms.liquid
@@ -1,0 +1,1 @@
+Presione este enlace para acceder a su cuenta Lime a través de suma: {{ value }}

--- a/lib/suma/anon_proxy/message_handler/lime.rb
+++ b/lib/suma/anon_proxy/message_handler/lime.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "suma/messages/single_value"
+
 class Suma::AnonProxy::MessageHandler::Lime < Suma::AnonProxy::MessageHandler
   def key = "lime"
 
@@ -30,7 +32,14 @@ class Suma::AnonProxy::MessageHandler::Lime < Suma::AnonProxy::MessageHandler
     if link_md.nil?
       raise "Could not find a magic link in the message content: #{vendor_account_message.message_content}"
     end
-    vendor_account_message.vendor_account.replace_access_code(token, link_md[1]).save_changes
+    magic_link = link_md[1]
+    vendor_account_message.vendor_account.replace_access_code(token, magic_link).save_changes
+    msg = Suma::Messages::SingleValue.new(
+      "anon_proxy",
+      "lime-deep-link-access-code",
+      magic_link,
+    )
+    vendor_account_message.vendor_account.member.message_preferences!.dispatch(msg)
     result.handled = true
     return result
   end

--- a/lib/suma/message/preferences.rb
+++ b/lib/suma/message/preferences.rb
@@ -19,6 +19,7 @@ class Suma::Message::Preferences < Suma::Postgres::Model(:message_preferences)
   def sms_enabled? = self.sms_enabled
   def email_enabled? = self.email_enabled
 
+  # @param [Suma::Message::Template] message
   def dispatch(message)
     message.language = self.preferred_language
     to = self.member

--- a/lib/suma/messages/single_value.rb
+++ b/lib/suma/messages/single_value.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "suma/message/template"
+
+class Suma::Messages::SingleValue < Suma::Message::Template
+  def self.fixtured(recipient)
+    msg = self.new(
+      "anon_proxy",
+      "lime-deep-link-access-code",
+      "https://mysuma.org/some-lime-link-#{recipient.id}",
+    )
+    msg.language = ["es", "en"].sample
+    return msg
+  end
+
+  def initialize(folder, template, value)
+    @folder = folder
+    @template = template
+    @value = value
+    super()
+  end
+
+  def localized? = true
+
+  def template_folder = @folder
+  def template_name = @template
+
+  def liquid_drops
+    return super.merge(
+      value: @value,
+    )
+  end
+end

--- a/spec/suma/anon_proxy/message_handler_spec.rb
+++ b/spec/suma/anon_proxy/message_handler_spec.rb
@@ -126,6 +126,11 @@ RSpec.describe Suma::AnonProxy::MessageHandler, :db do
           "https://limebike.app.link/email_verification?authentication_code=hXYamQ1JGVifc6xuMv6qUrLZ",
         latest_access_code_set_at: match_time(:now),
       )
+      expect(vendor_account.contact.member.message_deliveries.last).to have_attributes(
+        template: "anon_proxy/lime-deep-link-access-code",
+        transport_type: "sms",
+        transport_service: "signalwire",
+      )
     end
 
     it "noops if we do not recognize the message" do

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -333,6 +333,7 @@
     "polling": "Working...",
     "polling_detail": "This can take up to a minute.",
     "recent_messages_from_vendor": "Recent Messages from {{vendorName}}",
+    "success": "Please follow the instructions that has been sent to your phone in order to launch this app.",
     "vendor_private_accounts": "{{vendorName}} Private Accounts"
   },
   "titles": {

--- a/webapp/public/locale/es/strings.json
+++ b/webapp/public/locale/es/strings.json
@@ -332,6 +332,7 @@
     "polling": "Procesando...",
     "polling_detail": "Esto puede tardar hasta un minuto.",
     "recent_messages_from_vendor": "Mensajes recientes de {{vendorName}}",
+    "success": "Siga las instrucciones que se enviaron a su teléfono para iniciar esta aplicación.",
     "vendor_private_accounts": "Cuentas Privadas de {{vendorName}}"
   },
   "titles": {

--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import loaderRing from "../assets/images/loader-ring.svg";
+import AnimatedCheckmark from "../components/AnimatedCheckmark";
 import ErrorScreen from "../components/ErrorScreen";
 import FormError from "../components/FormError";
 import LayoutContainer from "../components/LayoutContainer";
@@ -93,7 +94,7 @@ export default function PrivateAccountsList() {
         <LayoutContainer gutters>
           <Stack gap={3}>
             {accounts.items.map((a) => (
-              <Card key={a.id} className="pb-3">
+              <Card key={a.id}>
                 <Card.Body>
                   <PrivateAccount account={a} onHelp={() => handleHelp(a)} />
                 </Card.Body>
@@ -127,8 +128,7 @@ function PrivateAccount({ account, onHelp }) {
           .then((r) => {
             if (r.data.foundChange) {
               // Turn this off before navigating in case promise callbacks don't run.
-              window.setTimeout(() => setButtonStatus(INITIAL), 100);
-              window.location.href = r.data.vendorAccount.magicLink;
+              window.setTimeout(() => setButtonStatus(SUCCESS), 100);
             } else {
               pollAndReplace();
             }
@@ -172,31 +172,42 @@ function PrivateAccount({ account, onHelp }) {
   }
 
   let content;
-  if (buttonStatus === INITIAL) {
+  if (buttonStatus === "a") {
     content = (
-      <Stack direction="horizontal" gap={2} className="mt-3 justify-content-center">
+      <Stack direction="horizontal" gap={2} className="justify-content-center mb-1">
         <Button onClick={handleInitialClick}>{t("private_accounts:initial")}</Button>
         <Button variant="outline-primary" onClick={() => onHelp()}>
           {t("common:help")}
         </Button>
       </Stack>
     );
+  } else if (buttonStatus === "b") {
+    content = (
+      <Alert variant="info" className="w-100 mb-0">
+        <Stack direction="horizontal" gap={3}>
+          <div className="me-auto">
+            <h5>{t("private_accounts:polling")}</h5>
+            <p>{t("private_accounts:polling_detail")}</p>
+          </div>
+          <img
+            src={loaderRing}
+            width="80"
+            height="80"
+            alt={t("private_accounts:polling")}
+          />
+        </Stack>
+      </Alert>
+    );
   } else {
     content = (
-      <Stack direction="vertical" className="mt-3">
-        <Alert variant="info">
-          <p className="lead mb-0">
-            {t("private_accounts:polling")}
-            <img
-              src={loaderRing}
-              width="80"
-              height="80"
-              alt={t("private_accounts:polling")}
-            />
-          </p>
-          <p>{t("private_accounts:polling_detail")}</p>
-        </Alert>
-      </Stack>
+      <Alert variant="success" className="mb-0">
+        <Stack direction="horizontal" gap={3}>
+          {t("private_accounts:success")}
+          <div className="ms-auto">
+            <AnimatedCheckmark />
+          </div>
+        </Stack>
+      </Alert>
     );
   }
   return (
@@ -205,6 +216,7 @@ function PrivateAccount({ account, onHelp }) {
         image={vendorImage}
         height={80}
         params={{ crop: "none", fmt: "png", flatten: [255, 255, 255] }}
+        className="mb-3"
       />
       {content}
       <FormError error={error} className="mt-3" />
@@ -214,3 +226,4 @@ function PrivateAccount({ account, onHelp }) {
 
 const INITIAL = 1;
 const POLLING = 2;
+const SUCCESS = 3;

--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -172,7 +172,7 @@ function PrivateAccount({ account, onHelp }) {
   }
 
   let content;
-  if (buttonStatus === "a") {
+  if (buttonStatus === INITIAL) {
     content = (
       <Stack direction="horizontal" gap={2} className="justify-content-center mb-1">
         <Button onClick={handleInitialClick}>{t("private_accounts:initial")}</Button>
@@ -181,7 +181,7 @@ function PrivateAccount({ account, onHelp }) {
         </Button>
       </Stack>
     );
-  } else if (buttonStatus === "b") {
+  } else if (buttonStatus === POLLING) {
     content = (
       <Alert variant="info" className="w-100 mb-0">
         <Stack direction="horizontal" gap={3}>


### PR DESCRIPTION
Show the link in the UI does not reliably launch the Lime app (it may work for other apps- we have confirmed this is a bug on the Lime side, with how it redirects/deep links). So send an SMS instead, which uses a different URL handling which seems to work more reliably.