### PR TITLE
Improve one time password

### DIFF
--- a/webapp/src/pages/OneTimePassword.jsx
+++ b/webapp/src/pages/OneTimePassword.jsx
@@ -37,9 +37,18 @@ const OneTimePassword = () => {
       submitRef.current.disabled = true;
       return setOtpChars([...otpChars.map((num, idx) => (idx === index ? "" : num))]);
     }
+
+    // IOS keyboard paste does not call the onPaste event, instead it calls onChange.
+    // when the value equals the OTP length, we set it
+    if (value.length === OTP_LENGTH) {
+      setOtpChars(value.split(""));
+      submitRef.current.disabled = false;
+      submitRef.current.focus();
+      return;
+    }
+
     const newOtp = [...otpChars.map((num, idx) => (idx === index ? value : num))];
     setOtpChars(newOtp);
-
     submitRef.current.disabled = !otpValid(newOtp);
 
     if (target.nextSibling) {

--- a/webapp/src/pages/OneTimePassword.jsx
+++ b/webapp/src/pages/OneTimePassword.jsx
@@ -64,7 +64,6 @@ const OneTimePassword = () => {
   };
 
   const handleOtpPaste = (event) => {
-    event.preventDefault();
     if (!event?.clipboardData) {
       return;
     }

--- a/webapp/src/pages/OneTimePassword.jsx
+++ b/webapp/src/pages/OneTimePassword.jsx
@@ -45,6 +45,9 @@ const OneTimePassword = () => {
       submitRef.current.disabled = false;
       submitRef.current.focus();
       return;
+    } else if (value.length !== 1) {
+      // handle maxLength of 1 here, it allows onChange to capture 6 digits when IOS keyboard pasting
+      return;
     }
 
     const newOtp = [...otpChars.map((num, idx) => (idx === index ? value : num))];
@@ -148,7 +151,7 @@ const OneTimePassword = () => {
                 className="otp-field mb-2 p-1"
                 type="text"
                 name="otp"
-                maxLength="1"
+                maxLength="6"
                 inputMode="numeric"
                 key={index}
                 value={data}

--- a/webapp/src/pages/OneTimePassword.jsx
+++ b/webapp/src/pages/OneTimePassword.jsx
@@ -52,6 +52,7 @@ const OneTimePassword = () => {
   };
 
   const handleOtpPaste = (event) => {
+    event.preventDefault();
     if (!event?.clipboardData) {
       return;
     }


### PR DESCRIPTION
Fixes #592 

Pasting code from IOS devices Keyboard pasting did not trigger the `paste` event, instead, it triggers the `onChange` event. Solution is to handle pasting through onChange similar to the `handleOtpPaste` function. Follow changes happened due to this solution:
- Since we have to handle 6 pasted characters in each of the 6 inputs, we set the `maxLength` property to 6
- Multiple characters are allowed, so we check that there are no non-digit characters, otherwise we return
- Replaced `onChange` event to `onInput` to allow immediate after the value of an element has changed; [ref](https://www.w3schools.com/jsref/event_onchange.asp#:~:text=The%20onchange%20event%20occurs%20when,the%20content%20has%20been%20changed.)
- handle when an input selection carat is to the left by fetching the 0 index of the value, otherwise fetch the last index of value

Handle character deletion
- Set condition to catch when "Backspace" and "Delete" keys are triggered
- Remove current value and focus the previous input element