### PR TITLE
Admin form fixes

### DIFF
--- a/adminapp/package-lock.json
+++ b/adminapp/package-lock.json
@@ -22,7 +22,6 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
         "axios": "^1.2.3",
-        "bluebird": "^3.7.2",
         "clsx": "^1.2.1",
         "dayjs": "^1.11.7",
         "humps": "git+https://github.com/lithictech/humps.git#fb9844c8d37cea67ee9c592e2685aee68d05015f",
@@ -4532,11 +4531,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.3.tgz",
-      "integrity": "sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -4724,11 +4723,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -6070,9 +6064,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -12276,11 +12270,11 @@
       "dev": true
     },
     "axios": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.3.tgz",
-      "integrity": "sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -12443,11 +12437,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -13462,9 +13451,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "form-data": {
       "version": "4.0.0",

--- a/adminapp/package.json
+++ b/adminapp/package.json
@@ -17,7 +17,6 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
     "axios": "^1.2.3",
-    "bluebird": "^3.7.2",
     "clsx": "^1.2.1",
     "dayjs": "^1.11.7",
     "humps": "git+https://github.com/lithictech/humps.git#fb9844c8d37cea67ee9c592e2685aee68d05015f",

--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -38,7 +38,7 @@ import VendorDetailPage from "./pages/VendorDetailPage";
 import VendorEditPage from "./pages/VendorEditPage";
 import VendorListPage from "./pages/VendorListPage";
 import applyHocs from "./shared/applyHocs";
-import bluejay from "./shared/bluejay";
+import { installPromiseExtras } from "./shared/bluejay";
 import ClientsideSearchParamsProvider from "./shared/react/ClientsideSearchParamsProvider";
 import Redirect from "./shared/react/Redirect";
 import renderComponent from "./shared/react/renderComponent";
@@ -51,7 +51,7 @@ import { SnackbarProvider } from "notistack";
 import React from "react";
 import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
 
-window.Promise = bluejay.Promise;
+installPromiseExtras(window.Promise);
 
 export default function App() {
   return (

--- a/adminapp/src/components/ResourceForm.jsx
+++ b/adminapp/src/components/ResourceForm.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import useBusy from "../hooks/useBusy";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
-import merge from "lodash/merge";
+import assign from "lodash/assign";
 import set from "lodash/set";
 import React from "react";
 import { useForm } from "react-hook-form";
@@ -26,7 +26,7 @@ export default function ResourceForm({ InnerForm, baseResource, isCreate, applyC
 
   const setField = React.useCallback(
     (f, v) => {
-      const newChanges = merge({}, changes);
+      const newChanges = assign({}, changes);
       set(newChanges, f, v);
       setChanges(newChanges);
     },
@@ -47,7 +47,7 @@ export default function ResourceForm({ InnerForm, baseResource, isCreate, applyC
   return (
     <InnerForm
       isCreate={isCreate}
-      resource={merge({}, baseResource, changes)}
+      resource={assign({}, baseResource, changes)}
       setFields={setChanges}
       setField={setField}
       setFieldFromInput={setFieldFromInput}

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -275,6 +275,10 @@ function OptionAddress({ address, onFieldChange }) {
       });
   }, []);
 
+  if (!address) {
+    return null;
+  }
+
   function handleChange(e) {
     onFieldChange({ [e.target.name]: e.target.value });
   }

--- a/adminapp/src/shared/bluejay.js
+++ b/adminapp/src/shared/bluejay.js
@@ -1,34 +1,52 @@
-import config from "../config";
-import Promise from "bluebird";
+export function installPromiseExtras(Promise) {
+  Promise.delay = function delay(durationMs, p) {
+    p = p || Promise.resolve();
+    return p.then((r) => {
+      return new Promise((resolve) => {
+        window.setTimeout(() => resolve(r), durationMs);
+      });
+    });
+  };
 
-Promise.delayOr = function delayOr(durationMs, otherPromise, options) {
-  options = options || { buffer: 100 };
-  const started = Date.now();
-  return otherPromise.then((r) => {
-    const waited = Date.now() - started;
-    const stillLeftToWait = durationMs - waited;
-    // If we have a number of milliseconds or less than buffer left to wait,
-    // we can return the original result without delay, because we know we took about durationMs.
-    if (stillLeftToWait <= options.buffer) {
-      return r;
-    }
-    // Otherwise, we should delay until the intended elapsed time has been reached.
-    return Promise.delay(stillLeftToWait, r);
-  });
-};
+  Promise.prototype.delay = function delay(durationMs) {
+    return Promise.delay(durationMs, this);
+  };
 
-Promise.prototype.delayOr = function delayOr(durationMs, options) {
-  return Promise.delayOr(durationMs, this, options);
-};
+  Promise.delayOr = function delayOr(durationMs, otherPromise, options) {
+    options = options || { buffer: 100 };
+    const started = Date.now();
+    return otherPromise.then((r) => {
+      const waited = Date.now() - started;
+      const stillLeftToWait = durationMs - waited;
+      // If we have a number of milliseconds or less than buffer left to wait,
+      // we can return the original result without delay, because we know we took about durationMs.
+      if (stillLeftToWait <= options.buffer) {
+        return r;
+      }
+      // Otherwise, we should delay until the intended elapsed time has been reached.
+      return Promise.delay(stillLeftToWait, r);
+    });
+  };
 
-Promise.prototype.tapTap = function tapTap(f) {
-  return this.tap(f).tapCatch(f);
-};
+  Promise.prototype.delayOr = function delayOr(durationMs, options) {
+    return Promise.delayOr(durationMs, this, options);
+  };
 
-Promise.config({
-  cancellation: true,
-  longStackTraces: config.debug,
-  warnings: config.debug,
-});
+  Promise.prototype.tap = function tap(f) {
+    return this.then((v) => {
+      f(v);
+      return v;
+    });
+  };
 
-export default Promise;
+  Promise.prototype.tapCatch = function tapCatch(f) {
+    return this.catch((r) => {
+      f(r);
+      return Promise.reject(r);
+    });
+  };
+
+  Promise.prototype.tapTap = function tapTap(f) {
+    return this.tap(f).tapCatch(f);
+  };
+}

--- a/lib/suma/admin_api/commerce_offerings.rb
+++ b/lib/suma/admin_api/commerce_offerings.rb
@@ -121,7 +121,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
                  coerce_with: proc { |s| s.values.each_with_index.map { |fo, ordinal| fo.merge(ordinal:) } } do
           requires :type, type: String, values: Suma::Commerce::OfferingFulfillmentOption::TYPES
           requires(:description, type: JSON) { use :translated_text }
-          optional(:address, type: JSON) { use :address }
+          optional(:address, default: nil, type: JSON) { use :address }
         end
         optional :period_begin, type: Time
         optional :period_end, type: Time

--- a/lib/suma/admin_api/commerce_offerings.rb
+++ b/lib/suma/admin_api/commerce_offerings.rb
@@ -126,7 +126,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
         optional :period_begin, type: Time
         optional :period_end, type: Time
         optional :begin_fulfillment_at, type: Time
-        optional :prohibit_charge_at_checkout, type: Boolean, allow_blank: false, default: false
+        optional :prohibit_charge_at_checkout, type: Boolean, allow_blank: false
         optional :max_ordered_items_cumulative, type: Integer
         optional :max_ordered_items_per_member, type: Integer
       end

--- a/lib/suma/admin_api/common_endpoints.rb
+++ b/lib/suma/admin_api/common_endpoints.rb
@@ -24,7 +24,9 @@ module Suma::AdminAPI::CommonEndpoints
         next unless (assoc = mtype.association_reflections[k])
         params.delete(k)
         if assoc[:type].to_s.end_with?("_to_one")
-          if association_class?(assoc, Suma::TranslatedText)
+          if v.nil?
+            fk_attrs[assoc[:name]] = nil
+          elsif association_class?(assoc, Suma::TranslatedText)
             fk_attrs[assoc[:name]] = Suma::TranslatedText.find_or_create(**v)
           elsif association_class?(assoc, Suma::Address)
             fk_attrs[assoc[:name]] = Suma::Address.lookup(v)

--- a/spec/suma/admin_api/commerce_offerings_spec.rb
+++ b/spec/suma/admin_api/commerce_offerings_spec.rb
@@ -231,6 +231,18 @@ RSpec.describe Suma::AdminAPI::CommerceOfferings, :db do
         have_attributes(id: add.id, address: include(address1: "new st")),
       )
     end
+
+    it "errors with a 409 if a foreign key constraint is violated" do
+      offering = Suma::Fixtures.offering.create
+      ful_opt = Suma::Fixtures.offering_fulfillment_option.create(offering:)
+
+      Suma::Fixtures.checkout.create(fulfillment_option: ful_opt)
+
+      post "/v1/commerce_offerings/#{offering.id}", fulfillment_options: {}
+
+      expect(last_response).to have_status(409)
+      expect(last_response).to have_json_body.that_includes(error: include(message: /could not be removed/))
+    end
   end
 
   describe "POST /v1/commerce_offering/:id/eligibilities" do


### PR DESCRIPTION
Admin: fix resource update issues

Use `assign` instead of `merge` so we can remove entries.

Fix bug with `postForm` and empty values.

Fixes https://github.com/lithictech/suma/issues/565

---

Admin: Update axios, remove bluebird

We needed to update axios to pick up form serializer changes.
However this caused a problem with bluebird promises.
So, we removed bluebird, since we hardly use it anyway.
However this did require:

- Implementing some utility functions like `Promise.delay`
  and `tap`/`tapCatch`, and
- Replacing `Promise.cancel()` with
  an adhoc usage of `AbortController`. Promise cancellation
  is really tricky to hookup and not worth it so we won't worry about
  it, we can just use AbortController where needed.

---

Admin api: Fix bug with updates

Handle add/remove/delete of nested resources.

Fixes https://github.com/lithictech/suma/issues/566

Note that I do not believe this will handle some edge cases
around multiple levels of nesting. We can solve them when
we come to it, though.

---

Admin offerings: Remove default param value

Was resulting in 'prohibit charge' being set to 'false'
even if it was not passed explicitly.