### PR TITLE
Remove bluebird and refactor promises usage

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,7 +11,6 @@
         "@sentry/browser": "^7.31.1",
         "@sentry/tracing": "^7.31.1",
         "axios": "^1.2.3",
-        "bluebird": "^3.7.2",
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.3",
         "clsx": "^1.2.1",
@@ -2485,11 +2484,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/bootstrap": {
       "version": "5.2.3",
@@ -8609,11 +8603,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bootstrap": {
       "version": "5.2.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,6 @@
     "@sentry/browser": "^7.31.1",
     "@sentry/tracing": "^7.31.1",
     "axios": "^1.2.3",
-    "bluebird": "^3.7.2",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.3",
     "clsx": "^1.2.1",

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -44,7 +44,7 @@ import Styleguide from "./pages/Styleguide";
 import UnclaimedOrderList from "./pages/UnclaimedOrderList";
 import Utilities from "./pages/Utilities";
 import applyHocs from "./shared/applyHocs";
-import bluejay from "./shared/bluejay";
+import { installPromiseExtras } from "./shared/bluejay";
 import Redirect from "./shared/react/Redirect";
 import renderComponent from "./shared/react/renderComponent";
 import BackendGlobalsProvider from "./state/BackendGlobalsProvider";
@@ -61,7 +61,7 @@ import React from "react";
 import { HelmetProvider } from "react-helmet-async";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
-window.Promise = bluejay.Promise;
+installPromiseExtras(window.Promise);
 
 export default function App() {
   return (

--- a/webapp/src/shared/bluejay.js
+++ b/webapp/src/shared/bluejay.js
@@ -1,34 +1,52 @@
-import config from "../config";
-import Promise from "bluebird";
+export function installPromiseExtras(Promise) {
+  Promise.delay = function delay(durationMs, p) {
+    p = p || Promise.resolve();
+    return p.then((r) => {
+      return new Promise((resolve) => {
+        window.setTimeout(() => resolve(r), durationMs);
+      });
+    });
+  };
 
-Promise.delayOr = function delayOr(durationMs, otherPromise, options) {
-  options = options || { buffer: 100 };
-  const started = Date.now();
-  return otherPromise.then((r) => {
-    const waited = Date.now() - started;
-    const stillLeftToWait = durationMs - waited;
-    // If we have a number of milliseconds or less than buffer left to wait,
-    // we can return the original result without delay, because we know we took about durationMs.
-    if (stillLeftToWait <= options.buffer) {
-      return r;
-    }
-    // Otherwise, we should delay until the intended elapsed time has been reached.
-    return Promise.delay(stillLeftToWait, r);
-  });
-};
+  Promise.prototype.delay = function delay(durationMs) {
+    return Promise.delay(durationMs, this);
+  };
 
-Promise.prototype.delayOr = function delayOr(durationMs, options) {
-  return Promise.delayOr(durationMs, this, options);
-};
+  Promise.delayOr = function delayOr(durationMs, otherPromise, options) {
+    options = options || { buffer: 100 };
+    const started = Date.now();
+    return otherPromise.then((r) => {
+      const waited = Date.now() - started;
+      const stillLeftToWait = durationMs - waited;
+      // If we have a number of milliseconds or less than buffer left to wait,
+      // we can return the original result without delay, because we know we took about durationMs.
+      if (stillLeftToWait <= options.buffer) {
+        return r;
+      }
+      // Otherwise, we should delay until the intended elapsed time has been reached.
+      return Promise.delay(stillLeftToWait, r);
+    });
+  };
 
-Promise.prototype.tapTap = function tapTap(f) {
-  return this.tap(f).tapCatch(f);
-};
+  Promise.prototype.delayOr = function delayOr(durationMs, options) {
+    return Promise.delayOr(durationMs, this, options);
+  };
 
-Promise.config({
-  cancellation: true,
-  longStackTraces: config.debug,
-  warnings: config.debug,
-});
+  Promise.prototype.tap = function tap(f) {
+    return this.then((v) => {
+      f(v);
+      return v;
+    });
+  };
 
-export default Promise;
+  Promise.prototype.tapCatch = function tapCatch(f) {
+    return this.catch((r) => {
+      f(r);
+      return Promise.reject(r);
+    });
+  };
+
+  Promise.prototype.tapTap = function tapTap(f) {
+    return this.tap(f).tapCatch(f);
+  };
+}


### PR DESCRIPTION
Fixes #302

- Remove the `bluebird` package from the webapp
- Refactor the `.cancel()` promise dependency with `AbortController` (since removing bluebird caused issues)
- Add/update the `bluejay` file shared between both front-end apps and use it at the apps top level