### PR TITLE
Replace 'launch app' with 'link app'

### DIFF
--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -346,6 +346,7 @@
     "create_account": "Create account",
     "initial": "Launch app",
     "intro": "Used to hide your email and phone number from vendors you use through the Suma platform. Follow the instructions for the vendors you want to create a Private Account with.",
+    "link_app": "Link App",
     "no_private_accounts": "It looks like no vendors are set up for Private Accounts. Contact your administrator for more information.",
     "polling": "Working...",
     "polling_detail": "This can take up to a minute.",

--- a/webapp/public/locale/es/strings.json
+++ b/webapp/public/locale/es/strings.json
@@ -346,6 +346,7 @@
     "create_account": "Crear una cuenta",
     "initial": "Iniciar aplicación",
     "intro": "Se utiliza para ocultar su correo electrónico y número de teléfono de los proveedores que utiliza a través de la plataforma suma. Siga las instrucciones de los proveedores con los que desea crear una cuenta privada.",
+    "link_app": "Vincular App",
     "no_private_accounts": "Parece que no hay proveedores configurados para cuentas privadas. Póngase en contacto con su administrador para obtener más información.",
     "polling": "Procesando...",
     "polling_detail": "Esto puede tardar hasta un minuto.",

--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -81,7 +81,7 @@ export default function PrivateAccountsList() {
             <ScrollTopOnMount />
             <SumaMarkdown>{modalAccount?.instructions}</SumaMarkdown>
             <div className="d-flex justify-content-end mt-2">
-              <Button variant="outline-primary" onClick={() => setModalAccount(null)}>
+              <Button variant="outline-secondary" onClick={() => setModalAccount(null)}>
                 {t("common:close")}
               </Button>
             </div>
@@ -178,7 +178,7 @@ function PrivateAccount({ account, onHelp }) {
   if (buttonStatus === INITIAL) {
     content = (
       <Stack direction="horizontal" gap={2} className="justify-content-center mb-1">
-        <Button onClick={handleInitialClick}>{t("private_accounts:initial")}</Button>
+        <Button onClick={handleInitialClick}>{t("private_accounts:link_app")}</Button>
         <Button variant="outline-primary" onClick={() => onHelp()}>
           {t("common:help")}
         </Button>


### PR DESCRIPTION
Fixes #602 

We no longer launch 3rd-party apps automatically through the browser, we resorted to SMS link launch, so the context "Launch App" is not correct anymore, "Link app" sounds more accurate.
- Translate (we use Spanish word "vincular" to mean "link" in many areas, so this translations seems accurate)

### Private Account page - button context refactor (EN)
![Screenshot 2024-02-27 at 5 15 41 PM](https://github.com/lithictech/suma/assets/66847768/6754f710-1c9c-4dff-bf8a-31c8d4f66b7f)

### Private Account page - button context refactor (ES)
![Screenshot 2024-02-27 at 5 15 50 PM](https://github.com/lithictech/suma/assets/66847768/0881d62c-c454-4321-aca3-8a8510bc6a12)
