### PR TITLE
Add ability to update member using new methods

### DIFF
--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -13,6 +13,7 @@ import FundingTransactionCreatePage from "./pages/FundingTransactionCreatePage";
 import FundingTransactionDetailPage from "./pages/FundingTransactionDetailPage";
 import FundingTransactionListPage from "./pages/FundingTransactionListPage";
 import MemberDetailPage from "./pages/MemberDetailPage";
+import MemberEditPage from "./pages/MemberEditPage";
 import MemberListPage from "./pages/MemberListPage";
 import MessageDetailPage from "./pages/MessageDetailPage";
 import MessageListPage from "./pages/MessageListPage";
@@ -387,6 +388,11 @@ function PageSwitch() {
         exact
         path="/member/:id"
         element={renderWithHocs(redirectIfUnauthed, withLayout(), MemberDetailPage)}
+      />
+      <Route
+        exact
+        path="/member/:id/edit"
+        element={renderWithHocs(redirectIfUnauthed, withLayout(), MemberEditPage)}
       />
       <Route
         exact

--- a/adminapp/src/components/AddressInputs.jsx
+++ b/adminapp/src/components/AddressInputs.jsx
@@ -1,0 +1,143 @@
+import api from "../api";
+import formHelpers from "../modules/formHelpers";
+import useMountEffect from "../shared/react/useMountEffect";
+import useToggle from "../shared/react/useToggle";
+import ResponsiveStack from "./ResponsiveStack";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Icon,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from "@mui/material";
+import isEmpty from "lodash/isEmpty";
+import React from "react";
+
+export default function AddressInputs({
+  address,
+  onFieldChange,
+  onAddressOn,
+  onAddressOff,
+}) {
+  const addingAddress = useToggle(Boolean(address));
+  function handleFieldChange(a) {
+    onFieldChange({ address: { ...address, ...a } });
+  }
+  function handleAddressOn() {
+    addingAddress.turnOn();
+    onAddressOn({ address: formHelpers.initialAddress });
+  }
+  function handleAddressOff() {
+    addingAddress.turnOff();
+    onAddressOff({ address: null });
+  }
+  return (
+    <Stack spacing={2}>
+      {addingAddress.isOff ? (
+        <Button onClick={handleAddressOn}>
+          <AddIcon /> Add Address
+        </Button>
+      ) : (
+        <>
+          <AddressFields address={address} onFieldChange={(a) => handleFieldChange(a)} />
+          <Button onClick={handleAddressOff} variant="warning">
+            <Icon color="warning">
+              <DeleteIcon />
+            </Icon>
+            Remove Address
+          </Button>
+        </>
+      )}
+    </Stack>
+  );
+}
+
+function AddressFields({ address, onFieldChange }) {
+  const [supportedGeographies, setSupportedGeographies] = React.useState({});
+
+  useMountEffect(() => {
+    api
+      .getSupportedGeographies()
+      .then(api.pickData)
+      .then((data) => {
+        setSupportedGeographies(data);
+      });
+  }, []);
+
+  if (!address) {
+    return null;
+  }
+  function handleChange(e) {
+    onFieldChange({ [e.target.name]: e.target.value });
+  }
+  return (
+    <Stack spacing={2}>
+      <FormLabel>Address</FormLabel>
+      <ResponsiveStack>
+        <TextField
+          value={address.address1}
+          name="address1"
+          size="small"
+          label="Street Address"
+          variant="outlined"
+          onChange={handleChange}
+          fullWidth
+          required
+        />
+        <TextField
+          name="address2"
+          value={address.address2}
+          size="small"
+          label="Unit or Apartment Number"
+          variant="outlined"
+          onChange={handleChange}
+          fullWidth
+        />
+      </ResponsiveStack>
+      <ResponsiveStack>
+        <TextField
+          name="city"
+          value={address.city}
+          size="small"
+          label="City"
+          variant="outlined"
+          onChange={handleChange}
+          required
+        />
+        <FormControl size="small" sx={{ width: { xs: "100%", sm: "50%" } }} required>
+          <InputLabel>State</InputLabel>
+          <Select
+            label="State"
+            name="stateOrProvince"
+            value={
+              !isEmpty(supportedGeographies?.provinces) ? address.stateOrProvince : ""
+            }
+            onChange={handleChange}
+          >
+            <MenuItem disabled>Choose state</MenuItem>
+            {supportedGeographies?.provinces?.map((st) => (
+              <MenuItem key={st.value} value={st.value}>
+                {st.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          name="postalCode"
+          value={address.postalCode}
+          size="small"
+          label="Zip code"
+          variant="outlined"
+          onChange={handleChange}
+          required
+        />
+      </ResponsiveStack>
+    </Stack>
+  );
+}

--- a/adminapp/src/components/AddressInputs.jsx
+++ b/adminapp/src/components/AddressInputs.jsx
@@ -1,7 +1,6 @@
 import api from "../api";
 import formHelpers from "../modules/formHelpers";
 import useMountEffect from "../shared/react/useMountEffect";
-import useToggle from "../shared/react/useToggle";
 import ResponsiveStack from "./ResponsiveStack";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -19,27 +18,19 @@ import {
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 
-export default function AddressInputs({
-  address,
-  onFieldChange,
-  onAddressOn,
-  onAddressOff,
-}) {
-  const addingAddress = useToggle(Boolean(address));
+export default function AddressInputs({ address, onFieldChange }) {
   function handleFieldChange(a) {
     onFieldChange({ address: { ...address, ...a } });
   }
   function handleAddressOn() {
-    addingAddress.turnOn();
-    onAddressOn({ address: formHelpers.initialAddress });
+    onFieldChange({ address: formHelpers.initialAddress });
   }
   function handleAddressOff() {
-    addingAddress.turnOff();
-    onAddressOff({ address: null });
+    onFieldChange({ address: null });
   }
   return (
     <Stack spacing={2}>
-      {addingAddress.isOff ? (
+      {isEmpty(address) ? (
         <Button onClick={handleAddressOn}>
           <AddIcon /> Add Address
         </Button>

--- a/adminapp/src/components/ResourceDetail.jsx
+++ b/adminapp/src/components/ResourceDetail.jsx
@@ -32,7 +32,7 @@ export default function ResourceDetail({ apiGet, title, properties, toEdit, chil
         <div>
           <DetailGrid
             title={<Title toEdit={toEdit && toEdit(state)}>{title(state)}</Title>}
-            properties={properties(state)}
+            properties={properties(state, replaceState)}
           />
           {children && children(state, replaceState)}
         </div>

--- a/adminapp/src/components/ResourceForm.jsx
+++ b/adminapp/src/components/ResourceForm.jsx
@@ -1,7 +1,10 @@
 import api from "../api";
 import useBusy from "../hooks/useBusy";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
+import { isNil, mergeWith } from "lodash";
 import assign from "lodash/assign";
+import isArray from "lodash/isArray";
+import { isObject } from "lodash/lang";
 import merge from "lodash/merge";
 import set from "lodash/set";
 import React from "react";
@@ -45,10 +48,22 @@ export default function ResourceForm({ InnerForm, baseResource, isCreate, applyC
     [setField]
   );
 
+  const resource = mergeWith({}, baseResource, changes, (obj, src) => {
+    // Since `_.merge()` only merges array indexes and does not replace arrays,
+    // we need to check for empty arrays and return them, also return src when
+    // it's an image or not an object (like a string).
+    // This allows nested resources and sub-nested resources to be removed/set
+    const isEmptyArray = isArray(src) && !isNil(src);
+    if (!isObject(src) || isEmptyArray || src instanceof File) {
+      return src;
+    }
+    // Otherwise, return default object and src merge
+    return merge({}, obj, src);
+  });
   return (
     <InnerForm
       isCreate={isCreate}
-      resource={merge({}, baseResource, changes)}
+      resource={resource}
       setFields={setChanges}
       setField={setField}
       setFieldFromInput={setFieldFromInput}

--- a/adminapp/src/modules/formHelpers.js
+++ b/adminapp/src/modules/formHelpers.js
@@ -2,7 +2,7 @@ const initialTranslation = { en: "", es: "" };
 
 const initialFulfillmentOption = { type: "pickup", description: initialTranslation };
 
-const initialFulfillmentAddress = {
+const initialAddress = {
   address1: "",
   address2: "",
   city: "",
@@ -13,7 +13,7 @@ const initialFulfillmentAddress = {
 const formHelpers = {
   initialTranslation,
   initialFulfillmentOption,
-  initialFulfillmentAddress,
+  initialAddress,
 };
 
 export default formHelpers;

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -86,7 +86,7 @@ export default function MemberDetailPage() {
           {
             label: "Roles",
             children: model.roles.map((role) => (
-              <Chip key={role} label={capitalize(role.name)} sx={{ mr: 0.5 }} />
+              <Chip key={role.id} label={capitalize(role.name)} sx={{ mr: 0.5 }} />
             )),
             hideEmpty: true,
           },

--- a/adminapp/src/pages/MemberEditPage.jsx
+++ b/adminapp/src/pages/MemberEditPage.jsx
@@ -1,0 +1,10 @@
+import api from "../api";
+import ResourceEdit from "../components/ResourceEdit";
+import MemberForm from "./MemberForm";
+import React from "react";
+
+export default function MemberEditPage() {
+  return (
+    <ResourceEdit apiGet={api.getMember} apiUpdate={api.updateMember} Form={MemberForm} />
+  );
+}

--- a/adminapp/src/pages/MemberForm.jsx
+++ b/adminapp/src/pages/MemberForm.jsx
@@ -1,0 +1,134 @@
+import AddressInputs from "../components/AddressInputs";
+import FormLayout from "../components/FormLayout";
+import ResponsiveStack from "../components/ResponsiveStack";
+import theme from "../theme";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import {
+  Box,
+  Chip,
+  FormHelperText,
+  FormLabel,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import isEmpty from "lodash/isEmpty";
+import merge from "lodash/merge";
+import React from "react";
+
+export default function MemberForm({
+  resource,
+  setField,
+  setFieldFromInput,
+  register,
+  isBusy,
+  onSubmit,
+}) {
+  return (
+    <FormLayout
+      title={"Update Member"}
+      subtitle="Edit member account information"
+      onSubmit={onSubmit}
+      isBusy={isBusy}
+    >
+      <Stack spacing={2}>
+        <ResponsiveStack>
+          <TextField
+            {...register("name")}
+            label="Name"
+            name="name"
+            value={resource.name || ""}
+            type="text"
+            variant="outlined"
+            fullWidth
+            onChange={setFieldFromInput}
+          />
+          <TextField
+            {...register("email")}
+            label="Email"
+            name="email"
+            value={resource.email || ""}
+            type="text"
+            variant="outlined"
+            fullWidth
+            onChange={setFieldFromInput}
+          />
+        </ResponsiveStack>
+        <Roles
+          roles={resource.roles}
+          availableRoles={resource.availableRoles}
+          setRoles={(r) => setField("roles", r)}
+        />
+        <AddressInputs
+          address={resource.legalEntity.address}
+          onFieldChange={(addressObj) =>
+            setField("legalEntity", merge(resource.legalEntity, addressObj))
+          }
+          onAddressOn={(emptyAddressObj) =>
+            setField("legalEntity", merge(resource.legalEntity, emptyAddressObj))
+          }
+          onAddressOff={(nullAddressObj) =>
+            setField("legalEntity", merge(resource.legalEntity, nullAddressObj))
+          }
+        />
+      </Stack>
+    </FormLayout>
+  );
+}
+
+function Roles({ roles, availableRoles, setRoles }) {
+  const [updatedRoles, setUpdatedRoles] = React.useState(roles);
+
+  function deleteRole(id) {
+    const newRoles = updatedRoles.filter((c) => c.id !== id);
+    setUpdatedRoles(newRoles);
+    setRoles(newRoles);
+  }
+
+  function handleAdd(newRole) {
+    const newRoles = [...roles, newRole];
+    setUpdatedRoles(newRoles);
+    setRoles(newRoles);
+  }
+
+  const exisitingRoleIds = roles.map((c) => c.id);
+  availableRoles = availableRoles.filter((c) => !exisitingRoleIds.includes(c.id));
+
+  const noRoles = isEmpty(roles) && isEmpty(availableRoles);
+  return (
+    <Box>
+      <FormLabel>Roles</FormLabel>
+      <FormHelperText>
+        If you remove special roles like "admin", you will be logged out of this account.
+      </FormHelperText>
+      <Stack direction="row" spacing={1} sx={{ mt: theme.spacing(1) }}>
+        {updatedRoles.map(({ id, name }) => (
+          <Chip
+            key={id}
+            label={name}
+            color="success"
+            title="Delete Role"
+            onClick={() => deleteRole(id)}
+            onDelete={() => deleteRole(id)}
+          />
+        ))}
+        {!isEmpty(availableRoles) &&
+          availableRoles.map((role) => (
+            <Chip
+              key={role.id}
+              label={role.name}
+              deleteIcon={<AddCircleOutlineIcon />}
+              title="Add Role"
+              onClick={() => handleAdd(role)}
+              onDelete={() => handleAdd(role)}
+            />
+          ))}
+        {noRoles && (
+          <Typography>
+            * No roles available, ask developers for help if you see this
+          </Typography>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/adminapp/src/pages/MemberForm.jsx
+++ b/adminapp/src/pages/MemberForm.jsx
@@ -64,12 +64,6 @@ export default function MemberForm({
           onFieldChange={(addressObj) =>
             setField("legalEntity", merge(resource.legalEntity, addressObj))
           }
-          onAddressOn={(emptyAddressObj) =>
-            setField("legalEntity", merge(resource.legalEntity, emptyAddressObj))
-          }
-          onAddressOff={(nullAddressObj) =>
-            setField("legalEntity", merge(resource.legalEntity, nullAddressObj))
-          }
         />
       </Stack>
     </FormLayout>
@@ -77,17 +71,13 @@ export default function MemberForm({
 }
 
 function Roles({ roles, availableRoles, setRoles }) {
-  const [updatedRoles, setUpdatedRoles] = React.useState(roles);
-
   function deleteRole(id) {
-    const newRoles = updatedRoles.filter((c) => c.id !== id);
-    setUpdatedRoles(newRoles);
+    const newRoles = roles.filter((c) => c.id !== id);
     setRoles(newRoles);
   }
 
   function handleAdd(newRole) {
     const newRoles = [...roles, newRole];
-    setUpdatedRoles(newRoles);
     setRoles(newRoles);
   }
 
@@ -102,7 +92,7 @@ function Roles({ roles, availableRoles, setRoles }) {
         If you remove special roles like "admin", you will be logged out of this account.
       </FormHelperText>
       <Stack direction="row" spacing={1} sx={{ mt: theme.spacing(1) }}>
-        {updatedRoles.map(({ id, name }) => (
+        {roles.map(({ id, name }) => (
           <Chip
             key={id}
             label={name}

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -219,8 +219,6 @@ function FulfillmentOption({ index, type, description, address, onChange, onRemo
         <AddressInputs
           address={address}
           onFieldChange={(addressObj) => onChange(addressObj)}
-          onAddressOn={(emptyAddressObj) => onChange(emptyAddressObj)}
-          onAddressOff={(nullAddressObj) => onChange(nullAddressObj)}
         />
       </Stack>
     </Box>

--- a/adminapp/src/shared/sentry.js
+++ b/adminapp/src/shared/sentry.js
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/browser";
-import { BrowserTracing } from "@sentry/tracing";
 
 /**
  * Call cb(Sentry), and console log if there is any sort of error.
@@ -41,7 +40,7 @@ export function initSentry({
     environment,
     allowUrls,
     sampleRate: 1.0,
-    integrations: [new BrowserTracing()],
+    integrations: [new Sentry.browserTracingIntegration()],
     ...rest,
   });
   if (application) {

--- a/lib/suma/admin_api/common_endpoints.rb
+++ b/lib/suma/admin_api/common_endpoints.rb
@@ -11,38 +11,14 @@ module Suma::AdminAPI::CommonEndpoints
       return mp
     end
 
-    def replace_roles(ids, model)
-      assoc = model.class.association_reflections[:roles]
-      assoc_name = assoc[:name].to_s.split("_").join(" ")
-
-      ids.each do |id|
-        association_class(assoc)[id] or adminerror!(403, "Unknown #{assoc_name.singularize}: #{id}")
-      end
-      to_remove = model.roles_dataset.exclude(id: ids)
-      to_add = association_class(assoc).where(id: ids).exclude(id: model.roles_dataset.select(:id))
-      to_add.each { |c| model.send(assoc[:add_method], c) }
-      to_remove.each { |c| model.send(assoc[:remove_method], c) }
-      summary = model.roles_dataset.select_map(:name).join(", ")
-
-      admin_member.add_activity(
-        message_name: "#{assoc_name.singularize.delete(' ')}change",
-        summary: "Admin #{admin_member.email} modified #{assoc_name} of #{model.class}[#{model.id}]: #{summary}",
-        subject_type: model.class.name,
-        subject_id: model.id,
-      )
-    end
-
-    def update_model(m, orig_params, process_params: nil, save: true)
+    def update_model(m, orig_params, save: true)
       params = orig_params.deep_symbolize_keys
       params.delete(:id)
-      process_params&.call(params)
       mtype = m.class
       images = []
       to_many_assocs_and_args = []
       to_one_assocs_and_params = []
       fk_attrs = {}
-      # handle roles separately
-      roles = params.delete(:roles)
       params.to_a.each do |(k, v)|
         next unless (assoc = mtype.association_reflections[k])
         params.delete(k)
@@ -53,13 +29,6 @@ module Suma::AdminAPI::CommonEndpoints
             fk_attrs[assoc[:name]] = Suma::TranslatedText.find_or_create(**v)
           elsif association_class?(assoc, Suma::Address)
             fk_attrs[assoc[:name]] = Suma::Address.lookup(v)
-          elsif association_class?(assoc, Suma::LegalEntity)
-            assoc_model = if (assoc_model_id = v[:id])
-                            Suma::LegalEntity[assoc_model_id.to_i]
-            else
-              Suma::LegalEntity.new
-            end
-            update_model(assoc_model, v)
           elsif association_class?(assoc, Suma::Image)
             uf = Suma::UploadedFile.create_from_multipart(v)
             images << Suma::Image.new(uploaded_file: uf)
@@ -76,9 +45,10 @@ module Suma::AdminAPI::CommonEndpoints
       m.set(fk_attrs)
       save_or_error!(m) if save
       images.each { |im| m.add_image(im) }
-      replace_roles(roles.map { |r| r[:id] }, m) unless roles.nil?
       to_one_assocs_and_params.each do |(assoc, mparams)|
-        fk_model = association_class(assoc).find_or_create_or_find(assoc[:key] => m.id)
+        assoc_cls = association_class(assoc)
+        fk_model = assoc_cls.find_or_create_or_find(assoc_cls.primary_key => m.id)
+        mparams.delete(assoc_cls.primary_key)
         update_model(fk_model, mparams)
       end
       to_many_assocs_and_args.each do |(assoc, args)|
@@ -147,18 +117,14 @@ module Suma::AdminAPI::CommonEndpoints
     end
   end
 
-  def self.create(route_def, model_type, entity, process_params: nil, &)
+  def self.create(route_def, model_type, entity, &)
     route_def.instance_exec do
       helpers MutationHelpers
       yield
       post :create do
         model_type.db.transaction do
           m = model_type.new
-          update_model(
-            m,
-            params,
-            process_params:,
-          )
+          update_model(m, params,)
           created_resource_headers(m.id, m.admin_link)
           status 200
           present m, with: entity
@@ -167,7 +133,7 @@ module Suma::AdminAPI::CommonEndpoints
     end
   end
 
-  def self.update(route_def, model_type, entity, process_params: nil, &)
+  def self.update(route_def, model_type, entity, around: nil, &)
     route_def.instance_exec do
       route_param :id, type: Integer do
         helpers MutationHelpers
@@ -175,11 +141,13 @@ module Suma::AdminAPI::CommonEndpoints
         post do
           # model_type.db.transaction do
           (m = model_type[params[:id]]) or forbidden!
-          update_model(
-            m,
-            params,
-            process_params:,
-          )
+          if around
+            around.call(self, m) do
+              update_model(m, params)
+            end
+          else
+            update_model(m, params)
+          end
           created_resource_headers(m.id, m.admin_link)
           status 200
           present m, with: entity

--- a/lib/suma/admin_api/common_endpoints.rb
+++ b/lib/suma/admin_api/common_endpoints.rb
@@ -32,7 +32,7 @@ module Suma::AdminAPI::CommonEndpoints
           elsif association_class?(assoc, Suma::Image)
             uf = Suma::UploadedFile.create_from_multipart(v)
             images << Suma::Image.new(uploaded_file: uf)
-          elsif v.key?(:id)
+          elsif v.key?(:id) && v.one?
             fk_attrs[assoc[:key]] = v[:id]
           else
             to_one_assocs_and_params << [assoc, v]

--- a/lib/suma/admin_api/common_endpoints.rb
+++ b/lib/suma/admin_api/common_endpoints.rb
@@ -33,6 +33,9 @@ module Suma::AdminAPI::CommonEndpoints
             uf = Suma::UploadedFile.create_from_multipart(v)
             images << Suma::Image.new(uploaded_file: uf)
           elsif v.key?(:id) && v.one?
+            # If we're passing in a hash like {id:}, we just want to replace the FK.
+            # If the hash includes more fields, it'll get caught by the else which replaces
+            # and updates the association.
             fk_attrs[assoc[:key]] = v[:id]
           else
             to_one_assocs_and_params << [assoc, v]

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -5,123 +5,8 @@ require "grape"
 require "suma/admin_api"
 
 class Suma::AdminAPI::Members < Suma::AdminAPI::V1
+  include Suma::Service::Types
   include Suma::AdminAPI::Entities
-
-  ALL_TIMEZONES = Set.new(TZInfo::Timezone.all_identifiers)
-
-  resource :members do
-    desc "Return all members, newest first"
-    params do
-      use :pagination
-      use :ordering, model: Suma::Member
-      use :searchable
-      optional :download, type: String, values: ["csv"]
-    end
-    get do
-      ds = Suma::Member.dataset
-      if (email_like = search_param_to_sql(params, :email))
-        name_like = search_param_to_sql(params, :name)
-        phone_like = phone_search_param_to_sql(params)
-        ds = ds.where(email_like | name_like | phone_like)
-      end
-      ds = order(ds, params)
-
-      if params[:download]
-        csv = Suma::Member::Exporter.new(ds).to_csv
-        env["api.format"] = :binary
-        content_type "text/csv"
-        body csv
-        header["Content-Disposition"] = "attachment; filename=suma-members-export.csv"
-      else
-        ds = paginate(ds, params)
-        present_collection ds, with: MemberEntity
-      end
-    end
-
-    route_param :id, type: Integer do
-      helpers do
-        def lookup_member!
-          (member = Suma::Member[params[:id]]) or forbidden!
-          return member
-        end
-      end
-
-      desc "Return the member"
-      get do
-        member = lookup_member!
-        present member, with: DetailedMemberEntity
-      end
-
-      desc "Update the member"
-      params do
-        optional :name, type: String
-        optional :note, type: String
-        optional :email, type: String
-        optional :phone, type: Integer
-        optional :timezone, type: String, values: ALL_TIMEZONES
-        optional :roles, type: Array[String]
-        optional :onboarding_verified, type: Boolean
-      end
-      post do
-        member = lookup_member!
-        fields = params
-        member.db.transaction do
-          if (roles = fields.delete(:roles))
-            member.remove_all_roles
-            roles.uniq.each { |r| member.add_role(Suma::Role[name: r]) }
-          end
-          set_declared(member, params)
-          member.save_changes
-        end
-        status 200
-        present member, with: DetailedMemberEntity
-      end
-
-      post :close do
-        member = lookup_member!
-        admin = admin_member
-        member.db.transaction do
-          member.add_activity(
-            message_name: "accountclosed",
-            summary: "Admin #{admin.email} closed member #{member.email} account",
-            subject_type: "Suma::Member",
-            subject_id: member.id,
-          )
-          member.soft_delete unless member.soft_deleted?
-        end
-        status 200
-        present member, with: DetailedMemberEntity
-      end
-
-      params do
-        requires :values, type: Array[JSON] do
-          requires :constraint_id, type: Integer
-          requires :status, values: ["verified", "pending", "rejected"]
-        end
-      end
-      post :eligibilities do
-        member = lookup_member!
-        admin = admin_member
-        member.db.transaction do
-          summary = []
-          params[:values].each do |h|
-            ec = Suma::Eligibility::Constraint[h[:constraint_id]] or
-              adminerror!(403, "Unknown eligibility constraint: #{h[:constraint_id]}")
-            member.replace_eligibility_constraint(ec, h[:status])
-            summary << "#{ec.name} => #{h[:status]}"
-          end
-          member.add_activity(
-            message_name: "eligibilitychange",
-            summary: "Admin #{admin.email} modified eligibilities of #{member.email}: #{summary.join(', ')}",
-            subject_type: "Suma::Member",
-            subject_id: member.id,
-          )
-        end
-        status 200
-        present member, with: DetailedMemberEntity
-      end
-    end
-  end
 
   class MemberActivityEntity < BaseEntity
     include Suma::AdminAPI::Entities
@@ -185,11 +70,9 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     include AutoExposeDetail
     expose :opaque_id
     expose :note
-    expose :roles do |instance|
-      instance.roles.map(&:name)
-    end
-    expose :available_roles do |_|
-      Suma::Role.order(:name).select_map(:name)
+    expose :roles, with: RoleEntity
+    expose :available_roles, with: RoleEntity do |_|
+      Suma::Role.order(:name).all
     end
     expose :onboarding_verified?, as: :onboarding_verified
     expose :onboarding_verified_at
@@ -209,5 +92,115 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :message_deliveries, with: MessageDeliveryEntity
     expose :preferences!, as: :preferences, with: PreferencesEntity
     expose :anon_proxy_vendor_accounts, as: :vendor_accounts, with: MemberVendorAccountEntity
+  end
+
+  ALL_TIMEZONES = Set.new(TZInfo::Timezone.all_identifiers)
+
+  resource :members do
+    desc "Return all members, newest first"
+    params do
+      use :pagination
+      use :ordering, model: Suma::Member
+      use :searchable
+      optional :download, type: String, values: ["csv"]
+    end
+    get do
+      ds = Suma::Member.dataset
+      if (email_like = search_param_to_sql(params, :email))
+        name_like = search_param_to_sql(params, :name)
+        phone_like = phone_search_param_to_sql(params)
+        ds = ds.where(email_like | name_like | phone_like)
+      end
+      ds = order(ds, params)
+
+      if params[:download]
+        csv = Suma::Member::Exporter.new(ds).to_csv
+        env["api.format"] = :binary
+        content_type "text/csv"
+        body csv
+        header["Content-Disposition"] = "attachment; filename=suma-members-export.csv"
+      else
+        ds = paginate(ds, params)
+        present_collection ds, with: MemberEntity
+      end
+    end
+
+    Suma::AdminAPI::CommonEndpoints.get_one self, Suma::Member, DetailedMemberEntity
+    Suma::AdminAPI::CommonEndpoints.update(
+      self,
+      Suma::Member,
+      DetailedMemberEntity,
+    ) do
+      params do
+        optional :name, type: String
+        optional :note, type: String
+        optional :email, type: String
+        optional :phone, type: Integer
+        optional :timezone, type: String, values: ALL_TIMEZONES
+        optional :roles,
+                 type: Array[JSON] do
+          use :model_with_id
+          requires :name, type: String
+        end
+        optional :onboarding_verified, type: Boolean
+        optional :legal_entity, type: JSON do
+          optional :name, type: String
+          optional(:address, default: nil, type: JSON) { use :address }
+        end
+      end
+    end
+
+    route_param :id, type: Integer do
+      helpers do
+        def lookup_member!
+          (member = Suma::Member[params[:id]]) or forbidden!
+          return member
+        end
+      end
+
+      post :close do
+        member = lookup_member!
+        admin = admin_member
+        member.db.transaction do
+          member.add_activity(
+            message_name: "accountclosed",
+            summary: "Admin #{admin.email} closed member #{member.email} account",
+            subject_type: "Suma::Member",
+            subject_id: member.id,
+          )
+          member.soft_delete unless member.soft_deleted?
+        end
+        status 200
+        present member, with: DetailedMemberEntity
+      end
+
+      params do
+        requires :values, type: Array[JSON] do
+          requires :constraint_id, type: Integer
+          requires :status, values: ["verified", "pending", "rejected"]
+        end
+      end
+      post :eligibilities do
+        member = lookup_member!
+        admin = admin_member
+        member.db.transaction do
+          summary = []
+          params[:values].each do |h|
+            ec = Suma::Eligibility::Constraint[h[:constraint_id]] or
+              adminerror!(403, "Unknown eligibility constraint: #{h[:constraint_id]}")
+            member.replace_eligibility_constraint(ec, h[:status])
+            summary << "#{ec.name} => #{h[:status]}"
+          end
+          member.add_activity(
+            message_name: "eligibilitychange",
+            summary: "Admin #{admin.email} modified eligibilities of #{member.email}: #{summary.join(', ')}",
+            subject_type: "Suma::Member",
+            subject_id: member.id,
+          )
+        end
+        status 200
+        present member, with: DetailedMemberEntity
+      end
+    end
   end
 end

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -130,7 +130,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
       self,
       Suma::Member,
       DetailedMemberEntity,
-      around: ->(rt, m, &block) do
+      around: lambda do |rt, m, &block|
         roles = rt.params.delete(:roles)
         block.call
         if roles
@@ -144,7 +144,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
             subject_id: m.id,
           )
         end
-      end
+      end,
     ) do
       params do
         optional :name, type: String

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -168,6 +168,14 @@ class Suma::Member < Suma::Postgres::Model(:members)
     return self
   end
 
+  def replace_roles(roles)
+    ids = roles.map(&:id)
+    to_remove = self.roles_dataset.exclude(id: ids)
+    to_add = Suma::Role.where(id: ids).exclude(id: self.roles_dataset.select(:id))
+    to_add.each { |c| self.add_role(c) }
+    to_remove.each { |c| self.remove_role(c) }
+  end
+
   def greeting
     return self.name.blank? ? "there" : self.name
   end

--- a/spec/suma/admin_api/commerce_products_spec.rb
+++ b/spec/suma/admin_api/commerce_products_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Suma::AdminAPI::CommerceProducts, :db do
   end
 
   describe "POST /v1/commerce_products/:id" do
-    it "updates the product" do
+    it "updates the product and can create a new inventory" do
       photo_file = File.open("spec/data/images/photo.png", "rb")
       image = Rack::Test::UploadedFile.new(photo_file, "image/png", true)
       product = Suma::Fixtures.product.create
@@ -119,6 +119,16 @@ RSpec.describe Suma::AdminAPI::CommerceProducts, :db do
       expect(last_response).to have_json_body.that_includes(id: product.id)
       expect(product.refresh).to have_attributes(our_cost: cost("$24"))
       expect(product.inventory).to have_attributes(quantity_on_hand: 2)
+    end
+
+    it "updates the product and existing inventory" do
+      product = Suma::Fixtures.product.create
+      product.inventory!.update(quantity_on_hand: 5)
+
+      post "/v1/commerce_products/#{product.id}", inventory: {quantity_on_hand: 201}
+
+      expect(last_response).to have_status(200)
+      expect(product.inventory.refresh).to have_attributes(quantity_on_hand: 201)
     end
   end
 end

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe Suma::AdminAPI::Members, :db do
       member = Suma::Fixtures.member.with_legal_entity(legal_entity).create
 
       post "/v1/members/#{member.id}", legal_entity: {
+        id: legal_entity.id,
         name: "hello",
         address: {
           address1: "main st",

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Suma::AdminAPI::Members, :db do
 
       expect(last_response).to have_status(200)
       expect(member.refresh.roles.map(&:name)).to contain_exactly("existing", "to_add")
-      expect(member.refresh.activities).to contain_exactly(have_attributes(message_name: 'rolechange'))
+      expect(member.refresh.activities).to contain_exactly(have_attributes(message_name: "rolechange"))
     end
 
     it "updates legal entity if given" do

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -168,7 +168,20 @@ RSpec.describe Suma::AdminAPI::Members, :db do
       }
 
       expect(last_response).to have_status(200)
-      expect(member.refresh.legal_entity).to have_attributes(address: have_attributes(address1: "main st"))
+      expect(member.refresh.legal_entity).to have_attributes(
+        id: legal_entity.id, address: have_attributes(address1: "main st"),
+      )
+    end
+
+    it "reassigns legal entity if just an ID is given" do
+      legal_entity1 = Suma::Fixtures.legal_entity.create
+      legal_entity2 = Suma::Fixtures.legal_entity.create
+      member = Suma::Fixtures.member.with_legal_entity(legal_entity1).create
+
+      post "/v1/members/#{member.id}", legal_entity: {id: legal_entity2.id}
+
+      expect(last_response).to have_status(200)
+      expect(member.refresh.legal_entity).to have_attributes(id: legal_entity2.id)
     end
   end
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,8 +8,8 @@
       "name": "suma",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/browser": "^7.31.1",
-        "@sentry/tracing": "^7.31.1",
+        "@sentry/browser": "^7.102.0",
+        "@sentry/tracing": "^7.102.0",
         "axios": "^1.2.3",
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.3",
@@ -1155,100 +1155,118 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/@sentry/browser": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.31.1.tgz",
-      "integrity": "sha512-Rg9F61S1tz1Dv3iUyyGP26bxoi7WJAG2+f2fBbSmFuJ+JTH4Jvu2/F1bBig8Dz01ejzVhbNSUUCfoDhSvksIsQ==",
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.102.0.tgz",
+      "integrity": "sha512-GxHdzbOF4tg6TtyQzFqb/8c/p07n68qZC5KYwzs7AuW5ey0IPmdC58pOh3Kk52JA0P69/RZy39+r1p1Swr6C+Q==",
       "dependencies": {
-        "@sentry/core": "7.31.1",
-        "@sentry/replay": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.102.0.tgz",
+      "integrity": "sha512-rgNO4PdFv0AYflBsCNbSIwpQuOOJQTqyu8i8U0PupjveNjkm0CUJhber/ZOcaGmbyjdvwikGwgWY2O0Oj0USCA==",
+      "dependencies": {
+        "@sentry/core": "7.102.0",
+        "@sentry/replay": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.102.0.tgz",
+      "integrity": "sha512-BlE33HWL1IzkGa0W+pwTiyu01MUIfYf+WnO9UC8qkDW3jxVvg2zhoSjXSxikT+KPCOgoZpQHspaTzwjnI1LCvw==",
+      "dependencies": {
+        "@sentry/core": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@sentry/browser": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.102.0.tgz",
+      "integrity": "sha512-hIggcMnojIbWhbmlRfkykHmy6n7pjug0AHfF19HRUQxAx9KJfMH5YdWvohov0Hb9fS+jdvqgE+/4AWbEeXQrHw==",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.102.0",
+        "@sentry-internal/replay-canvas": "7.102.0",
+        "@sentry-internal/tracing": "7.102.0",
+        "@sentry/core": "7.102.0",
+        "@sentry/replay": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sentry/core": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.31.1.tgz",
-      "integrity": "sha512-quaNU6z8jabmatBTDi28Wpff2yzfWIp/IU4bbi2QOtEiCNT+TQJXqlRTRMu9xLrX7YzyKCL5X2gbit/85lyWUg==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.102.0.tgz",
+      "integrity": "sha512-GO9eLOSBK1waW4AD0wDXAreaNqXFQ1MPQZrkKcN+GJYEFhJK1+u+MSV7vO5Fs/rIfaTZIZ2jtEkxSSAOucE8EQ==",
       "dependencies": {
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@sentry/replay": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.31.1.tgz",
-      "integrity": "sha512-sLArvwZn6IwA/bASctyhxN7LhdCXJvMmyTynRfmk7pzuNzBMc5CNlHeIsDpHrfQuH53IKicvl6cHnHyclu5DSA==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.102.0.tgz",
+      "integrity": "sha512-sUIBN4ZY0J5/dQS3KOe5VLykm856KZkTrhV8kmBEylzQhw1BBc8i2ehTILy5ZYh9Ra8uXPTAmtwpvYf/dRDfAg==",
       "dependencies": {
-        "@sentry/core": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1"
+        "@sentry-internal/tracing": "7.102.0",
+        "@sentry/core": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.31.1.tgz",
-      "integrity": "sha512-kW6vNwddp2Ycq2JfTzveUEIRF9YQwvl7L6BBoOZt9oVnYlsPipEeyU2Q277LatHldr8hDo2tbz/vz2BQjO5GSw==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.102.0.tgz",
+      "integrity": "sha512-2ZLgJw43qY7FjRHnnPGp4rOlPpsrcDGcFlnPIVJgfV14b4bfin1kMMeVgHc9O1S+DTfrkakcPnPnOg1qK1qltg==",
       "dependencies": {
-        "@sentry/core": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
-        "tslib": "^1.9.3"
+        "@sentry-internal/tracing": "7.102.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/tracing/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@sentry/types": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.1.tgz",
-      "integrity": "sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.102.0.tgz",
+      "integrity": "sha512-FPfFBP0x3LkPARw1/6cWySLq1djIo8ao3Qo2KNBeE9CHdq8bsS1a8zzjJLuWG4Ww+wieLP8/lY3WTgrCz4jowg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.1.tgz",
-      "integrity": "sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.102.0.tgz",
+      "integrity": "sha512-cp5KCRe0slOVMwG4iP2Z4UajQkjryRTiFskZ5H7Q3X9R5voM8+DAhiDcIW88GL9NxqyUrAJOjmKdeLK2vM+bdA==",
       "dependencies": {
-        "@sentry/types": "7.31.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.102.0"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -7584,89 +7602,90 @@
         "picomatch": "^2.2.2"
       }
     },
-    "@sentry/browser": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.31.1.tgz",
-      "integrity": "sha512-Rg9F61S1tz1Dv3iUyyGP26bxoi7WJAG2+f2fBbSmFuJ+JTH4Jvu2/F1bBig8Dz01ejzVhbNSUUCfoDhSvksIsQ==",
+    "@sentry-internal/feedback": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.102.0.tgz",
+      "integrity": "sha512-GxHdzbOF4tg6TtyQzFqb/8c/p07n68qZC5KYwzs7AuW5ey0IPmdC58pOh3Kk52JA0P69/RZy39+r1p1Swr6C+Q==",
       "requires": {
-        "@sentry/core": "7.31.1",
-        "@sentry/replay": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/core": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.102.0.tgz",
+      "integrity": "sha512-rgNO4PdFv0AYflBsCNbSIwpQuOOJQTqyu8i8U0PupjveNjkm0CUJhber/ZOcaGmbyjdvwikGwgWY2O0Oj0USCA==",
+      "requires": {
+        "@sentry/core": "7.102.0",
+        "@sentry/replay": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
+      }
+    },
+    "@sentry-internal/tracing": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.102.0.tgz",
+      "integrity": "sha512-BlE33HWL1IzkGa0W+pwTiyu01MUIfYf+WnO9UC8qkDW3jxVvg2zhoSjXSxikT+KPCOgoZpQHspaTzwjnI1LCvw==",
+      "requires": {
+        "@sentry/core": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.102.0.tgz",
+      "integrity": "sha512-hIggcMnojIbWhbmlRfkykHmy6n7pjug0AHfF19HRUQxAx9KJfMH5YdWvohov0Hb9fS+jdvqgE+/4AWbEeXQrHw==",
+      "requires": {
+        "@sentry-internal/feedback": "7.102.0",
+        "@sentry-internal/replay-canvas": "7.102.0",
+        "@sentry-internal/tracing": "7.102.0",
+        "@sentry/core": "7.102.0",
+        "@sentry/replay": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
       }
     },
     "@sentry/core": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.31.1.tgz",
-      "integrity": "sha512-quaNU6z8jabmatBTDi28Wpff2yzfWIp/IU4bbi2QOtEiCNT+TQJXqlRTRMu9xLrX7YzyKCL5X2gbit/85lyWUg==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.102.0.tgz",
+      "integrity": "sha512-GO9eLOSBK1waW4AD0wDXAreaNqXFQ1MPQZrkKcN+GJYEFhJK1+u+MSV7vO5Fs/rIfaTZIZ2jtEkxSSAOucE8EQ==",
       "requires": {
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
       }
     },
     "@sentry/replay": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.31.1.tgz",
-      "integrity": "sha512-sLArvwZn6IwA/bASctyhxN7LhdCXJvMmyTynRfmk7pzuNzBMc5CNlHeIsDpHrfQuH53IKicvl6cHnHyclu5DSA==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.102.0.tgz",
+      "integrity": "sha512-sUIBN4ZY0J5/dQS3KOe5VLykm856KZkTrhV8kmBEylzQhw1BBc8i2ehTILy5ZYh9Ra8uXPTAmtwpvYf/dRDfAg==",
       "requires": {
-        "@sentry/core": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1"
+        "@sentry-internal/tracing": "7.102.0",
+        "@sentry/core": "7.102.0",
+        "@sentry/types": "7.102.0",
+        "@sentry/utils": "7.102.0"
       }
     },
     "@sentry/tracing": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.31.1.tgz",
-      "integrity": "sha512-kW6vNwddp2Ycq2JfTzveUEIRF9YQwvl7L6BBoOZt9oVnYlsPipEeyU2Q277LatHldr8hDo2tbz/vz2BQjO5GSw==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.102.0.tgz",
+      "integrity": "sha512-2ZLgJw43qY7FjRHnnPGp4rOlPpsrcDGcFlnPIVJgfV14b4bfin1kMMeVgHc9O1S+DTfrkakcPnPnOg1qK1qltg==",
       "requires": {
-        "@sentry/core": "7.31.1",
-        "@sentry/types": "7.31.1",
-        "@sentry/utils": "7.31.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry-internal/tracing": "7.102.0"
       }
     },
     "@sentry/types": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.1.tgz",
-      "integrity": "sha512-1uzr2l0AxEnxUX/S0EdmXUQ15/kDsam8Nbdw4Gai8SU764XwQgA/TTjoewVP597CDI/AHKan67Y630/Ylmkx9w=="
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.102.0.tgz",
+      "integrity": "sha512-FPfFBP0x3LkPARw1/6cWySLq1djIo8ao3Qo2KNBeE9CHdq8bsS1a8zzjJLuWG4Ww+wieLP8/lY3WTgrCz4jowg=="
     },
     "@sentry/utils": {
-      "version": "7.31.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.1.tgz",
-      "integrity": "sha512-ZsIPq29aNdP9q3R7qIzJhZ9WW+4DzE9g5SfGwx3UjTIxoRRBfdUJUbf7S+LKEdvCkKbyoDt6FLt5MiSJV43xBA==",
+      "version": "7.102.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.102.0.tgz",
+      "integrity": "sha512-cp5KCRe0slOVMwG4iP2Z4UajQkjryRTiFskZ5H7Q3X9R5voM8+DAhiDcIW88GL9NxqyUrAJOjmKdeLK2vM+bdA==",
       "requires": {
-        "@sentry/types": "7.31.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.102.0"
       }
     },
     "@sinclair/typebox": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/browser": "^7.31.1",
-    "@sentry/tracing": "^7.31.1",
+    "@sentry/browser": "^7.102.0",
+    "@sentry/tracing": "^7.102.0",
     "axios": "^1.2.3",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.3",

--- a/webapp/src/pages/OnboardingSignup.jsx
+++ b/webapp/src/pages/OnboardingSignup.jsx
@@ -3,6 +3,7 @@ import FormButtons from "../components/FormButtons";
 import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
 import { mdp, t } from "../localization";
+import keepDigits from "../modules/keepDigits";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import { extractErrorCode } from "../state/useError";
 import useUser from "../state/useUser";
@@ -65,7 +66,7 @@ export default function OnboardingSignup() {
   };
 
   const handleZipChange = (e) => {
-    const v = e.target.value.replace(/\D/, "").slice(0, 5);
+    const v = keepDigits(e.target.value).slice(0, 5);
     runSetter(e.target.name, setZipCode, v);
   };
 

--- a/webapp/src/pages/Start.jsx
+++ b/webapp/src/pages/Start.jsx
@@ -35,7 +35,7 @@ export default function Start() {
   });
 
   const handlePhoneChange = (e) => {
-    const formattedNum = maskPhoneNumber(e.target.value, phone);
+    const formattedNum = maskPhoneNumber(e.target.value);
     clearErrors();
     setValue("phone", formattedNum);
     setPhone(formattedNum);

--- a/webapp/src/shared/sentry.js
+++ b/webapp/src/shared/sentry.js
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/browser";
-import { BrowserTracing } from "@sentry/tracing";
 
 /**
  * Call cb(Sentry), and console log if there is any sort of error.
@@ -41,7 +40,7 @@ export function initSentry({
     environment,
     allowUrls,
     sampleRate: 1.0,
-    integrations: [new BrowserTracing()],
+    integrations: [new Sentry.browserTracingIntegration()],
     ...rest,
   });
   if (application) {


### PR DESCRIPTION
Fixes #597 

- Use `common_endpoint#update` method to update members.
- Update admin 'MemberDetailPage' to reuse common `ResourceDetail` component
- Create `MemberEditPage' that includes the form and uses the new 'resource' components 
- Add tests

---

Create reusable component `AddressInputs` and improve props, then use where necessary

---

Update Sentry on the webapp to match the adminapp version and update to use the new BrowserTracing syntax on this shared file.

---

Common Endpoints:

- Ensure that we handle `LegalEntity` values so that it updates addresses correctly 
- Ensure that 'roles' are updated separately to use a 'replace' method instead of the normal many_to_many handling

--- 

Pass 'replaceModel' prop to the ResourceDetail component so that we are able to replace state easier

