### PR TITLE
Soft delete old member account and transfer associations to new member account

### DIFF
--- a/lib/suma/fixtures/members.rb
+++ b/lib/suma/fixtures/members.rb
@@ -55,7 +55,7 @@ module Suma::Fixtures::Members
   end
 
   decorator :with_phone, presave: true do |phone=nil|
-    self.phone = phone || Faker::PhoneNumber.cell_phone
+    self.phone = phone || Suma::PhoneNumber::US.normalize(Faker::PhoneNumber.cell_phone)
   end
 
   decorator :with_legal_entity do |opts={}|

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -188,7 +188,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
       end
 
       bank_accounts = self.legal_entity.bank_accounts_dataset.usable.verified.all
-      carts = self.commerce_carts_dataset.all
+      carts = self.commerce_carts_dataset.all.filter { |c| c.checkouts_dataset.any?(&:completed?) }
       trips = self.mobility_trips_dataset.all
       if [bank_accounts, carts, trips].flatten.empty?
         self.soft_delete


### PR DESCRIPTION
Fixes #605

We found that it's best to transfer the least or most necessary old member associations: bank accounts, commerce carts and mobility trips. The rest of the associations should be treated as immutable.

Create new method `Suma::Member.close_account_and_transfer` that does:
- Transfer bank accounts, commerce carts and mobility trips to new member
- Check if there is an active trip in either member, raise error if true
- Transfers old member bank accounts only if they do not exist in the new member account
- Transfer nothing and return early if there are no associations to transfer
- Add activity to each member to summarize transferred associations and keep reference for suma staff

---

Test method