### PR TITLE
Handle Twilio invalid phone errors

### DIFF
--- a/lib/suma/spec_helpers/message.rb
+++ b/lib/suma/spec_helpers/message.rb
@@ -28,8 +28,10 @@ module Suma::SpecHelpers::Message
     opts[:headers] ||= {}
     opts[:headers]["Content-Type"] = "application/json"
 
-    body = load_fixture_data(opts[:fixture])
-    body["sid"] = opts[:sid]
+    if (body = opts[:body]).nil?
+      body = load_fixture_data(opts[:fixture])
+      body["sid"] = opts[:sid]
+    end
 
     req = stub_request(:post, "https://sumafaketest.signalwire.com/2010-04-01/Accounts/sw-test-project/Messages.json")
     req = req.to_return(

--- a/spec/data/twilio/error_invalid_phone.json
+++ b/spec/data/twilio/error_invalid_phone.json
@@ -1,0 +1,6 @@
+{
+  "code": 60200,
+  "message": "Invalid parameter `To`: +19020342424",
+  "more_info": "https://www.twilio.com/docs/errors/60200",
+  "status": 400
+}


### PR DESCRIPTION
We were handling signalwire failures,
but not Twilio failures.

Fixes https://lithic-technology.sentry.io/issues/4919178578