### PR TITLE
Raise a clear error when ledger contribs fail, fix inspects, make ledger.account_id non-nullable

### DIFF
--- a/db/migrations/042_ledger_account_notnull.rb
+++ b/db/migrations/042_ledger_account_notnull.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:payment_ledgers) do
+      set_column_not_null :account_id
+    end
+  end
+end

--- a/lib/suma/postgres/model_utilities.rb
+++ b/lib/suma/postgres/model_utilities.rb
@@ -257,8 +257,12 @@ module Suma::Postgres::ModelUtilities
           ]
         elsif k.end_with?("_cents")
           accessor = k.match(/^([a-z_]+)_cents/)[1]
-          k = accessor
-          self.send(accessor).format
+          if self.respond_to?(accessor)
+            k = accessor
+            self.send(accessor).format
+          else
+            v.inspect
+          end
         elsif (enc_field = self.class.encrypted_attributes_by_column[k.to_sym])
           k = enc_field.name
           "encrypted"

--- a/lib/suma/typed_struct.rb
+++ b/lib/suma/typed_struct.rb
@@ -21,8 +21,9 @@ class Suma::TypedStruct
 
   def inspect
     methods_to_keep = self.public_methods - Suma::TypedStruct._cached_base_methods
-    methods_to_keep.reject! { |m| m.to_s.end_with?("=") }
-    kvps = methods_to_keep.map { |m| "#{m}: #{self.send(m)}" }.join(", ")
+    methods_to_keep.reject! { |m| m.to_s.end_with?("=") || self.method(m).arity.nonzero? }
+    methods_to_keep.sort!
+    kvps = methods_to_keep.map { |m| "#{m}: #{self.send(m).inspect}" }.join(", ")
     return "#{self.class.name}(#{kvps})"
   end
 end

--- a/spec/suma/payment/account_spec.rb
+++ b/spec/suma/payment/account_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe "Suma::Payment::Account", :db do
     let!(:cash_ledger) { account.ensure_cash_ledger }
 
     it "raises if there is no cash ledger" do
-      account.remove_ledger(cash_ledger)
+      cash_ledger.remove_all_vendor_service_categories
+      cash_ledger.destroy
       expect do
         account.calculate_charge_contributions(context, grocery_service, money("$6"))
       end.to raise_error(Suma::InvalidPrecondition, /has no cash ledger/)

--- a/spec/suma/postgres/model_spec.rb
+++ b/spec/suma/postgres/model_spec.rb
@@ -326,10 +326,17 @@ RSpec.describe "Suma::Postgres::Model", :db do
       expect(s).to include("active_during: [2016-12-30 12:17:55...2017-12-30 12:17:55)")
     end
 
-    it "formats money" do
+    it "formats cents columns using money" do
       state = Suma::Postgres::TestingPixie.create
       state.price_per_unit_cents = 240
       expect(state.inspect).to include("price_per_unit: $2.40")
+    end
+
+    it "formats cents columns where there is no money accessor" do
+      state = Suma::Postgres::TestingPixie.create
+      state.price_per_unit_cents = 240
+      state.instance_eval("undef :price_per_unit", __FILE__, __LINE__)
+      expect(state.inspect).to include("price_per_unit_cents: 240")
     end
 
     it "decrypts strings and uris" do

--- a/spec/suma/typed_struct_spec.rb
+++ b/spec/suma/typed_struct_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Suma::TypedStruct do
+  describe "inspect" do
+    it "renders all accessors" do
+      t = Class.new(described_class) do
+        attr_accessor :x, :y
+
+        def a = :a
+        def b(_) = :b
+        def z = :z
+
+        def z=(_)
+          :z=
+        end
+      end
+      expect(t.new(x: "x", y: :y).inspect).to eq('(a: :a, x: "x", y: :y, z: :z)')
+    end
+  end
+end


### PR DESCRIPTION
Raise a clear error when ledger contribs fail

For situations like a $3 balance, $24 target amount,
and a $19-for-$5 match, there is no whole-cent ledger contribution
that results in exactly $24.

Rather than simply raising an error, the error detail
is now a lot more comprehensive and explains to programmers what to do.

---

Fix bugs with inspect methods

TypedStruct should only render zero-arity methods
into its representation.

Models with a _cents column, which don't use money_fields plugin,
should use a standard representation, not a money accessor
(because they don't have it).

---

Ledger account FK should be non-nullable

Not sure how this snuck in- ledgers must belong to a payment account.