### PR TITLE
Add analytics system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ message-render: env-MESSAGE
 i18n-format:
 	@bundle exec rake i18n:format
 
+analytics-reimport:
+	@bundle exec rake analytics:truncate
+	@bundle exec rake analytics:import
+
 take-production-db-snapshot:
 	heroku pg:backups:capture --app $(production_app)
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,8 @@ Appydays::Dotenviable.load
 
 require "sentry-ruby"
 
+require "suma/tasks/analytics"
+Suma::Tasks::Analytics.new
 require "suma/tasks/annotate"
 Suma::Tasks::Annotate.new
 require "suma/tasks/db"

--- a/db/migrations/043_analytics.rb
+++ b/db/migrations/043_analytics.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_schema(:analytics, if_not_exists: true)
+
+    create_table(Sequel[:analytics][:members]) do
+      primary_key :pk
+      integer :member_id, unique: true, null: false
+
+      timestamptz :created_at
+      timestamptz :updated_at
+      timestamptz :soft_deleted_at
+      citext :email
+      text :phone
+      text :name
+      text :timezone
+
+      integer :order_count
+    end
+
+    create_table(Sequel[:analytics][:orders]) do
+      primary_key :pk
+      integer :order_id, unique: true, null: false
+
+      timestamptz :created_at
+      timestamptz :updated_at
+      timestamptz :soft_deleted_at
+      integer :member_id
+
+      decimal :funded_amount
+      decimal :paid_amount
+    end
+  end
+end

--- a/db/migrations/043_analytics.rb
+++ b/db/migrations/043_analytics.rb
@@ -9,9 +9,8 @@ Sequel.migration do
       integer :member_id, unique: true, null: false
 
       timestamptz :created_at
-      timestamptz :updated_at
       timestamptz :soft_deleted_at
-      citext :email
+      text :email
       text :phone
       text :name
       text :timezone
@@ -24,16 +23,56 @@ Sequel.migration do
       integer :order_id, unique: true, null: false
 
       timestamptz :created_at
-      timestamptz :updated_at
-      timestamptz :soft_deleted_at
+      text :order_status
+      text :fulfillment_status
+
       integer :member_id
 
-      decimal :funded_amount
-      decimal :paid_amount
+      decimal :undiscounted_cost
+      decimal :customer_cost
+      decimal :savings
+      decimal :handling
+      decimal :taxable_cost
+      decimal :tax
+      decimal :total
+
+      decimal :funded_cost
+      decimal :paid_cost
+      decimal :cash_paid
+      decimal :noncash_paid
+    end
+
+    create_table(Sequel[:analytics][:order_items]) do
+      primary_key :pk
+      integer :checkout_item_id, unique: true, null: false
+
+      timestamptz :created_at
+      integer :order_id
+      integer :member_id
+
+      decimal :undiscounted_cost
+      decimal :customer_cost
+      decimal :savings
+    end
+
+    create_table(Sequel[:analytics][:ledgers]) do
+      primary_key :pk
+      integer :ledger_id, unique: true, null: false
+
+      integer :payment_account_id
+      integer :member_id
+      text :name
+
+      decimal :balance
+      decimal :total_credits
+      decimal :total_debits
     end
   end
+
   down do
     drop_table(Sequel[:analytics][:members])
     drop_table(Sequel[:analytics][:orders])
+    drop_table(Sequel[:analytics][:order_items])
+    drop_table(Sequel[:analytics][:ledgers])
   end
 end

--- a/db/migrations/043_analytics.rb
+++ b/db/migrations/043_analytics.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-  change do
+  up do
     create_schema(:analytics, if_not_exists: true)
 
     create_table(Sequel[:analytics][:members]) do
@@ -31,5 +31,9 @@ Sequel.migration do
       decimal :funded_amount
       decimal :paid_amount
     end
+  end
+  down do
+    drop_table(Sequel[:analytics][:members])
+    drop_table(Sequel[:analytics][:orders])
   end
 end

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,20 @@
+# Suma Analytics Tables
+
+Suma's database includes analytics tables, which are denormalized from transactional data.
+
+- Analytics models are like normal models, backed by actual tables.
+- In theory we could use views, but in practice, our domain model is sufficiently complex
+  that it would require a large duplication of application logic into SQL queries.
+- This is prohibitive for small orgs without dedicated analyists,
+  so a trigger-based system that is part of the application leverages all the domain modeling work
+  that has been done.
+
+The analytics tables are all in the `analytics` schema,
+and defaults to the same database as transactional data.
+Set `ANALYTICS_DATABASE_URL` to choose a different database.
+
+For every model event (`suma.member.created`, etc), we find all analytics models that depend on it,
+and update the relevant row/rows. For example, when an order is created,
+we upsert an order row, and upsert the order count of the relevant member.
+
+See `suma/analytics/model.rb` for instructions on creating analytics models.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -2,7 +2,7 @@
 
 Suma's database includes analytics tables, which are denormalized from transactional data.
 
-- Analytics models are like normal models, backed by actual tables.
+- Analytics models are like normal models, backed by actual tables and managed by migrations.
 - In theory we could use views, but in practice, our domain model is sufficiently complex
   that it would require a large duplication of application logic into SQL queries.
 - This is prohibitive for small orgs without dedicated analyists,
@@ -14,7 +14,10 @@ and defaults to the same database as transactional data.
 Set `ANALYTICS_DATABASE_URL` to choose a different database.
 
 For every model event (`suma.member.created`, etc), we find all analytics models that depend on it,
-and update the relevant row/rows. For example, when an order is created,
-we upsert an order row, and upsert the order count of the relevant member.
+and upsert the relevant rows. For example, when an order is created,
+we upsert a row into `analytics.orders`, a row for each order item into `analytics.order_items`,
+and upsert the `order_count` column of `analytics.members` for the member who placed the order.
 
+See `Suma::Analytics` for code related to analytics.
 See `suma/analytics/model.rb` for instructions on creating analytics models.
+Run `make analytics-reimport` to truncate and recreate all analytics tables.

--- a/docs/payments.md
+++ b/docs/payments.md
@@ -379,3 +379,48 @@ We do this ahead of time validation for two reasons:
   as the transaction processes. By checking these things only ahead of time,
   we do not pretend to have any guarantees about the same validity
   as the transaction processes.
+
+# Glossary
+
+Because we're dealing with a lot of different models, and different users need to discuss the same thing
+(ie, backend, frontend, operators, members, etc), here is a glossary of what various terms mean.
+
+Note that in most cases, the words "price", "amount", and "cost" are interchangeable.
+
+For use in examples, assume we're looking at a product that is normally sold by a vendor for $100,
+is sold to Suma by the vendor for $40, and is sold by Suma to Suma customers for $60.
+Suma has also secured a grant from a government to cover $30 of the cost for each purchase.
+
+- **Cash amount:** How much of a payment was covered by cash contributions,
+  both already existing on the cash ledger and also through new funding transactions during checkout.
+  $30 in our example (`$60 retail price - $30 subsidy`).
+- **Customer price**: See *discounted price*.
+- **Discount**: See *savings*.
+- **Discounted price**: What a customer pays for a product, without any subsidy.
+  $60 in our example.
+- **Funded amount:** How much of a payment (which is usually the *discounted price*) comes from funding transactions
+  created as part of the 'checkout', rather than from existing ledger balances, both cash or non-cash.
+  In other words, this is the amount a customer is charged at checkout, which can be $0 for orders covered
+  fully by existing balances on a ledger, or dynamic subsidy triggers.
+  Note that this is related to *cash amount.* In our example, if the full $30 was charged at checkout,
+  *funded amount* would be $30. But if the customer had $5 in cash balance on their ledger,
+  *funded amount* would be $25 since only $25 would be charged at checkout.
+- **Paid amount**: See *discounted price*
+- **Retail price**: See *undiscounted price*.
+- **Savings**: The difference between the *retail price* and the *discounted price*.
+  How much the customer saved purchasing through Suma.
+  $40 in our example (`$100 retail - $60 discounted price`).
+- **Subsidy**: Contributions to the *discounted price* that do not come from the *cash ledger*.
+- **Total**: The *discounted price* plus tax and handling.
+- **Undiscounted price**: What something is normally sold for.
+  $100 in our example.
+  This number is purely informational- it is used to calculate the savings customers achieve purchasing through Suma.
+- **Wholesale price:** What Suma pays the vendor for a product.
+  $40 in our example.
+  This number is purely informational- it is used to calculate the Cost of Goods Sold (COGS) and similar metrics.
+
+
+
+
+- **Undiscounted cost:** the full price someone would pay, without any discounts.
+- **Discounted cost:** the price someone pays after markdowns/discounts.

--- a/lib/suma/analytics.rb
+++ b/lib/suma/analytics.rb
@@ -8,9 +8,11 @@ module Suma::Analytics
     # upsert them into all corresponding analytics tables.
     # All instances in +oltp_models+ must have the same type.
     def upsert_from_transactional_model(oltp_models, olap_classes: nil)
-      oltp_models = [oltp_models] unless oltp_models.respond_to?(:to_ary)
-      raise Suma::InvalidPrecondition, "models must all be the same type" unless
-        oltp_models.map(&:class).uniq.count == 1
+      oltp_models = Suma.as_ary(oltp_models)
+      return nil if oltp_models.empty?
+      uniq_oltp_classes = oltp_models.map(&:class).uniq
+      raise Suma::InvalidPrecondition, "models must all be the same type, got: #{uniq_oltp_classes.map(&:name)}" unless
+        uniq_oltp_classes.count == 1
       model_cls = oltp_models.first.class.first.class
       eligible_olap_classes = self.olap_classes.select { |d| d.denormalize_from?(model_cls) }
       olap_classes = olap_classes.nil? ? eligible_olap_classes : (olap_classes & eligible_olap_classes)

--- a/lib/suma/analytics.rb
+++ b/lib/suma/analytics.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Suma::Analytics
+  class << self
+    def olap_classes = Suma::Analytics::Model.named_descendants
+
+    # Given an OLTP model instances (like a Suma::Member),
+    # upsert them into all corresponding analytics tables.
+    # All instances in +oltp_models+ must have the same type.
+    def upsert_from_transactional_model(oltp_models, olap_classes: nil)
+      oltp_models = [oltp_models] unless oltp_models.respond_to?(:to_ary)
+      raise Suma::InvalidPrecondition, "models must all be the same type" unless
+        oltp_models.map(&:class).uniq.count == 1
+      model_cls = oltp_models.first.class.first.class
+      eligible_olap_classes = self.olap_classes.select { |d| d.denormalize_from?(model_cls) }
+      olap_classes = olap_classes.nil? ? eligible_olap_classes : (olap_classes & eligible_olap_classes)
+      return nil if olap_classes.empty?
+      row_groups = olap_classes.map do |olap_cls|
+        oltp_models.flat_map { |o| olap_cls.to_rows(o) }
+      end
+      upserting = olap_classes.zip(row_groups)
+      upserting.each { |(m, rows)| m.upsert_rows(*rows) }
+      return upserting
+    end
+
+    # Destroy analytics rows that are based on the given model class and ids.
+    # For example, [Suma::Member, 1] would destroy Suma::Analytics::Member rows with a member_id of 1.
+    def destroy_from_transactional_model(oltp_class, ids)
+      olap_classes = self.olap_classes.select { |d| d.destroy_from?(oltp_class) }
+      olap_classes.each { |m| m.destroy_rows(ids) }
+    end
+
+    # Upsert all data from all transactional classes that are denormalized.
+    # Importing is designed to be as efficient as possible, but is still pretty slow.
+    # Usually you'd use this after a +truncate_all+, or adding new columns to an analytics table.
+    #
+    # @param oltp_classes [Array<Class>,Class] Reimport analytics models depend on any of these classes.
+    #   All rows are imported. If nil, use all oltp classes that olap classes depend on.
+    #   For example, using +oltp_classes+ of +Suma::Order
+    #   will process +Suma::Analytics::Member+ and +Suma::Analytics::Order+.
+    # @param olap_classes [Array<Class>,Class] Reimport these analytics models only.
+    #   All oltp classe that these olap models depend on will be loaded and imported.
+    #   For example, using +olap_classes+ of +Suma::Analytics::Member+ will process all members and orders.
+    def reimport_all(oltp_classes: nil, olap_classes: nil)
+      olap_classes ||= self.olap_classes
+      olap_classes = Suma.as_ary(olap_classes)
+      oltp_classes ||= olap_classes.flat_map(&:denormalizing_from).uniq
+      oltp_classes = Suma.as_ary(oltp_classes)
+      oltp_classes.each do |oltp_cls|
+        oltp_cls.dataset.each_cursor_page(yield_page: true) do |rows|
+          self.upsert_from_transactional_model(rows, olap_classes:)
+        end
+      end
+    end
+
+    def truncate_all
+      self.olap_classes.each { |m| m.truncate(cascade: true) }
+    end
+  end
+end

--- a/lib/suma/analytics/ledger.rb
+++ b/lib/suma/analytics/ledger.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::Ledger < Suma::Analytics::Model(Sequel[:analytics][:ledgers])
+  unique_key :ledger_id
+
+  destroy_from Suma::Payment::Ledger
+
+  denormalize Suma::Payment::BookTransaction, with: :denormalize_booking_transaction
+
+  def self.denormalize_booking_transaction(bx)
+    return [bx.originating_ledger, bx.receiving_ledger].map do |led|
+      {
+        ledger_id: led.id,
+        payment_account_id: led.account_id,
+        member_id: led.account.member_id,
+        name: led.name,
+        balance: led.balance,
+        total_credits: led.received_book_transactions.sum(Money.new(0), &:amount),
+        total_debits: led.originated_book_transactions.sum(Money.new(0), &:amount),
+      }
+    end
+  end
+end

--- a/lib/suma/analytics/member.rb
+++ b/lib/suma/analytics/member.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::Member < Suma::Analytics::Model(Sequel[:analytics][:members])
+  unique_key :member_id
+
+  destroy_from Suma::Member
+  denormalize Suma::Member, with: :denormalize_member
+  denormalize Suma::Commerce::Order, with: :denormalize_order
+
+  def self.denormalize_member(member)
+    return {member_id: member.id, phone: member.phone}
+  end
+
+  def self.denormalize_order(order)
+    member = order.checkout.cart.member
+    return {member_id: member.id, order_count: member.orders_dataset.count}
+  end
+end

--- a/lib/suma/analytics/member.rb
+++ b/lib/suma/analytics/member.rb
@@ -6,12 +6,17 @@ class Suma::Analytics::Member < Suma::Analytics::Model(Sequel[:analytics][:membe
   unique_key :member_id
 
   destroy_from Suma::Member
-  denormalize Suma::Member, with: :denormalize_member
-  denormalize Suma::Commerce::Order, with: :denormalize_order
+  denormalize Suma::Member, with: [
+    [:member_id, :id],
+    :created_at,
+    :soft_deleted_at,
+    :phone,
+    [:email, ->(m) { m.email&.downcase }],
+    :name,
+    :timezone,
+  ]
 
-  def self.denormalize_member(member)
-    return {member_id: member.id, phone: member.phone}
-  end
+  denormalize Suma::Commerce::Order, with: :denormalize_order
 
   def self.denormalize_order(order)
     member = order.checkout.cart.member

--- a/lib/suma/analytics/model.rb
+++ b/lib/suma/analytics/model.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "appydays/configurable"
+require "appydays/loggable"
+
+require "suma/analytics"
+require "suma/postgres/model_utilities"
+
+# See suma/postgres/model.rb
+Suma::Analytics::Model = Class.new(Sequel::Model)
+Suma::Analytics::Model.def_Model(Suma::Analytics)
+
+class Suma::Analytics::Model
+  include Appydays::Configurable
+  include Appydays::Loggable
+  extend Suma::Postgres::ModelUtilities
+
+  class RowMismatch < StandardError; end
+
+  configurable(:analytics_database) do
+    setting :uri, ENV.fetch("DATABASE_URL", "postgres://suma_analytics_test"), key: "ANALYTICS_DATABASE_URL"
+    setting :pool_timeout, 10
+    setting :max_connections, 4
+    after_configured do
+      options = {
+        logger: [self.logger],
+        sql_log_level: :debug,
+        max_connections: self.max_connections,
+        pool_timeout: self.pool_timeout,
+      }
+      db = Sequel.connect(self.uri, options)
+      self.db = db
+    end
+  end
+
+  def self.inherited(subclass)
+    super
+    subclass.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def unique_key(sym=nil)
+      @unique_key = sym unless sym.nil?
+      return @unique_key
+    end
+
+    # Declare that this class denormalizes the given class (a descendant of +Suma::Postgres::Model+)
+    # using the given method.
+    #
+    # @param transactional_model_class [Class] Like +Suma::Member+.
+    # @param with [Symbol,Proc] Like +member_to_rows+. Must return a hash of the row to upsert,
+    #   or an array of row hashes to upsert. Every row hash must include the +unique_key+,
+    #   used for conditional upserting.
+    def denormalize(transactional_model_class, with:)
+      self.denormalizers[transactional_model_class] = with
+    end
+
+    def denormalizers = (@denormalizers ||= {})
+
+    # @return [Array<Class>]
+    def denormalizing_from = self.denormalizers.keys
+
+    # Return true if this model handles instances of the given transactional model class.
+    # @param oltp_class [Class]
+    def denormalize_from?(oltp_class) = self.denormalizers.key?(oltp_class)
+
+    # Given a model, for which +can_handle?+ on its class returned true,
+    # call the handler for it and return its rows.
+    def to_rows(oltp_model)
+      h = self.denormalizers[oltp_model.class] or raise KeyError, "#{self} has no denormalizer for #{oltp_model.class}"
+      handler = h.is_a?(Symbol) ? self.method(h) : h
+      rows = handler.call(oltp_model)
+      rows = Suma.as_ary(rows)
+      unique_key = self.unique_key
+      unless (_rows_ok = rows.all? { |r| r.key?(unique_key) })
+        msg = "All rows need a key with the table's unique key, used for upsert: #{unique_key}"
+        raise Suma::InvalidPostcondition, msg
+      end
+      return rows
+    end
+
+    def upsert_rows(*rows)
+      unique_key = self.unique_key
+      combined_rows_by_unique_id = {}
+      rows.each do |row|
+        key = row.fetch(unique_key)
+        combined_rows_by_unique_id[key] ||= {}
+        combined_rows_by_unique_id[key].merge!(row)
+      end
+      combined_rows = combined_rows_by_unique_id.values
+      columns = combined_rows.first.keys.sort
+      combined_rows[1..].each do |r|
+        next if columns == r.keys.sort
+        msg = "All rows in upsert_rows must have a consistent schema.\n" \
+              "Row with #{unique_key}=#{r.fetch(unique_key)} has the keys: #{r.keys.sort}\n" \
+              "Expected keys: #{columns}"
+        raise RowMismatch, msg
+      end
+      updating = combined_rows.first.each_with_object({}) { |(c, _), h| h[c] = Sequel[:excluded][c] }
+      self.dataset.insert_conflict(
+        target: unique_key,
+        update: updating,
+      ).multi_insert(combined_rows)
+    end
+
+    def destroy_from(oltp_class)
+      @destroy_from = oltp_class
+    end
+
+    def destroy_from?(oltp_class) = oltp_class == @destroy_from
+
+    def destroy_rows(oltp_ids)
+      oltp_ids = Suma.as_ary(oltp_ids)
+      self.dataset.where(self.unique_key => oltp_ids).delete
+    end
+  end
+end

--- a/lib/suma/analytics/model.rb
+++ b/lib/suma/analytics/model.rb
@@ -39,12 +39,6 @@ class Suma::Analytics::Model
     subclass.extend(ClassMethods)
   end
 
-  def self.extensions
-    return [
-      "citext",
-    ]
-  end
-
   module ClassMethods
     def unique_key(sym=nil)
       @unique_key = sym unless sym.nil?
@@ -89,7 +83,7 @@ class Suma::Analytics::Model
       unique_key = self.unique_key
       rows.each do |row|
         unless row.key?(unique_key)
-          msg = "All rows need a key with the table's unique key #{unique_key.inspect}: #{row}"
+          msg = "#{self}: all rows need a key with the table's unique key #{unique_key.inspect}: #{row}"
           raise Suma::InvalidPostcondition, msg
         end
         row.transform_values! { |v| v.is_a?(Money) ? v.to_f : v }
@@ -109,7 +103,7 @@ class Suma::Analytics::Model
                 val = item[1].is_a?(Symbol) ? o.send(item[1]) : item[1].call(o)
                 [item[0], val]
               else
-                raise TypeError, "invalid denormalizer shorthand: #{item}"
+                raise TypeError, "invalid denormalizer shorthand: #{item.inspect}"
             end
           end
         end

--- a/lib/suma/analytics/model.rb
+++ b/lib/suma/analytics/model.rb
@@ -21,6 +21,7 @@ class Suma::Analytics::Model
     setting :uri, ENV.fetch("DATABASE_URL", "postgres://suma_analytics_test"), key: "ANALYTICS_DATABASE_URL"
     setting :pool_timeout, 10
     setting :max_connections, 4
+    setting :extension_schema, "public"
     after_configured do
       options = {
         logger: [self.logger],
@@ -38,6 +39,12 @@ class Suma::Analytics::Model
     subclass.extend(ClassMethods)
   end
 
+  def self.extensions
+    return [
+      "citext",
+    ]
+  end
+
   module ClassMethods
     def unique_key(sym=nil)
       @unique_key = sym unless sym.nil?
@@ -48,9 +55,17 @@ class Suma::Analytics::Model
     # using the given method.
     #
     # @param transactional_model_class [Class] Like +Suma::Member+.
-    # @param with [Symbol,Proc] Like +member_to_rows+. Must return a hash of the row to upsert,
-    #   or an array of row hashes to upsert. Every row hash must include the +unique_key+,
-    #   used for conditional upserting.
+    # @param with [Symbol,Proc,Array] Converter to take the transactional model and return a row to upsert,
+    #   or an array of rows to upsert.
+    #   Every row hash must include the +unique_key+, used for INSERT ON CONFLICT.
+    #   The +with+_ argument can be one of:
+    #   - A +Symbol+, which identifies the method, called with the transactional model instance.
+    #   - A +Proc+, called with the transactional model instance.
+    #   - An +Array+, which is a shorthand for denormalization. Each item in the array is one of:
+    #     - A +Symbol+, like `:name`, which would add a cell for `name=model.name`.
+    #     - A tuple of symbols, like `[:id, :member_id]`, which would add a cell for `member_id=model.id`.
+    #     - A tuple of a symbol and proc, like `[:email, ->(m) { m.email.upcase }]`,
+    #       called with the model instance, which would add a cell like `email='A@B.C'`.
     def denormalize(transactional_model_class, with:)
       self.denormalizers[transactional_model_class] = with
     end
@@ -68,18 +83,42 @@ class Suma::Analytics::Model
     # call the handler for it and return its rows.
     def to_rows(oltp_model)
       h = self.denormalizers[oltp_model.class] or raise KeyError, "#{self} has no denormalizer for #{oltp_model.class}"
-      handler = h.is_a?(Symbol) ? self.method(h) : h
+      handler = self.denormalizer_to_handler(h)
       rows = handler.call(oltp_model)
       rows = Suma.as_ary(rows)
       unique_key = self.unique_key
-      unless (_rows_ok = rows.all? { |r| r.key?(unique_key) })
-        msg = "All rows need a key with the table's unique key, used for upsert: #{unique_key}"
-        raise Suma::InvalidPostcondition, msg
+      rows.each do |row|
+        unless row.key?(unique_key)
+          msg = "All rows need a key with the table's unique key #{unique_key.inspect}: #{row}"
+          raise Suma::InvalidPostcondition, msg
+        end
+        row.transform_values! { |v| v.is_a?(Money) ? v.to_f : v }
       end
       return rows
     end
 
+    def denormalizer_to_handler(h)
+      return self.method(h) if h.is_a?(Symbol)
+      if h.is_a?(Array)
+        return lambda do |o|
+          h.to_h do |item|
+            case item
+              when Symbol
+                [item, o.send(item)]
+              when Array
+                val = item[1].is_a?(Symbol) ? o.send(item[1]) : item[1].call(o)
+                [item[0], val]
+              else
+                raise TypeError, "invalid denormalizer shorthand: #{item}"
+            end
+          end
+        end
+      end
+      return h
+    end
+
     def upsert_rows(*rows)
+      return nil if rows.empty?
       unique_key = self.unique_key
       combined_rows_by_unique_id = {}
       rows.each do |row|

--- a/lib/suma/analytics/order.rb
+++ b/lib/suma/analytics/order.rb
@@ -5,15 +5,33 @@ require "suma/analytics/model"
 class Suma::Analytics::Order < Suma::Analytics::Model(Sequel[:analytics][:orders])
   unique_key :order_id
 
-  denormalize Suma::Commerce::Order, with: :denormalize_order
+  destroy_from Suma::Commerce::Order
+  denormalize Suma::Commerce::Order, with: [
+    [:order_id, :id],
+    :created_at,
+    :order_status,
+    :fulfillment_status,
+    [:member_id, ->(o) { o.checkout.cart.member_id }],
+    :undiscounted_cost,
+    :customer_cost,
+    :savings,
+    :handling,
+    :taxable_cost,
+    :tax,
+    :total,
+    :funded_cost,
+    :paid_cost,
+    :cash_paid,
+    :noncash_paid,
+  ]
 
   def self.denormalize_order(order)
     member = order.checkout.cart.member
     return {
       order_id: order.id,
       member_id: member.id,
-      funded_amount: order.funded_amount.to_f,
-      paid_amount: order.paid_amount.to_f,
+      funded_amount: order.funded_amount,
+      paid_amount: order.paid_amount,
     }
   end
 end

--- a/lib/suma/analytics/order.rb
+++ b/lib/suma/analytics/order.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::Order < Suma::Analytics::Model(Sequel[:analytics][:orders])
+  unique_key :order_id
+
+  denormalize Suma::Commerce::Order, with: :denormalize_order
+
+  def self.denormalize_order(order)
+    member = order.checkout.cart.member
+    return {
+      order_id: order.id,
+      member_id: member.id,
+      funded_amount: order.funded_amount.to_f,
+      paid_amount: order.paid_amount.to_f,
+    }
+  end
+end

--- a/lib/suma/analytics/order.rb
+++ b/lib/suma/analytics/order.rb
@@ -24,14 +24,4 @@ class Suma::Analytics::Order < Suma::Analytics::Model(Sequel[:analytics][:orders
     :cash_paid,
     :noncash_paid,
   ]
-
-  def self.denormalize_order(order)
-    member = order.checkout.cart.member
-    return {
-      order_id: order.id,
-      member_id: member.id,
-      funded_amount: order.funded_amount,
-      paid_amount: order.paid_amount,
-    }
-  end
 end

--- a/lib/suma/analytics/order_item.rb
+++ b/lib/suma/analytics/order_item.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::OrderItem < Suma::Analytics::Model(Sequel[:analytics][:order_items])
+  unique_key :checkout_item_id
+
+  denormalize Suma::Commerce::Order, with: :denormalize_order
+
+  def self.denormalize_order(order)
+    checkout = order.checkout
+    member = checkout.cart.member
+    return order.checkout.items.map do |ci|
+      {
+        checkout_item_id: ci.id,
+        order_id: order.id,
+        member_id: member.id,
+        funded_amount: order.funded_amount.to_f,
+        paid_amount: order.paid_amount.to_f,
+      }
+    end
+  end
+end

--- a/lib/suma/analytics/order_item.rb
+++ b/lib/suma/analytics/order_item.rb
@@ -5,6 +5,8 @@ require "suma/analytics/model"
 class Suma::Analytics::OrderItem < Suma::Analytics::Model(Sequel[:analytics][:order_items])
   unique_key :checkout_item_id
 
+  destroy_from Suma::Commerce::CheckoutItem
+
   denormalize Suma::Commerce::Order, with: :denormalize_order
 
   def self.denormalize_order(order)
@@ -13,10 +15,12 @@ class Suma::Analytics::OrderItem < Suma::Analytics::Model(Sequel[:analytics][:or
     return order.checkout.items.map do |ci|
       {
         checkout_item_id: ci.id,
+        created_at: order.created_at,
         order_id: order.id,
         member_id: member.id,
-        funded_amount: order.funded_amount.to_f,
-        paid_amount: order.paid_amount.to_f,
+        undiscounted_cost: ci.undiscounted_cost,
+        customer_cost: ci.customer_cost,
+        savings: ci.savings,
       }
     end
   end

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -21,6 +21,7 @@ module Suma::Async
 
   # Registry of all jobs that will be required when the async system is started/run.
   JOBS = [
+    "suma/async/analytics_dispatch",
     "suma/async/emailer",
     "suma/async/ensure_default_member_ledgers_on_create",
     "suma/async/funding_transaction_processor",

--- a/lib/suma/async/analytics_dispatch.rb
+++ b/lib/suma/async/analytics_dispatch.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "amigo/job"
+
+class Suma::Async::AnalyticsDispatch
+  extend Amigo::Job
+
+  on "suma.*"
+
+  def _perform(event)
+    prefix, _sep, action = event.name.rpartition(".")
+    return unless ["created", "updated", "destroyed"].include?(action)
+    model_class = Suma::Postgres::Model.descendants.find { |d| d.event_prefix == prefix }
+    raise Suma::InvalidPrecondition, "cannot find model for #{prefix}" if model_class.nil?
+
+    if action == "destroyed"
+      Suma::Analytics.destroy_from_transactional_model(model_class, event.payload[0])
+      return
+    end
+
+    oltp_model = self.lookup_model(model_class, event)
+    Suma::Analytics.upsert_from_transactional_model(oltp_model)
+  end
+end

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -43,6 +43,7 @@ module Suma::Postgres
   # Require paths for model superclasses.
   SUPERCLASSES = [
     "suma/postgres/model",
+    "suma/analytics/model",
   ].freeze
 
   # Require paths for all Sequel models used by the app.
@@ -107,6 +108,10 @@ module Suma::Postgres
     "suma/vendor/service",
     "suma/vendor/service_category",
     "suma/vendor/service_rate",
+
+    # analytics models
+    "suma/analytics/member",
+    "suma/analytics/order",
   ].freeze
 
   # If true, deferred model events publish immediately.

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -110,8 +110,10 @@ module Suma::Postgres
     "suma/vendor/service_rate",
 
     # analytics models
+    "suma/analytics/ledger",
     "suma/analytics/member",
     "suma/analytics/order",
+    "suma/analytics/order_item",
   ].freeze
 
   # If true, deferred model events publish immediately.

--- a/lib/suma/tasks/analytics.rb
+++ b/lib/suma/tasks/analytics.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rake/tasklib"
+
+require "suma/tasks"
+
+class Suma::Tasks::Analytics < Rake::TaskLib
+  def initialize
+    super()
+    namespace :analytics do
+      desc "Truncate all analytics tables."
+      task :truncate do
+        require "suma/postgres"
+        Suma::Postgres.load_models
+        Suma::Analytics.truncate_all
+      end
+
+      desc "Process all transactional data into analytics data."
+      task :import do
+        require "suma/postgres"
+        Suma::Postgres.load_models
+        Suma::Analytics.reimport_all
+      end
+    end
+  end
+end

--- a/spec/suma/analytics/model_spec.rb
+++ b/spec/suma/analytics/model_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suma::Analytics::Model", :db do
+  let(:described_class) { Suma::Analytics::Model }
+
+  def analytics_model(name, &)
+    return create_model(name, model_class: Suma::Analytics::Model, &)
+  end
+
+  describe "#to_rows" do
+    it "calls the handler (named) for the class and returns the row array" do
+      subclass = analytics_model("ToRowsArray")
+      subclass.instance_eval do
+        unique_key :member_id
+        denormalize Suma::Member, with: :denormalize_member
+        def denormalize_member(m) = [{member_id: m.id, phone: m.phone}]
+      end
+      m = Suma::Fixtures.member.create(phone: "12223334444")
+      expect(subclass.to_rows(m)).to eq([{member_id: m.id, phone: "12223334444"}])
+    end
+
+    it "calls the handler (anonymous) for the class and wraps a returned hash into a row array" do
+      subclass = analytics_model("ToRowsHash")
+      subclass.instance_eval do
+        unique_key :member_id
+        denormalize Suma::Member, with: ->(m) do {member_id: m.id, phone: m.phone} end
+      end
+      m = Suma::Fixtures.member.create(phone: "12223334444")
+      expect(subclass.to_rows(m)).to eq([{member_id: m.id, phone: "12223334444"}])
+    end
+
+    it "errors if a row does not include the unique key" do
+      subclass = analytics_model("ToRowsHash")
+      subclass.instance_eval do
+        unique_key :member_id
+        denormalize Suma::Member, with: ->(m) do {phone: m.phone} end
+      end
+      m = Suma::Fixtures.member.create
+      expect { subclass.to_rows(m) }.to raise_error(/used for upsert: member_id/)
+    end
+  end
+
+  describe "#destroy_rows" do
+    it "deletes rows in the table using the specified class" do
+      subclass = analytics_model("Destroy") do
+        integer :member_id, unique: true
+      end
+      subclass.instance_eval do
+        unique_key :member_id
+        destroy_from Suma::Member
+      end
+      subclass.upsert_rows({member_id: 1}, {member_id: 2})
+      subclass.destroy_rows(1)
+      expect(subclass.all).to contain_exactly(include(member_id: 2))
+      subclass.destroy_rows([2])
+      expect(subclass.all).to be_empty
+    end
+  end
+
+  describe "#upsert_rows" do
+    it "inserts rows" do
+      subclass = analytics_model("InsertRows") do
+        integer :member_id, unique: true
+        text :name
+      end
+      subclass.instance_eval do
+        unique_key :member_id
+      end
+      subclass.upsert_rows({member_id: 1, name: "hello"}, {member_id: 2, name: "bye"})
+      expect(subclass.all).to contain_exactly(include(member_id: 1, name: "hello"), include(member_id: 2, name: "bye"))
+    end
+
+    it "updates rows" do
+      subclass = analytics_model("InsertRows") do
+        integer :member_id, unique: true
+        text :name
+      end
+      subclass.instance_eval do
+        unique_key :member_id
+      end
+      subclass.upsert_rows({member_id: 1, name: "hello"}, {member_id: 2, name: "bye"})
+      expect(subclass.all).to contain_exactly(include(member_id: 1, name: "hello"), include(member_id: 2, name: "bye"))
+      subclass.upsert_rows({member_id: 1, name: "hola"})
+      expect(subclass.all).to contain_exactly(include(member_id: 1, name: "hola"), include(member_id: 2, name: "bye"))
+    end
+
+    it "errors if all hashes do not have the same keys" do
+      subclass = analytics_model("InconsistentHashes") do
+        integer :member_id, unique: true
+      end
+      subclass.instance_eval do
+        unique_key :member_id
+      end
+      expect do
+        subclass.upsert_rows({member_id: 1, name1: "hello"}, {member_id: 2, name2: "bye"})
+      end.to raise_error(described_class::RowMismatch, /member_id=2 has the keys/)
+    end
+
+    describe "when multiple hashes have the same unique key" do
+      it "combines them for insert/update" do
+        subclass = analytics_model("SplitSchema") do
+          integer :member_id, unique: true
+          text :name1
+          text :name2
+        end
+        subclass.instance_eval do
+          unique_key :member_id
+        end
+        subclass.upsert_rows({member_id: 1, name1: "hi"}, {member_id: 1, name2: "hello"})
+        expect(subclass.all).to contain_exactly(include(member_id: 1, name1: "hi", name2: "hello"))
+        subclass.upsert_rows({member_id: 1, name1: "hi2"}, {member_id: 1, name2: "hello2"})
+        expect(subclass.all).to contain_exactly(include(member_id: 1, name1: "hi2", name2: "hello2"))
+      end
+
+      it "errors if all hashes do not end up with the same schema" do
+        subclass = analytics_model("InconsistentSchema") do
+          integer :member_id, unique: true
+        end
+        subclass.instance_eval do
+          unique_key :member_id
+        end
+        expect do
+          subclass.upsert_rows(
+            {member_id: 1, name1: "x"},
+            {member_id: 1, name2: "x"},
+            {member_id: 2, name1: "x"},
+          )
+        end.to raise_error(described_class::RowMismatch, /member_id=2 has the keys/)
+      end
+    end
+  end
+end

--- a/spec/suma/analytics_spec.rb
+++ b/spec/suma/analytics_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Suma::Analytics, :db do
       described_class.upsert_from_transactional_model(m)
       expect(Suma::Analytics::Member.all).to be_empty
     end
+
+    it "noops if empty" do
+      expect { described_class.upsert_from_transactional_model([]) }.to_not raise_error
+    end
   end
 
   describe "destroy_from_transactional_model" do
@@ -85,6 +89,14 @@ RSpec.describe Suma::Analytics, :db do
       Suma::Analytics.upsert_from_transactional_model(o)
       expect(Suma::Analytics::Order.dataset.all).to contain_exactly(
         include(order_id: o.id, member_id: o.checkout.cart.member_id, funded_amount: 0),
+      )
+    end
+
+    it "can denormalize order items" do
+      o = Suma::Fixtures.order.create
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::OrderItem.dataset.all).to contain_exactly(
+        include(order_id: o.id),
       )
     end
   end

--- a/spec/suma/analytics_spec.rb
+++ b/spec/suma/analytics_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Suma::Analytics, :db do
+  describe "upsert_from_transactional_model" do
+    it "can upsert a handled models" do
+      m = Suma::Fixtures.member.create
+      described_class.upsert_from_transactional_model(m)
+      expect(Suma::Analytics::Member.all).to have_length(1)
+    end
+
+    it "noops if there is no denormalizer" do
+      m = Suma::Fixtures.uploaded_file.create
+      described_class.upsert_from_transactional_model(m)
+      expect(Suma::Analytics::Member.all).to be_empty
+    end
+  end
+
+  describe "destroy_from_transactional_model" do
+    it "destroys rows related to the identified model" do
+      m = Suma::Fixtures.member.create
+      described_class.upsert_from_transactional_model(m)
+      expect(Suma::Analytics::Member.all).to have_length(1)
+      described_class.destroy_from_transactional_model(m.class, m.id)
+      expect(Suma::Analytics::Member.all).to be_empty
+    end
+  end
+
+  describe "truncate_all" do
+    it "deletes all analytics rows" do
+      Suma::Fixtures.order.create
+      described_class.reimport_all
+      expect(Suma::Analytics::Member.all).to have_length(1)
+      expect(Suma::Analytics::Order.all).to have_length(1)
+      described_class.truncate_all
+      expect(Suma::Analytics::Member.all).to be_empty
+      expect(Suma::Analytics::Order.all).to be_empty
+    end
+  end
+
+  describe "reimport_all" do
+    it "upserts rows for all relevant transactional models" do
+      Suma::Fixtures.order.create
+      Suma::Fixtures.order.create
+      described_class.reimport_all
+      expect(Suma::Analytics::Member.all).to have_length(2)
+      expect(Suma::Analytics::Order.all).to have_length(2)
+    end
+
+    it "can specify oltp models" do
+      Suma::Fixtures.order.create
+      Suma::Fixtures.order.create
+      described_class.reimport_all(oltp_classes: Suma::Member)
+      expect(Suma::Analytics::Member.all).to have_length(2)
+      expect(Suma::Analytics::Order.all).to have_length(0)
+    end
+
+    it "can specify olap models" do
+      Suma::Fixtures.order.create
+      Suma::Fixtures.order.create
+      described_class.reimport_all(olap_classes: Suma::Analytics::Order)
+      expect(Suma::Analytics::Member.all).to have_length(0)
+      expect(Suma::Analytics::Order.all).to have_length(2)
+    end
+  end
+
+  describe "Member" do
+    it "can denormalize a member" do
+      o = Suma::Fixtures.member.create
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::Member.dataset.all).to contain_exactly(include(member_id: o.id, order_count: nil))
+    end
+
+    it "can denormalize an order" do
+      o = Suma::Fixtures.order.create
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::Member.dataset.all).to contain_exactly(
+        include(member_id: o.checkout.cart.member_id, order_count: 1),
+      )
+    end
+  end
+
+  describe "Order" do
+    it "can denormalize an order" do
+      o = Suma::Fixtures.order.create
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::Order.dataset.all).to contain_exactly(
+        include(order_id: o.id, member_id: o.checkout.cart.member_id, funded_amount: 0),
+      )
+    end
+  end
+end


### PR DESCRIPTION
Suma's database includes analytics tables, which are denormalized from transactional data.

- Analytics models are like normal models, backed by actual tables and managed by migrations.
- In theory we could use views, but in practice, our domain model is sufficiently complex
  that it would require a large duplication of application logic into SQL queries.
- This is prohibitive for small orgs without dedicated analyists,
  so a trigger-based system that is part of the application leverages all the domain modeling work
  that has been done.

The analytics tables are all in the `analytics` schema,
and defaults to the same database as transactional data.
Set `ANALYTICS_DATABASE_URL` to choose a different database.

For every model event (`suma.member.created`, etc), we find all analytics models that depend on it,
and upsert the relevant rows. For example, when an order is created,
we upsert a row into `analytics.orders`, a row for each order item into `analytics.order_items`,
and upsert the `order_count` column of `analytics.members` for the member who placed the order.

See `Suma::Analytics` for code related to analytics.
See `suma/analytics/model.rb` for instructions on creating analytics models.
Run `make analytics-reimport` to truncate and recreate all analytics tables.
