### PR TITLE
Swagger: Fix busted API

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -14,7 +14,7 @@ Suma::Async.setup_web
 map "/api" do
   run Suma::Apps::API.build_app
 end
-map Suma::Apps::MOUNT_PATHS.fetch(Suma::Apps::AdminAPI) do
+map "/adminapi" do
   run Suma::Apps::AdminAPI.build_app
 end
 map Suma::Apps::WEB_MOUNT_PATH do
@@ -25,10 +25,5 @@ map "/admin" do
 end
 map "/sidekiq" do
   run Suma::Apps::SidekiqWeb.to_app
-end
-if Suma::Service.swagger_enabled
-  map "/swagger" do
-    run Suma::Apps::Swagger
-  end
 end
 run Suma::Apps::Root.to_app

--- a/lib/suma/apps.rb
+++ b/lib/suma/apps.rb
@@ -63,6 +63,8 @@ module Suma::Apps
     mount Suma::API::Payments
     mount Suma::API::Preferences
     mount Suma::API::Webhookdb
+    add_swagger_documentation(mount_path: "/swagger", info: {title: "Suma App API"}) if
+      Suma::Service.swagger_enabled
   end
 
   class AdminAPI < Suma::Service
@@ -84,6 +86,8 @@ module Suma::Apps
     mount Suma::AdminAPI::Roles
     mount Suma::AdminAPI::Search
     mount Suma::AdminAPI::Vendors
+    add_swagger_documentation(mount_path: "/swagger", info: {title: "Suma Admin API"}) if
+      Suma::Service.swagger_enabled
   end
 
   SidekiqWeb = Rack::Builder.new do
@@ -164,18 +168,5 @@ module Suma::Apps
     use(Rack::SslEnforcer, redirect_html: false) if Suma::Service.enforce_ssl
     use Rack::SimpleRedirect, routes: {/.*/ => ->(env) { "/app#{env['REQUEST_PATH']}" }}, status: 302
     run Rack::LambdaApp.new(->(_) { raise "Should not see this" })
-  end
-
-  MOUNT_PATHS = {
-    API => "/api",
-    AdminAPI => "/adminapi",
-  }.freeze
-
-  # View swagger docs at /swagger/doc
-  class Swagger < Grape::API
-    [API, AdminAPI].each do |api|
-      mount({api => MOUNT_PATHS.fetch(api)})
-    end
-    add_swagger_documentation(mount_path: "/doc")
   end
 end

--- a/lib/suma/service.rb
+++ b/lib/suma/service.rb
@@ -111,6 +111,8 @@ class Suma::Service < Grape::API
 
   # Add some context to Sentry on each request.
   before do
+    # In some cases, like Grape::Swagger, this runs in a Grape::API rather than a Suma::Service
+    next unless respond_to?(:current_member?)
     member = current_member?
     admin = admin_member?
     Sentry.configure_scope do |scope|


### PR DESCRIPTION
Using `mount API => '/api'` was breaking the actual API mount. Unfortunately that's the only way to have a single Swagger file with both the api and adminapi.

Instead, we now have `/api/swagger` and `/adminapi/swagger`.