### PR TITLE
Support no fulfillment options for offering picklist

### DIFF
--- a/adminapp/src/pages/OfferingPickListPage.jsx
+++ b/adminapp/src/pages/OfferingPickListPage.jsx
@@ -30,9 +30,6 @@ import { useParams } from "react-router-dom";
  * 'pick' list. The second table renders the quantity for each unique product
  * and fulfillment option, aka the 'pack' list. The last table shows all orders
  * information including their fulfillment status.
- *
- * The backend supports offerings with no fulfillment options so it is also
- * supported here.
  * @returns {JSX.Element}
  */
 export default function OfferingPickListPage() {
@@ -101,9 +98,10 @@ export default function OfferingPickListPage() {
     productIdsAndQuantities[pid] ||= 0;
     productIdsAndQuantities[pid] += quantity;
     // Represent no fulfillment with zero index
-    fulfillmentIdsAndProductQuantities[fulfillmentOption?.id || 0] ||= {};
-    fulfillmentIdsAndProductQuantities[fulfillmentOption?.id || 0][pid] ||= 0;
-    fulfillmentIdsAndProductQuantities[fulfillmentOption?.id || 0][pid] += quantity;
+    const fulfillmentOptionId = fulfillmentOption?.id || 0;
+    fulfillmentIdsAndProductQuantities[fulfillmentOptionId] ||= {};
+    fulfillmentIdsAndProductQuantities[fulfillmentOptionId][pid] ||= 0;
+    fulfillmentIdsAndProductQuantities[fulfillmentOptionId][pid] += quantity;
   });
   const fulfillmentAndProductQuantityRows = [];
   Object.entries(fulfillmentIdsAndProductQuantities).forEach(([fid, pq]) => {

--- a/adminapp/src/pages/OfferingPickListPage.jsx
+++ b/adminapp/src/pages/OfferingPickListPage.jsx
@@ -24,6 +24,17 @@ import uniqBy from "lodash/uniqBy";
 import React from "react";
 import { useParams } from "react-router-dom";
 
+/**
+ * Returns offering pick pack list of an offerings products and fulfillment
+ * options. The first table renders each product and their quantity, aka the
+ * 'pick' list. The second table renders the quantity for each unique product
+ * and fulfillment option, aka the 'pack' list. The last table shows all orders
+ * information including their fulfillment status.
+ *
+ * The backend supports offerings with no fulfillment options so it is also
+ * supported here.
+ * @returns {JSX.Element}
+ */
 export default function OfferingPickListPage() {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
   let { id } = useParams();
@@ -42,13 +53,21 @@ export default function OfferingPickListPage() {
     label: oi.offeringProduct.product.name,
     value: oi.offeringProduct.product.id,
   }));
-  const fulfillmentChoices = picklist.orderItems.map((oi) => ({
-    label: oi.fulfillmentOption.description,
-    value: oi.fulfillmentOption.id,
-  }));
-  function selectFilterMenuItems(allChoices) {
+  let fulfillmentChoices = picklist.orderItems
+    .filter((oi) => oi.fulfillmentOption)
+    .map((oi) => ({
+      label: oi.fulfillmentOption.description,
+      value: oi.fulfillmentOption.id,
+    }));
+  function selectFilterMenuItems(allChoices, isFulfillment) {
     const ch = sortBy(uniqBy(allChoices, "value"), "label");
-    const withEmpty = [{ label: "All", value: null }, ...ch];
+    const withEmpty = [{ label: "All", value: null }];
+    const noProductFulfillment = picklist.orderItems.some((oi) => !oi.fulfillmentOption);
+    if (isFulfillment && noProductFulfillment) {
+      withEmpty.push({ label: "No Fulfillment", value: "none" }, ...ch);
+    } else {
+      withEmpty.push(...ch);
+    }
     return withEmpty.map(({ label, value }) => (
       <MenuItem key={value} value={value}>
         {label}
@@ -60,7 +79,12 @@ export default function OfferingPickListPage() {
     [selectedProduct]
   );
   const fulfillmentOptMatches = React.useCallback(
-    (fo) => !selectedFulfillment || fo.id === Number(selectedFulfillment),
+    (fo) => {
+      if (selectedFulfillment === "none") {
+        return fo === null;
+      }
+      return !selectedFulfillment || fo?.id === Number(selectedFulfillment);
+    },
     [selectedFulfillment]
   );
   const matchingItems = (picklist.orderItems || []).filter(
@@ -76,9 +100,10 @@ export default function OfferingPickListPage() {
     const pid = offeringProduct.product.id;
     productIdsAndQuantities[pid] ||= 0;
     productIdsAndQuantities[pid] += quantity;
-    fulfillmentIdsAndProductQuantities[fulfillmentOption.id] ||= {};
-    fulfillmentIdsAndProductQuantities[fulfillmentOption.id][pid] ||= 0;
-    fulfillmentIdsAndProductQuantities[fulfillmentOption.id][pid] += quantity;
+    // Represent no fulfillment with zero index
+    fulfillmentIdsAndProductQuantities[fulfillmentOption?.id || 0] ||= {};
+    fulfillmentIdsAndProductQuantities[fulfillmentOption?.id || 0][pid] ||= 0;
+    fulfillmentIdsAndProductQuantities[fulfillmentOption?.id || 0][pid] += quantity;
   });
   const fulfillmentAndProductQuantityRows = [];
   Object.entries(fulfillmentIdsAndProductQuantities).forEach(([fid, pq]) => {
@@ -105,7 +130,7 @@ export default function OfferingPickListPage() {
                 label="Product"
                 onChange={(e) => setSearchParam("product", e.target.value || null)}
               >
-                {selectFilterMenuItems(productChoices)}
+                {selectFilterMenuItems(productChoices, false)}
               </Select>
             </FormControl>
             <FormControl sx={{ flex: 1, maxWidth: 300 }}>
@@ -115,7 +140,7 @@ export default function OfferingPickListPage() {
                 label="Fulfillment"
                 onChange={(e) => setSearchParam("fulfillment", e.target.value || null)}
               >
-                {selectFilterMenuItems(fulfillmentChoices)}
+                {selectFilterMenuItems(fulfillmentChoices, true)}
               </Select>
             </FormControl>
           </Stack>
@@ -162,7 +187,7 @@ export default function OfferingPickListPage() {
                 field: "fulfillmentOption",
                 headerName: "Fulfillment",
                 width: 350,
-                renderCell: ({ value }) => value.description,
+                renderCell: ({ value }) => (value ? value.description : "-"),
               },
               {
                 field: "quantity",
@@ -171,7 +196,7 @@ export default function OfferingPickListPage() {
               },
             ]}
             rows={fulfillmentAndProductQuantityRows}
-            getRowId={(row) => `${row.product.id}-${row.fulfillmentOption.id}`}
+            getRowId={(row) => `${row.product.id}-${row.fulfillmentOption?.id || 0}`}
             {...commonTableProps}
           />
           <StripedDataGrid
@@ -218,7 +243,7 @@ export default function OfferingPickListPage() {
                 field: "fulfillmentOption",
                 headerName: "Fulfillment",
                 width: 250,
-                renderCell: ({ value }) => value.description,
+                renderCell: ({ value }) => (value ? value.description : "-"),
               },
               {
                 field: "status",


### PR DESCRIPTION
Fixes #641 

We recently supported offerings with no fulfillment options, also support this in the admin `OfferingPickList` page. 

### With nothing selected
![Screenshot 2024-05-06 at 12 52 33 PM](https://github.com/lithictech/suma/assets/66847768/1c444590-5e11-4e92-a5ab-3e509ad778af)

### With option "No fulfillment" selected
![Screenshot 2024-05-06 at 12 52 47 PM](https://github.com/lithictech/suma/assets/66847768/693753e2-0b08-45d0-ae6d-fde67f21ec98)

### With option "No fulfillment" and product option selected
![Screenshot 2024-05-06 at 12 53 00 PM](https://github.com/lithictech/suma/assets/66847768/add0fa6f-a6ca-4382-a10a-d678738dce07)

   