### PR TITLE
Tighten up some security loose ends (CSV sanitization, reset code expiration, offering visibility)

### DIFF
--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -45,7 +45,7 @@ class Suma::API::Auth < Suma::API::V1
             subject_id: member.id,
           )
         end
-        member.add_reset_code({transport: "sms"})
+        Suma::Member::ResetCode.replace_active(member, transport: "sms")
         member.message_preferences!.update(preferred_language: params[:language]) if params[:language].present?
         status 200
         present member, with: AuthFlowMemberEntity

--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -33,6 +33,7 @@ class Suma::API::Commerce < Suma::API::V1
         helpers do
           def lookup_offering!
             (offering = Suma::Commerce::Offering[params[:offering_id]]) or forbidden!
+            check_eligibility!(offering, current_member)
             return offering
           end
 
@@ -76,9 +77,7 @@ class Suma::API::Commerce < Suma::API::V1
         end
 
         post :checkout do
-          member = current_member
           offering = lookup_offering!
-          check_eligibility!(offering, member)
           cart = lookup_cart!(offering)
           ctx = new_context
           begin

--- a/lib/suma/fixtures/reset_codes.rb
+++ b/lib/suma/fixtures/reset_codes.rb
@@ -25,4 +25,12 @@ module Suma::Fixtures::ResetCodes
   decorator :email do
     self.transport = "email"
   end
+
+  decorator :expired do
+    self.expire_at = Faker::Number.between(from: 1, to: 100).minutes.ago
+  end
+
+  decorator :used do
+    self.used = true
+  end
 end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -80,7 +80,11 @@ class Suma::Member < Suma::Postgres::Model(:members)
                     read_only: true
   one_to_one :payment_account, class: "Suma::Payment::Account"
   one_to_one :referral, class: "Suma::Member::Referral"
-  one_to_many :reset_codes, class: "Suma::Member::ResetCode", order: Sequel.desc([:created_at])
+  one_to_many :reset_codes,
+              class: "Suma::Member::ResetCode",
+              order: Sequel.desc([:created_at]),
+              # Use ResetCode.replace_active instead, add_reset_code is unsafe since it can keep multiple active.
+              adder: nil
   many_to_many :roles, class: "Suma::Role", join_table: :roles_members
   one_to_many :sessions, class: "Suma::Member::Session", order: Sequel.desc([:created_at, :id])
   one_to_many :commerce_carts, class: "Suma::Commerce::Cart"

--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -33,7 +33,15 @@ class Suma::Member::Exporter
     got = CSV.generate do |csv|
       csv << HEADERS.map(&:first)
       @dataset.paged_each do |m|
-        row = coercers.map { |c| c[m] }
+        row = coercers.map do |c|
+          v = c[m]
+          # If the string starts with an equal sign, add a space before it,
+          # so spreadsheet programs will not evaluate it as a macro
+          # which can be confusing (name of "=1+1" would appear as "2")
+          # and potentially dangerous.
+          v = " #{v}" if v.respond_to?(:start_with?) && v.start_with?("=")
+          v
+        end
         csv << row
       end
     end

--- a/lib/suma/member/reset_code.rb
+++ b/lib/suma/member/reset_code.rb
@@ -19,6 +19,13 @@ class Suma::Member::ResetCode < Suma::Postgres::Model(:member_reset_codes)
     end
   end
 
+  def self.replace_active(member, transport:, **options)
+    self.db.transaction do
+      member.reset_codes_dataset.where(transport:).usable.update(expire_at: Sequel.function(:now))
+      return self.create(member:, transport:, **options)
+    end
+  end
+
   # Invoke the given block with the reset code referred to by token.
   # Raise Unusable if code is unusable.
   def self.use_code_with_token(token)

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
     it "dispatches the code" do
       member = Suma::Fixtures.member(phone: "12223334444").create
       expect do
-        member.add_reset_code(token: "12345", transport: "sms")
+        Suma::Member::ResetCode.replace_active(member, token: "12345", transport: "sms")
       end.to perform_async_job(Suma::Async::ResetCodeCreateDispatch)
 
       expect(Suma::Message::Delivery.all).to contain_exactly(

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe Suma::Member::Exporter, :db do
     LINES
     expect(csv).to eq(lines)
   end
+
+  it "adds a space before values that start with an equal sign to avoid exporing a macro" do
+    member = Suma::Fixtures.member.create(name: "=1+1")
+    csv = described_class.new(Suma::Member.dataset).to_csv
+    expect(csv).to include("#{member.id}, =1+1")
+  end
 end


### PR DESCRIPTION
Sanitize CSV export to avoid implicit macros

---

Expire reset codes when a new one is requested

---

Tighten up offering visibility for constraints

Some endpoints were not checking if an offering
was eligible for a user.
