### PR TITLE
Checkout raise error if member unverified

### DIFF
--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -157,6 +157,8 @@ class Suma::API::Commerce < Suma::API::V1
             checkout.save_changes
             begin
               checkout.create_order(apply_at: now, cash_charge_amount: Money.new(params[:charge_amount_cents]))
+            rescue Suma::Member::ReadOnlyMode
+              merror!(403, "member unverified", code: "read_only_unverified")
             rescue Suma::Commerce::Checkout::Prohibited => e
               merror!(409, "Checkout prohibited: #{e.reason}", code: "checkout_fatal_error")
             rescue Suma::Commerce::Checkout::MaxQuantityExceeded

--- a/lib/suma/commerce/checkout.rb
+++ b/lib/suma/commerce/checkout.rb
@@ -169,6 +169,7 @@ class Suma::Commerce::Checkout < Suma::Postgres::Model(:commerce_checkouts)
       self.cart.lock!
       # Locking the checkout ensures we don't process it multiple times as a race
       self.lock!
+      raise Suma::Member::ReadOnlyMode if self.cart.member.read_only_reason === "read_only_unverified"
       # This isn't ideal- it'd be better
       if (prohibition_reason = self.cost_info(at: apply_at).checkout_prohibited_reason)
         raise Prohibited.new(

--- a/spec/suma/commerce/cart_spec.rb
+++ b/spec/suma/commerce/cart_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe "Suma::Commerce::Cart", :db do
 
     def create_fake_order(cart)
       member = cart.member
+      member.update(onboarding_verified_at: Time.now)
       Suma::Fixtures::Members.register_as_stripe_customer(member)
       Suma::Payment.ensure_cash_ledger(member)
       card = Suma::Fixtures.card.member(member).create

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
   end
 
   describe "checkout_prohibited_reason" do
-    let(:member) { Suma::Fixtures.member.create }
+    let(:member) { Suma::Fixtures.member.onboarding_verified.create }
     let(:offering) { Suma::Fixtures.offering.create }
     let(:cart) { Suma::Fixtures.cart(member:, offering:).with_any_product.create }
     let(:checkout) { Suma::Fixtures.checkout(cart:).populate_items.with_payment_instrument.create }
@@ -107,7 +107,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
   end
 
   describe "create_order" do
-    let(:member) { Suma::Fixtures.member.registered_as_stripe_customer.create }
+    let(:member) { Suma::Fixtures.member.onboarding_verified.registered_as_stripe_customer.create }
     let(:offering) { Suma::Fixtures.offering.create }
     let!(:fulfillment) { Suma::Fixtures.offering_fulfillment_option(offering:).create }
     let(:product) { Suma::Fixtures.product.category(:food).create }
@@ -129,9 +129,18 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       checkout_.create_order(apply_at: Time.now, cash_charge_amount: amount)
     end
 
-    it "errors if charging is prohibited" do
+    it "raises if charging is prohibited" do
       checkout.soft_delete
       expect { create_order }.to raise_error(described_class::Prohibited, /not_editable/)
+    end
+
+    it "raises if member is unverified" do
+      unverified = Suma::Fixtures.member.registered_as_stripe_customer.with_cash_ledger.create
+      card = Suma::Fixtures.card.member(unverified).create
+      cart = Suma::Fixtures.cart(offering:, member: unverified).with_product(product, 2).create
+      checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+
+      expect { create_order(checkout_: checkout) }.to raise_error(Suma::Member::ReadOnlyMode)
     end
 
     it "creates the order from the checkout" do
@@ -236,7 +245,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         cash_vsc = Suma::Vendor::ServiceCategory.cash
         food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
         holidaymeal_vsc = Suma::Fixtures.vendor_service_category(name: "Holiday Special", parent: food_vsc).create
-        member = Suma::Fixtures.member.create
+        member = Suma::Fixtures.member.onboarding_verified.create
 
         cash_ledger = Suma::Payment.ensure_cash_ledger(member)
         ledger_fac = Suma::Fixtures.ledger.member(member)
@@ -306,7 +315,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         top_vsc = Suma::Fixtures.vendor_service_category(name: "Everything").create
         mid_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: top_vsc).create
         low_vsc = Suma::Fixtures.vendor_service_category(name: "Organic", parent: mid_vsc).create
-        member = Suma::Fixtures.member.create
+        member = Suma::Fixtures.member.onboarding_verified.create
 
         cash_ledger = Suma::Payment.ensure_cash_ledger(member)
         top_ledger = Suma::Fixtures.ledger.member(member).with_categories(top_vsc).create


### PR DESCRIPTION
Part of DeepArmor phase 1-2 fixes.
Prohibits creating checkout orders if a member has not onboarded or is unverified by raising a localized error code 'read_only_unverified' to the webapp for members to view.