### PR TITLE
Switch to serverside sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem "signalwire"
 gem "state_machines"
 gem "stripe"
 gem "twilio-ruby", "~> 5.74"
-gem "warden"
 gem "yajl-ruby"
 
 # By default, Heroku ignores 'test' gem groups.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,8 +313,6 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
-    warden (1.2.9)
-      rack (>= 2.0.9)
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -402,7 +400,6 @@ DEPENDENCIES
   stripe
   timecop
   twilio-ruby (~> 5.74)
-  warden
   webmock
   yajl-ruby
 

--- a/db/migrations/048_database_sessions.rb
+++ b/db/migrations/048_database_sessions.rb
@@ -3,19 +3,25 @@
 Sequel.migration do
   up do
     alter_table(:member_sessions) do
-      add_column :opaque_id, :text, unique: true
+      add_column :token, :text, unique: true
       add_column :logged_out_at, :timestamptz
+      add_foreign_key :impersonating_id, :members, on_delete: :set_null
     end
+
     from(:member_sessions).
-      update(opaque_id: Sequel.function(:concat, "ses_", Sequel.function(:gen_random_uuid)))
-    # alter_table(:member_sessions) do
-    #   set_column_not_null(:opaque_id)
-    # end
+      update(token: Sequel.function(:concat, "ses_", Sequel.function(:gen_random_uuid)))
+
+    alter_table(:member_sessions) do
+      set_column_not_null(:token)
+    end
   end
+
   down do
     alter_table(:member_sessions) do
-      drop_column :opaque_id
+      drop_column :token
       drop_column :logged_out_at
+      drop_column :last_access_at
+      drop_column :impersonating_id
     end
   end
 end

--- a/db/migrations/048_database_sessions.rb
+++ b/db/migrations/048_database_sessions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:member_sessions) do
+      add_column :opaque_id, :text, unique: true
+      add_column :logged_out_at, :timestamptz
+    end
+    from(:member_sessions).
+      update(opaque_id: Sequel.function(:concat, "ses_", Sequel.function(:gen_random_uuid)))
+    # alter_table(:member_sessions) do
+    #   set_column_not_null(:opaque_id)
+    # end
+  end
+  down do
+    alter_table(:member_sessions) do
+      drop_column :opaque_id
+      drop_column :logged_out_at
+    end
+  end
+end

--- a/lib/suma/admin_api/auth.rb
+++ b/lib/suma/admin_api/auth.rb
@@ -31,7 +31,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
     end
 
     delete do
-      delete_session_cookies
+      logout
       status 204
       body ""
     end
@@ -40,7 +40,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
     resource :impersonate do
       desc "Remove any active impersonation and return the admin member."
       delete do
-        Suma::Service::Auth::Impersonation.new(env["warden"]).off(admin_member)
+        Suma::Service::Auth::Impersonation.new(env.fetch("yosoy")).off(admin_member)
 
         status 200
         present admin_member, with: CurrentMemberEntity, env:
@@ -51,7 +51,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
         post do
           (target = Suma::Member[params[:member_id]]) or forbidden!
 
-          Suma::Service::Auth::Impersonation.new(env["warden"]).on(target)
+          Suma::Service::Auth::Impersonation.new(env["yosoy"]).on(target)
 
           status 200
           present admin_member, with: CurrentMemberEntity, env:

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -36,7 +36,7 @@ module Suma::AdminAPI::Entities
 
   class CurrentMemberEntity < Suma::Service::Entities::CurrentMember
     expose :impersonating, with: Suma::Service::Entities::CurrentMember do |_|
-      self.impersonation.is? ? self.impersonation.current_member : nil
+      self.current_session.impersonating
     end
   end
 

--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -77,8 +77,8 @@ class Suma::API::Auth < Suma::API::V1
         merror!(403, "Sorry, that token is invalid or the phone number is not in our system.", code: "invalid_otp")
       end
 
-      set_member(me)
-      create_session(me)
+      session = create_session(me)
+      set_session(session)
       status 200
       present me, with: CurrentMemberEntity, env:
     end

--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -84,7 +84,7 @@ class Suma::API::Auth < Suma::API::V1
     end
 
     delete do
-      delete_session_cookies
+      logout
       status 204
       body ""
     end

--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -93,7 +93,7 @@ module Suma::API::Entities
     expose :read_only_reason
     expose :usable_payment_instruments, with: PaymentInstrumentEntity
     expose :admin_member, expose_nil: false, with: Suma::Service::Entities::CurrentMember do |_|
-      self.impersonation.is? ? self.impersonation.admin_member : nil
+      self.current_session.impersonation? ? self.current_session.member : nil
     end
     expose :show_private_accounts do |m|
       !Suma::AnonProxy::VendorAccount.for(m).empty?

--- a/lib/suma/fixtures/sessions.rb
+++ b/lib/suma/fixtures/sessions.rb
@@ -14,6 +14,7 @@ module Suma::Fixtures::Sessions
   base :session do
     self.peer_ip ||= Faker::Internet.ip_v4_address
     self.user_agent ||= Faker::Internet.user_agent
+    self.opaque_id ||= SecureRandom.uuid
   end
 
   before_saving do |instance|

--- a/lib/suma/fixtures/sessions.rb
+++ b/lib/suma/fixtures/sessions.rb
@@ -14,7 +14,6 @@ module Suma::Fixtures::Sessions
   base :session do
     self.peer_ip ||= Faker::Internet.ip_v4_address
     self.user_agent ||= Faker::Internet.user_agent
-    self.opaque_id ||= SecureRandom.uuid
   end
 
   before_saving do |instance|
@@ -22,29 +21,13 @@ module Suma::Fixtures::Sessions
     instance
   end
 
-  decorator :android_webview do
-    self.user_agent = "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 " \
-                      "(KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36"
+  decorator :for do |member=nil|
+    member = Suma::Fixtures.member(**member).create unless member.is_a?(Suma::Member)
+    self.member = member
   end
 
-  decorator :ios_webview do
-    self.user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) " \
-                      "AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H141"
-  end
-
-  decorator :android_app do
-    self.user_agent = "com.mysuma.suma / 1.0.4-android OS/Android-11 BuildTime/1613071039431 Device/Pixel 2"
-  end
-
-  decorator :ios_app do
-    self.user_agent = "com.mysuma.suma / 2.20.40-ios OS/iOS-13.5 BuildTime/1613071039431 Device/iPhone"
-  end
-
-  decorator :android_default do
-    self.user_agent = "okhttp/3.12.1"
-  end
-
-  decorator :ios_default do
-    self.user_agent = "MySuma/1.0.3 CFNetwork/1128.0.1 Darwin/19.6.0"
+  decorator :impersonating do |member=nil|
+    member = Suma::Fixtures.member(**member).create unless member.is_a?(Suma::Member)
+    self.impersonating = member
   end
 end

--- a/lib/suma/member/session.rb
+++ b/lib/suma/member/session.rb
@@ -20,6 +20,7 @@ class Suma::Member::Session < Suma::Postgres::Model(:member_sessions)
     self.validates_presence :peer_ip
     self.validates_presence :user_agent
     self.validates_presence :member_id
+    # self.validates_presence :opaque_id
   end
 end
 

--- a/lib/suma/service.rb
+++ b/lib/suma/service.rb
@@ -110,7 +110,7 @@ class Suma::Service < Grape::API
   # See https://github.com/ruby-grape/grape#register-custom-middleware-for-authentication
   Grape::Middleware::Auth::Strategies.add(
     :admin,
-    Suma::Yosoy::BlockAuthenticatorMiddleware.new(->(proxy) { proxy.authenticated!(:admin).admin? }),
+    Suma::Yosoy::BlockAuthenticatorMiddleware.new(->(proxy) { proxy.authenticated_object!.member.admin? }),
   )
 
   # Add some context to Sentry on each request.

--- a/lib/suma/service.rb
+++ b/lib/suma/service.rb
@@ -8,7 +8,6 @@ require "sentry-ruby"
 require "sequel"
 require "sequel/adapters/postgres"
 require "set"
-require "warden"
 
 require "suma"
 require "suma/i18n"
@@ -107,7 +106,12 @@ class Suma::Service < Grape::API
     return {error:}
   end
 
-  Grape::Middleware::Auth::Strategies.add(:admin, Suma::Service::Auth::Admin)
+  # Middleware to use for Grape admin auth.
+  # See https://github.com/ruby-grape/grape#register-custom-middleware-for-authentication
+  Grape::Middleware::Auth::Strategies.add(
+    :admin,
+    Suma::Yosoy::BlockAuthenticatorMiddleware.new(->(proxy) { proxy.authenticated!(:admin).admin? }),
+  )
 
   # Add some context to Sentry on each request.
   before do

--- a/lib/suma/service/auth.rb
+++ b/lib/suma/service/auth.rb
@@ -24,15 +24,6 @@ module Suma::Service::Auth
   class Middleware < Suma::Yosoy::Middleware
     def serialize_into_session(session, _env) = session.token
 
-    # TODO: Support legacy sessions
-    # else
-    #   # Legacy sessions used member id as the key. Find or create a session.
-    #   if (member = Suma::Member[key])
-    #     member.sessions_dataset.order(:created_at).last ||
-    #       member.add_session(**Suma::Member::Session.params_for_request(Rack::Request.new(env)))
-    #   end
-    # end
-
     def serialize_from_session(key, _env)
       Suma::Member::Session.dataset.valid[token: key]
     end

--- a/lib/suma/service/auth.rb
+++ b/lib/suma/service/auth.rb
@@ -1,155 +1,18 @@
 # frozen_string_literal: true
 
-require "appydays/configurable"
-require "warden"
+require "suma/yosoy"
 
 class Suma::Service::Auth
-  include Appydays::Configurable
-
-  class PasswordStrategy < Warden::Strategies::Base
-    def valid?
-      params["password"] && (params["phone"] || params["email"])
-    end
-
-    def authenticate!
-      member = self.lookup_member
-      success!(member) if member
-    end
-
-    protected def lookup_member
-      if params["phone"]
-        member = Suma::Member.with_us_phone(params["phone"].strip)
-        if member.nil?
-          fail!("No member with that phone")
-          return nil
-        end
-      else
-        member = Suma::Member.with_email(params["email"].strip)
-        if member.nil?
-          fail!("No member with that email")
-          return nil
-        end
-      end
-      return member if member.authenticate(params["password"])
-      fail!("Incorrect password")
-      return nil
-    end
+  class Middleware < Suma::Yosoy::Middleware
+    def serialize_into_session(user) = user.pk
+    def serialize_from_session(key) = Suma::Member[key]
+    def inactivity_timeout = Suma::Service.max_session_age
   end
 
-  class AdminPasswordStrategy < PasswordStrategy
-    def authenticate!
-      return unless (member = self.lookup_member)
-      unless member.admin?
-        fail!
-        return
-      end
-      success!(member)
-    end
-  end
-
-  # Create the middleware for a Warden auth failure.
-  # Is not a 'normal' Rack middleware, which normally accepts 'app' in the initializer and has
-  # 'call' as an instance method.
-  # See https://github.com/wardencommunity/warden/wiki/Setup
-  class FailureApp
-    def self.call(env)
-      warden_opts = env.fetch("warden.options", {})
-      msg = warden_opts[:message] || env["suma.authfailuremessage"] || "Unauthorized"
-      body = Suma::Service.error_body(401, msg)
-      return 401, {"Content-Type" => "application/json"}, [body.to_json]
-    end
-  end
-
-  # Middleware to use for Grape admin auth.
-  # See https://github.com/ruby-grape/grape#register-custom-middleware-for-authentication
-  class Admin
-    def initialize(app, *_args)
-      @app = app
-    end
-
-    def call(env)
-      warden = env["warden"]
-      member = warden.authenticate!(scope: :admin)
-
-      unless member.admin?
-        body = Suma::Service.error_body(401, "Unauthorized")
-        return 401, {"Content-Type" => "application/json"}, [body.to_json]
-      end
-      return @app.call(env)
-    end
-  end
-
-  Warden::Manager.serialize_into_session(&:id)
-  Warden::Manager.serialize_from_session { |id| Suma::Member[id] }
-  Warden::Manager.after_set_user do |_user, auth, opts|
-    # Store the 'last access' timestamp for this user session, and refresh it on every request.
-    # If the timestamp is too old, reject the session.
-    # This avoids a replay attack using an old cookie; even though the cookie itself gets an expires_at,
-    # it can still be reused by an attacker later. Since the contents of the cookie are encrypted,
-    # they cannot modify the last_access value stored in the session.
-    scope = opts[:scope]
-    # If there is no last_access timestamp, this is the initial session auth, or it's a legacy cookie (pre-May 2024).
-    # Since we don't want to log everyone out when this ships, we allow these legacy sessions to continue.
-    if (ts = auth.session(scope)["last_access"])
-      ts = Time.parse(ts)
-      expire_at = ts + Suma::Service.max_session_age
-      if Time.now > expire_at
-        auth.logout(scope)
-        throw(:warden, scope:, reason: "Cookie expired")
-      end
-    end
-    auth.session(scope)["last_access"] = Time.now.iso8601
-  end
-
-  Warden::Strategies.add(:password, PasswordStrategy)
-  Warden::Strategies.add(:admin_password, AdminPasswordStrategy)
-
-  # Restore the /unauthenticated route to what it originally was.
-  # This is an API, not a rendered app...
-  Warden::Manager.before_failure do |env, opts|
-    env["PATH_INFO"] = opts[:attempted_path]
-  end
-
-  def self.add_warden_middleware(builder)
-    builder.use Warden::Manager do |manager|
-      # manager.default_strategies :password
-      manager.failure_app = FailureApp
-
-      manager.scope_defaults(:member, strategies: [:password])
-      manager.scope_defaults(:admin, strategies: [:admin_password])
-    end
-  end
-
-  class Impersonation
-    attr_reader :warden
-
-    def initialize(warden)
-      @warden = warden
-    end
-
-    def is?
-      return false unless self.warden.authenticated?(:admin)
-      return self.warden.session(:admin)["impersonating"].present?
-    end
-
-    def current_member
-      return self.warden.authenticate!(scope: :member)
-    end
-
-    def admin_member
-      return self.warden.authenticate!(scope: :admin)
-    end
-
-    def on(target_member)
-      self.warden.session(:admin)["impersonating"] = target_member.id
-      self.warden.logout(:member)
-      self.warden.set_user(target_member, scope: :member)
-    end
-
-    def off(admin_member)
-      self.warden.logout(:member)
-      self.warden.session(:admin).delete("impersonating")
-      self.warden.set_user(admin_member, scope: :member)
-    end
+  class Impersonation < Suma::Yosoy::Impersonation
+    def target_scope = :member
+    def parent_scope = :admin
+    def current_member = self.target_user
+    def admin_member = self.parent_user
   end
 end

--- a/lib/suma/service/auth.rb
+++ b/lib/suma/service/auth.rb
@@ -2,17 +2,27 @@
 
 require "suma/yosoy"
 
-class Suma::Service::Auth
-  class Middleware < Suma::Yosoy::Middleware
-    def serialize_into_session(user) = user.pk
-    def serialize_from_session(key) = Suma::Member[key]
-    def inactivity_timeout = Suma::Service.max_session_age
-  end
+module Suma::Service::Auth
+  X = 1
 
-  class Impersonation < Suma::Yosoy::Impersonation
-    def target_scope = :member
-    def parent_scope = :admin
-    def current_member = self.target_user
-    def admin_member = self.parent_user
+  class Middleware < Suma::Yosoy::Middleware
+    def serialize_into_session(session, _env) = session.token
+
+    # TODO: Support legacy sessions
+    # else
+    #   # Legacy sessions used member id as the key. Find or create a session.
+    #   if (member = Suma::Member[key])
+    #     member.sessions_dataset.order(:created_at).last ||
+    #       member.add_session(**Suma::Member::Session.params_for_request(Rack::Request.new(env)))
+    #   end
+    # end
+
+    def serialize_from_session(key, _env)
+      Suma::Member::Session.dataset.valid[token: key]
+    end
+
+    def inactivity_timeout
+      Suma::Service.max_session_age
+    end
   end
 end

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -89,7 +89,7 @@ module Suma::Service::Entities
     end
     protected def impersonation(env=nil)
       env ||= options[:env]
-      return @impersonation ||= Suma::Service::Auth::Impersonation.new(env["warden"])
+      return @impersonation ||= Suma::Service::Auth::Impersonation.new(env.fetch("yosoy"))
     end
   end
 

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -87,9 +87,11 @@ module Suma::Service::Entities
     expose :roles do |instance|
       instance.roles.map(&:name)
     end
-    protected def impersonation(env=nil)
-      env ||= options[:env]
-      return @impersonation ||= Suma::Service::Auth::Impersonation.new(env.fetch("yosoy"))
+    protected def current_session
+      env = options.fetch(:env)
+      yosoy = env.fetch("yosoy")
+      @current_session ||= yosoy.authenticated_object!
+      return @current_session
     end
   end
 

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -70,36 +70,6 @@ module Suma::Service::Helpers
     return m
   end
 
-  # Handle denying authentication if the given session is valid for auth.
-  # That is:
-  # - if we have an admin, but they should not be (deleted or missing role), throw unauthed error.
-  # - if current user is nil, return nil, since the caller can handle it.
-  # - if current user is deleted and there is no admin, throw unauthed error.
-  # - if current user is deleted and admin is deleted, throw unauthed error.
-  # - otherwise, return current user.
-  #
-  # The scenarios this covers are:
-  # - Normal users cannot auth if deleted.
-  # - Admins can sudo deleted users, and current_member still works.
-  # - Deleted admins cannot auth or get their sudo'ed user.
-  #
-  # NOTE: It is safe to throw unauthed errors for deleted users-
-  # this does not expose whether a user exists or not,
-  # because the only way to call this is via cookies,
-  # and cookies are encrypted. So it is impossible to force requests
-  # trying to auth/check auth for a user without knowing the secret.
-  #
-  # @param session [Suma::Member::Session,nil]
-  # @param potential_admin [Suma::Member,nil]
-  def _check_member_deleted(session, potential_admin)
-    return nil if session.nil?
-    unauthenticated! if
-      potential_admin && (potential_admin.soft_deleted? || !potential_admin.admin?)
-    member = session.member
-    unauthenticated! if member.soft_deleted? && potential_admin.nil?
-    return member
-  end
-
   def logout
     current_session?&.mark_logged_out&.save_changes
     options = env[Rack::RACK_SESSION_OPTIONS]

--- a/lib/suma/service/middleware.rb
+++ b/lib/suma/service/middleware.rb
@@ -17,7 +17,7 @@ module Suma::Service::Middleware
     self.add_ssl_middleware(builder) if Suma::Service.enforce_ssl
     self.add_session_middleware(builder)
     self.add_security_middleware(builder)
-    Suma::Service::Auth.add_warden_middleware(builder)
+    self.add_auth_middleware(builder)
     self.add_etag_middleware(builder)
     builder.use(RequestLogger)
   end
@@ -64,6 +64,10 @@ module Suma::Service::Middleware
     # builder.use Rack::Protection, except: :session_hijacking
   end
 
+  def self.add_auth_middleware(builder)
+    builder.use Suma::Service::Auth::Middleware
+  end
+
   def self.add_etag_middleware(builder)
     builder.use Rack::ConditionalGet
     builder.use Rack::ETag
@@ -85,7 +89,7 @@ module Suma::Service::Middleware
   class RequestLogger < Appydays::Loggable::RequestLogger
     def request_tags(env)
       tags = super
-      tags[:member_id] = env["warden"].user(:member)&.id || 0
+      tags[:member_id] = env["yosoy"].authenticated?(:member)&.id || 0
       return tags
     end
   end

--- a/lib/suma/service/middleware.rb
+++ b/lib/suma/service/middleware.rb
@@ -65,6 +65,7 @@ module Suma::Service::Middleware
   end
 
   def self.add_auth_middleware(builder)
+    builder.use Suma::Service::Auth::LegacySessionAdapterMiddleware
     builder.use Suma::Service::Auth::Middleware
   end
 

--- a/lib/suma/service/middleware.rb
+++ b/lib/suma/service/middleware.rb
@@ -89,7 +89,7 @@ module Suma::Service::Middleware
   class RequestLogger < Appydays::Loggable::RequestLogger
     def request_tags(env)
       tags = super
-      tags[:member_id] = env["yosoy"].authenticated?(:member)&.id || 0
+      tags[:member_id] = env["yosoy"].authenticated_object?&.member_id || 0
       return tags
     end
   end

--- a/lib/suma/spec_helpers/service.rb
+++ b/lib/suma/spec_helpers/service.rb
@@ -4,7 +4,6 @@ require "appydays/loggable"
 require "pathname"
 require "rack/test"
 require "rspec"
-require "warden"
 require "yajl"
 
 require "suma/spec_helpers"
@@ -12,12 +11,7 @@ require "suma/spec_helpers"
 module Suma::SpecHelpers::Service
   def self.included(context)
     context.include(SumaTestMethods)
-
-    ::Warden.test_mode!
-
     super
-
-    context.after(:each) { Warden.test_reset! }
   end
 
   def last_session_id
@@ -26,31 +20,29 @@ module Suma::SpecHelpers::Service
     return session["session_id"]
   end
 
-  def login_as(member, opts=nil)
-    opts ||= {scope: :member}
-    Warden.on_next_request do |proxy|
-      opts[:event] ||= :authentication
-      proxy.set_user(member, opts)
+  def login_as(member, scope: :member)
+    Suma::Yosoy.on_next_request do |proxy|
+      proxy.set_user(member, scope)
     end
   end
 
-  def login_as_admin(member, opts={})
-    login_as(member, opts.merge(scope: :member))
-    login_as(member, opts.merge(scope: :admin))
+  def login_as_admin(member)
+    login_as(member, scope: :member)
+    login_as(member, scope: :admin)
   end
 
   def impersonate(admin: nil, target: nil)
     admin ||= Suma::Fixtures.member.admin.create
     target ||= Suma::Fixtures.member.create
-    Warden.on_next_request do |proxy|
-      proxy.set_user(admin, event: :authentication, scope: :admin)
-      proxy.set_user(target, event: :authentication, scope: :member)
+    Suma::Yosoy.on_next_request do |proxy|
+      proxy.set_user(admin, :admin)
+      proxy.set_user(target, :member)
       Suma::Service::Auth::Impersonation.new(proxy).on(target)
     end
   end
 
   def logout(*scopes)
-    Warden.on_next_request do |proxy|
+    Suma::Yosoy.on_next_request do |proxy|
       proxy.logout(*scopes)
     end
   end

--- a/lib/suma/yosoy.rb
+++ b/lib/suma/yosoy.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+# Bare-bones Rack-based authentication library.
+# After a decade of using Warden and Grape we decided to just write our auth system for our needs.
+# This just manages authentication, not authorization,
+# and does not manage application-level concerns like OTPs, password reset, etc.
+class Suma::Yosoy
+  class << self
+    attr_accessor :_on_next_request
+
+    def on_next_request(&block)
+      @_on_next_request ||= []
+      @_on_next_request << block
+    end
+  end
+
+  # Subclassable middleware class.
+  # If throw(:yosoy, :somemethod) is used, the #somemethod method will be called to get the response.
+  # You can also override #response to provide a different response shape.
+  class Middleware
+    def initialize(app)
+      @app = app
+      @_on_next_request = []
+    end
+
+    # Used for environment lookup, like `env['yosoy']`
+    def env_key = "yosoy"
+
+    # Key for use in `throw(:yosoy)` that is caught by the middleware.
+    def throw_key = :yosoy
+
+    # Seconds after which a session will no longer be used,
+    # usually the same as a cookie expiration if using cookies.
+    # Nil to disable the inactivity timeout.
+    def inactivity_timeout = nil
+
+    def call(env)
+      proxy = Proxy.new(self, env)
+      env[self.env_key] = proxy
+      result = catch(self.throw_key) do
+        Suma::Yosoy._on_next_request&.each do |cb|
+          cb.call(proxy)
+        end
+        Suma::Yosoy._on_next_request&.clear
+        @app.call(env)
+      end
+      case result
+        when Hash
+          tag = result.delete(:tag)
+          extra = result
+        when Symbol
+          extra = {}
+          tag = result
+      else
+          return result
+      end
+      response = self.send(tag, **extra)
+      return response
+    end
+
+    def response(status_code, extra={})
+      headers = {
+        "Content-Type" => "application/json",
+      }
+      body = {error: {status: status_code, **extra}}
+      return [
+        status_code,
+        headers,
+        [body.to_json],
+      ]
+    end
+
+    def unauthenticated(**extra) = response(401, {code: "unauthenticated", **extra})
+
+    def serialize_into_session(_user) = raise NotImplementedError("Something like `user.id`")
+    def serialize_from_session(_key) = raise NotImplementedError("Something like `User[key]`")
+
+    # Rack session key for Yosoy.
+    def session_key(scope) = "yosoy.sessions.#{scope}"
+
+    #   # Store the 'last access' timestamp for this user session, and refresh it on every request.
+    #   # If the timestamp is too old, reject the session.
+    #   # This avoids a replay attack using an old cookie; even though the cookie itself gets an expires_at,
+    #   # it can still be reused by an attacker later. Since the contents of the cookie are encrypted,
+    #   # they cannot modify the last_access value stored in the session.
+    #   scope = opts[:scope]
+    #   # If there is no last_access timestamp, this is the initial session auth, or it's a legacy cookie (pre-May 2024).
+    #   # Since we don't want to log everyone out when this ships, we allow these legacy sessions to continue.
+    #   if (ts = auth.session(scope)["last_access"])
+    #     ts = Time.parse(ts)
+    #     expire_at = ts + Suma::Service.max_session_age
+    #     if Time.now > expire_at
+    #       auth.logout(scope)
+    #       throw(:warden, scope:, reason: "Cookie expired")
+    #     end
+    #   end
+    #   auth.session(scope)["last_access"] = Time.now.iso8601
+  end
+
+  class Proxy
+    attr_accessor :middleware, :env
+
+    def initialize(middleware, env)
+      @middleware = middleware
+      @env = env
+      @auth_ran = {}
+      @authed_users = {}
+      @last_access_set = false
+    end
+
+    def rack_session
+      return @rack_session ||= @env["rack.session"]
+    end
+
+    def reset!
+      @auth_ran.clear
+      @authed_users.clear
+      @last_access_set = false
+    end
+
+    def authenticated?(scope)
+      return @authed_users[scope] if @auth_ran[scope]
+      key = self.get_session_value(scope, "key")
+      return nil if key.nil?
+      user = @middleware.serialize_from_session(key)
+      @authed_users[scope] = user
+      @auth_ran[scope] = true
+      self._check_last_access
+      self._mark_last_access
+      return user
+    end
+
+    def authenticated!(scope)
+      u = self.authenticated?(scope)
+      self.unauthenticated! if u.nil?
+      return u
+    end
+
+    def set_user(user, scope)
+      self.set_session_value(scope, "key", @middleware.serialize_into_session(user))
+    end
+
+    def unauthenticated!(**kw)
+      self.throw!(:unauthenticated, **kw)
+    end
+
+    def throw!(tag, **kw)
+      throw(@middleware.throw_key, {tag:, **kw})
+    end
+
+    def get_session_value(scope, key, default=nil)
+      session = _get_session(scope)
+      return default if session.nil?
+      return session.fetch(key, default)
+    end
+
+    def set_session_value(scope, key, value)
+      if (session = _get_session(scope)).nil?
+        session = {}
+        self.rack_session[self.middleware.session_key(scope)] = session
+      end
+      session[key] = value
+      session
+    end
+
+    def delete_session_value(scope, key)
+      session = _get_session(scope)
+      return if session.nil?
+      session.delete(key)
+    end
+
+    def _get_session(scope)
+      return self.rack_session[self.middleware.session_key(scope)]
+    end
+
+    # Store the 'last access' timestamp for this scope session, and refresh it on every authed request.
+    # If the timestamp is too old, reject the session.
+    # This avoids a replay attack using an old cookie; even though the cookie itself gets an expires_at,
+    # it can still be reused by an attacker later. Since the contents of the cookie are encrypted,
+    # they cannot modify the last_access value stored in the session.
+    def _mark_last_access
+      return if @last_access_set
+      self.rack_session["yosoy.last_access"] = Time.now.iso8601
+    end
+
+    def _check_last_access
+      return if self.middleware.inactivity_timeout.nil?
+      ts = self.rack_session["yosoy.last_access"]
+      # If there is no last_access timestamp, this is the initial session auth, or it's a legacy cookie.
+      # Since we don't want to log everyone out when this ships, we allow these legacy sessions to continue.
+      return if ts.nil?
+      ts = Time.parse(ts)
+      expire_at = ts + self.middleware.inactivity_timeout
+      return unless Time.now > expire_at
+      self.logout
+      self.unauthenticated!(reason: "Cookie expired")
+    end
+
+    def logout(*scopes)
+      if scopes.empty?
+        self.rack_session.keys.select { |k| k.start_with?("yosoy.") }.to_a.each do |key|
+          self.rack_session.delete(key)
+        end
+      else
+        scopes.each do |scope|
+          self.rack_session.delete(self.middleware.session_key(scope))
+        end
+      end
+      self.reset!
+    end
+  end
+
+  # Middleware that fails authentication if the callback proc returns falsy.
+  # Block is called with a +Proxy+.
+  class BlockAuthenticatorMiddleware
+    def initialize(callback)
+      @callback = callback
+      @app = nil
+    end
+
+    def env_key = "yosoy"
+
+    def new(app)
+      @app = app
+    end
+
+    def call(env)
+      proxy = env.fetch(self.env_key)
+      ok = @callback.call(proxy)
+      proxy.unauthenticated! unless ok
+      return @app.call(env)
+    end
+  end
+
+  class Impersonation
+    attr_reader :proxy
+
+    def initialize(proxy)
+      @proxy = proxy
+    end
+
+    def target_scope = raise NotImplementedError("Something like :user")
+    def parent_scope = raise NotImplementedError("Something like :admin")
+
+    def is?
+      return false unless self.proxy.authenticated?(self.parent_scope)
+      return self.proxy.get_session_value(self.parent_scope, "parent").present?
+    end
+
+    def target_user
+      return self.proxy.authenticated!(self.target_scope)
+    end
+
+    def parent_user
+      return self.proxy.authenticated!(self.parent_scope)
+    end
+
+    def on(target)
+      self.proxy.set_session_value(self.parent_scope, "parent", target.id)
+      self.proxy.logout(self.target_scope)
+      self.proxy.set_user(target, self.target_scope)
+    end
+
+    def off(parent)
+      self.proxy.logout(self.target_scope)
+      self.proxy.delete_session_value(self.parent_scope, "parent")
+      self.proxy.set_user(parent, self.target_scope)
+    end
+  end
+end

--- a/spec/suma/admin_api/anon_proxy_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::AnonProxy, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/anon_proxy/vendor_accounts" do

--- a/spec/suma/admin_api/auth_spec.rb
+++ b/spec/suma/admin_api/auth_spec.rb
@@ -100,11 +100,13 @@ RSpec.describe Suma::AdminAPI::Auth, :db do
   end
 
   describe "DELETE /v1/auth" do
-    it "removes the cookies" do
+    it "removes the cookies and marks the session deleted" do
       delete "/v1/auth"
 
       expect(last_response).to have_status(204)
       expect(last_response["Set-Cookie"]).to include("=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00")
+      expect(last_response["Clear-Site-Data"]).to eq("*")
+      expect(admin.sessions.last).to be_logged_out
     end
   end
 

--- a/spec/suma/admin_api/bank_accounts_spec.rb
+++ b/spec/suma/admin_api/bank_accounts_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::BankAccounts, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/bank_accounts/:id" do

--- a/spec/suma/admin_api/book_transactions_spec.rb
+++ b/spec/suma/admin_api/book_transactions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::BookTransactions, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/book_transactions" do

--- a/spec/suma/admin_api/commerce_offering_products_spec.rb
+++ b/spec/suma/admin_api/commerce_offering_products_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::CommerceOfferingProducts, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "POST /v1/commerce_offering_products/create" do

--- a/spec/suma/admin_api/commerce_offerings_spec.rb
+++ b/spec/suma/admin_api/commerce_offerings_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::CommerceOfferings, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/commerce_offerings" do

--- a/spec/suma/admin_api/commerce_orders_spec.rb
+++ b/spec/suma/admin_api/commerce_orders_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::CommerceOrders, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/commerce_orders" do

--- a/spec/suma/admin_api/commerce_products_spec.rb
+++ b/spec/suma/admin_api/commerce_products_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::CommerceProducts, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/commerce_products" do

--- a/spec/suma/admin_api/eligibility_constraints_spec.rb
+++ b/spec/suma/admin_api/eligibility_constraints_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::EligibilityConstraints, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/eligibility_constraints" do

--- a/spec/suma/admin_api/funding_transactions_spec.rb
+++ b/spec/suma/admin_api/funding_transactions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::FundingTransactions, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/funding_transactions" do

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::Members, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/members" do
@@ -112,7 +112,6 @@ RSpec.describe Suma::AdminAPI::Members, :db do
     end
 
     it "represents detailed info" do
-      Suma::Fixtures.session(member: admin, peer_ip: "1.2.3.4").create
       cash_ledger = Suma::Fixtures.ledger.member(admin).category(:cash).create
       charge1 = Suma::Fixtures.charge(member: admin).create
       charge1.add_book_transaction(Suma::Fixtures.book_transaction.from(cash_ledger).create)
@@ -121,7 +120,7 @@ RSpec.describe Suma::AdminAPI::Members, :db do
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
-        sessions: contain_exactly(include(ip_lookup_link: "https://whatismyipaddress.com/ip/1.2.3.4")),
+        sessions: contain_exactly(include(:ip_lookup_link)),
       )
     end
   end

--- a/spec/suma/admin_api/message_deliveries_spec.rb
+++ b/spec/suma/admin_api/message_deliveries_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::MessageDeliveries, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/message_deliveries" do

--- a/spec/suma/admin_api/meta_spec.rb
+++ b/spec/suma/admin_api/meta_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Suma::AdminAPI::Meta, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/meta/currencies" do

--- a/spec/suma/admin_api/organization_memberships_spec.rb
+++ b/spec/suma/admin_api/organization_memberships_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Suma::AdminAPI::OrganizationMemberships, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/organization_memberships" do

--- a/spec/suma/admin_api/organizations_spec.rb
+++ b/spec/suma/admin_api/organizations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::Organizations, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/organizations" do

--- a/spec/suma/admin_api/payment_ledgers_spec.rb
+++ b/spec/suma/admin_api/payment_ledgers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Suma::AdminAPI::PaymentLedgers, :db do
   let(:platform_account) { Suma::Fixtures.payment_account.platform.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/payment_ledgers" do

--- a/spec/suma/admin_api/payment_triggers_spec.rb
+++ b/spec/suma/admin_api/payment_triggers_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::PaymentTriggers, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/payment_triggers" do

--- a/spec/suma/admin_api/payout_transactions_spec.rb
+++ b/spec/suma/admin_api/payout_transactions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::PayoutTransactions, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/payout_transactions" do

--- a/spec/suma/admin_api/roles_spec.rb
+++ b/spec/suma/admin_api/roles_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Suma::AdminAPI::Roles, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/roles" do

--- a/spec/suma/admin_api/search_spec.rb
+++ b/spec/suma/admin_api/search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Suma::AdminAPI::Search, :db do
   let(:admin) { Suma::Fixtures.member.admin.create(name: "Bob") }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "POST /v1/search/ledgers" do

--- a/spec/suma/admin_api/vendors_spec.rb
+++ b/spec/suma/admin_api/vendors_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
   let(:admin) { Suma::Fixtures.member.admin.create }
 
   before(:each) do
-    login_as_admin(admin)
+    login_as(admin)
   end
 
   describe "GET /v1/vendors" do

--- a/spec/suma/api/auth_spec.rb
+++ b/spec/suma/api/auth_spec.rb
@@ -205,13 +205,28 @@ RSpec.describe Suma::API::Auth, :db, reset_configuration: Suma::Member do
   end
 
   describe "DELETE /v1/auth" do
-    it "removes the cookies and marks the session deleted" do
-      delete "/v1/auth"
+    describe "without an authed user" do
+      it "removes the cookies" do
+        delete "/v1/auth"
 
-      expect(last_response).to have_status(204)
-      expect(last_response["Set-Cookie"]).to include("=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00")
-      expect(last_response["Clear-Site-Data"]).to eq("*")
-      expect(member.sessions.last).to be_logged_out
+        expect(last_response).to have_status(204)
+        expect(last_response["Set-Cookie"]).to include("=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00")
+        expect(last_response["Clear-Site-Data"]).to eq("*")
+      end
+    end
+
+    describe "with an authed user" do
+      it "removes the cookies and marks the session deleted" do
+        session = Suma::Fixtures.session.create
+        login_as(session)
+
+        delete "/v1/auth"
+
+        expect(last_response).to have_status(204)
+        expect(last_response["Set-Cookie"]).to include("=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00")
+        expect(last_response["Clear-Site-Data"]).to eq("*")
+        expect(session.refresh).to be_logged_out
+      end
     end
   end
 

--- a/spec/suma/api/auth_spec.rb
+++ b/spec/suma/api/auth_spec.rb
@@ -205,12 +205,13 @@ RSpec.describe Suma::API::Auth, :db, reset_configuration: Suma::Member do
   end
 
   describe "DELETE /v1/auth" do
-    it "removes the cookies" do
+    it "removes the cookies and marks the session deleted" do
       delete "/v1/auth"
 
       expect(last_response).to have_status(204)
       expect(last_response["Set-Cookie"]).to include("=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00")
       expect(last_response["Clear-Site-Data"]).to eq("*")
+      expect(member.sessions.last).to be_logged_out
     end
   end
 

--- a/spec/suma/api/me_spec.rb
+++ b/spec/suma/api/me_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Suma::API::Me, :db do
       let(:admin) { Suma::Fixtures.member.admin.create }
       before(:each) do
         logout
-        login_as_admin(admin)
+        login_as(admin)
       end
 
       it "returns the impersonated user if they are impersonated" do

--- a/spec/suma/service_spec.rb
+++ b/spec/suma/service_spec.rb
@@ -735,12 +735,11 @@ RSpec.describe Suma::Service, :db do
       expect(last_response).to have_status(401)
     end
 
-    it "errors and clears cookies if the user is deleted" do
+    it "errors if the user is deleted" do
       login_as(member)
       member.soft_delete
       get "/current_member"
       expect(last_response).to have_status(401)
-      expect(last_response.cookies).to be_empty
     end
 
     describe "session validation", reset_configuration: described_class do
@@ -786,15 +785,14 @@ RSpec.describe Suma::Service, :db do
       expect(last_response).to have_json_body.that_includes(id: member.id)
     end
 
-    it "errors and clears cookies if the admin impersonating a user is deleted" do
+    it "401s if the admin impersonating a user is deleted" do
       impersonate(admin:, target: member)
       admin.soft_delete
       get "/current_member"
       expect(last_response).to have_status(401)
-      expect(last_response.cookies).to be_empty
     end
 
-    it "errors if the admin impersonating a user does not have the admin role" do
+    it "401s if the admin impersonating a user does not have the admin role" do
       impersonate(admin:, target: member)
       admin.remove_all_roles
       get "/current_member"
@@ -838,7 +836,6 @@ RSpec.describe Suma::Service, :db do
       admin.soft_delete
       get "/current_member_safe"
       expect(last_response).to have_status(401)
-      expect(last_response.cookies).to be_empty
     end
   end
 
@@ -858,20 +855,18 @@ RSpec.describe Suma::Service, :db do
       expect(last_response).to have_status(401)
     end
 
-    it "errors and clears cookies if the admin is deleted" do
+    it "401s if the admin is deleted" do
       login_as_admin(admin)
       admin.soft_delete
       get "/admin_member"
       expect(last_response).to have_status(401)
-      expect(last_response.cookies).to be_empty
     end
 
-    it "errors and clears cookies if the admin does not have the role" do
+    it "401s if the admin does not have the role" do
       login_as_admin(admin)
       admin.remove_all_roles
       get "/admin_member"
       expect(last_response).to have_status(401)
-      expect(last_response.cookies).to be_empty
     end
 
     it "returns the admin, even while impersonating" do
@@ -899,20 +894,18 @@ RSpec.describe Suma::Service, :db do
       expect(last_response).to have_json_body.that_includes(id: nil)
     end
 
-    it "errors and clears cookies if the admin is deleted" do
+    it "errors if the admin is deleted" do
       login_as_admin(admin)
       admin.soft_delete
       get "/admin_member_safe"
       expect(last_response).to have_status(401)
-      expect(last_response.cookies).to be_empty
     end
 
-    it "errors and clears cookies if the admin does not have the role" do
+    it "errors if the admin does not have the role" do
       login_as_admin(admin)
       admin.remove_all_roles
       get "/admin_member_safe"
       expect(last_response).to have_status(401)
-      expect(last_response.cookies).to be_empty
     end
 
     it "returns the admin, even while impersonating" do

--- a/spec/suma/yosoy_spec.rb
+++ b/spec/suma/yosoy_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "timecop"
+
+require "suma/yosoy"
+
+RSpec.describe Suma::Yosoy do
+  mw_class = Class.new(Suma::Yosoy::Middleware) do
+    def env_key = "yosoytest"
+    def throw_key = :yosoytest
+    def serialize_into_session(ao, _env) = ao.fetch(:id)
+    def serialize_from_session(key, _env) = {id: key}
+    def custom_reason(**extra) = response(402, **extra)
+  end
+
+  def req = Rack::MockRequest.env_for("/")
+  let(:auth_obj) { {id: 1} }
+  let(:coder) { Rack::Session::Cookie::Base64::Marshal.new }
+
+  define_method :create_mw do |cls: mw_class, app: nil, &block|
+    app ||= block
+    app = Rack::Session::Cookie.new(app, {secret: "sekret", coder:})
+    app = cls.new(app)
+    app
+  end
+
+  define_method :decode_cookie do |resp|
+    s = resp[1]["Set-Cookie"]
+    s = s.delete_prefix("rack.session=")
+    return coder.decode(Rack::Utils.unescape(s))
+  end
+
+  it "handles the auth flow successfully" do
+    mw = create_mw do |env|
+      yosoy = env.fetch("yosoytest")
+      yosoy.set_authenticated_object(auth_obj)
+      expect(yosoy.authenticated_object!).to eq({id: 1})
+      expect(yosoy.authenticated_object?).to eq({id: 1})
+      [200, {}, "ok"]
+    end
+
+    resp = mw.call(req)
+    expect(resp).to match_array(
+      [200, {"Set-Cookie" => start_with("rack.session=")}, "ok"],
+    )
+    expect(decode_cookie(resp)).to contain_exactly(
+      ["session_id", be_present],
+      ["yosoy.key", 1],
+      ["yosoy.last_access", match_time(:now)],
+    )
+  end
+
+  it "handles the unauthed flow successfully" do
+    mw = create_mw do |env|
+      yosoy = env.fetch("yosoytest")
+      expect(yosoy.authenticated_object?).to be_nil
+      expect(yosoy.authenticated_object!).to eq({"id" => 1})
+    end
+
+    expect(mw.call(req)).to match_array(
+      [401, {"Content-Type" => "application/json"}, ["{\"error\":{\"status\":401,\"code\":\"unauthenticated\"}}"]],
+    )
+  end
+
+  it "can log out" do
+    mw = create_mw do |env|
+      yosoy = env.fetch("yosoytest")
+      yosoy.set_authenticated_object(auth_obj)
+      yosoy.logout
+      [200, {}, "ok"]
+    end
+
+    resp = mw.call(req)
+    expect(resp).to match_array(
+      [200, {"Set-Cookie" => start_with("rack.session=")}, "ok"],
+    )
+    expect(decode_cookie(resp)).to contain_exactly(
+      ["session_id", be_present],
+    )
+  end
+
+  it "can use the throw! method" do
+    mw = create_mw do |env|
+      yosoy = env.fetch("yosoytest")
+      yosoy.throw!(:custom_reason, x: 1)
+    end
+
+    resp = mw.call(req)
+    expect(resp).to match_array(
+      [402, {"Content-Type" => "application/json"}, ["{\"error\":{\"status\":402,\"x\":1}}"]],
+    )
+  end
+
+  it "can use an explicit throw with a symbol" do
+    mw = create_mw do |*|
+      throw(:yosoytest, :custom_reason)
+    end
+
+    resp = mw.call(req)
+    expect(resp).to match_array(
+      [402, {"Content-Type" => "application/json"}, ["{\"error\":{\"status\":402}}"]],
+    )
+  end
+
+  it "defaults to 401 if throwing without a reason" do
+    mw = create_mw do |*|
+      throw(:yosoytest)
+    end
+
+    resp = mw.call(req)
+    expect(resp).to match_array(
+      [401, {"Content-Type" => "application/json"}, ["{\"error\":{\"status\":401,\"code\":\"unauthenticated\"}}"]],
+    )
+  end
+
+  it "errors if throwing with an unhandled reason" do
+    mw = create_mw do |*|
+      throw(:yosoytest, :unsupported)
+    end
+
+    expect do
+      mw.call(req)
+    end.to raise_error(described_class::UnhandledReason, /Use a supported reason/)
+  end
+
+  it "times out if last_access is exceeded" do
+    mwclass_with_timeout = Class.new(mw_class) do
+      def inactivity_timeout = 300
+    end
+    mw = create_mw(cls: mwclass_with_timeout) do |env|
+      yosoy = env.fetch("yosoytest")
+      yosoy.set_authenticated_object(auth_obj) unless yosoy.authenticated_object?
+      [200, {}, "ok"]
+    end
+    now = Time.now
+    resp_t0 = Timecop.freeze(now) do
+      mw.call(req)
+    end
+    expect(resp_t0[0]).to eq(200)
+
+    Timecop.freeze(now + 299.seconds) do
+      env = req
+      env["HTTP_COOKIE"] = resp_t0[1].fetch("Set-Cookie")
+      resp_t299 = mw.call(env)
+      expect(resp_t299[0]).to eq(200)
+    end
+
+    Timecop.freeze(now + 301.seconds) do
+      env = req
+      env["HTTP_COOKIE"] = resp_t0[1].fetch("Set-Cookie")
+      resp_t301 = mw.call(env)
+      expect(resp_t301[0]).to eq(401)
+    end
+  end
+
+  it "does not check last_access if not used" do
+    mw = create_mw do |env|
+      yosoy = env.fetch("yosoytest")
+      yosoy.set_authenticated_object(auth_obj) unless yosoy.authenticated_object?
+      [200, {}, "ok"]
+    end
+    resp_t0 = mw.call(req)
+    expect(resp_t0[0]).to eq(200)
+
+    Timecop.freeze(5.years.from_now) do
+      env = req
+      env["HTTP_COOKIE"] = resp_t0[1].fetch("Set-Cookie")
+      resp_tfuture = mw.call(env)
+      expect(resp_tfuture[0]).to eq(200)
+    end
+  end
+
+  it "calls on_next_request before the request, then clears" do
+    calls = 0
+    Suma::Yosoy.on_next_request do |proxy|
+      expect(proxy).to be_a(Suma::Yosoy::Proxy)
+      calls += 1
+    end
+
+    mw = create_mw do |_env|
+      [200, {}, "ok"]
+    end
+    expect(mw.call(req)[0]).to eq(200)
+    expect(mw.call(req)[0]).to eq(200)
+    expect(mw.call(req)[0]).to eq(200)
+    expect(calls).to eq(1)
+  end
+
+  describe described_class::BlockAuthenticatorMiddleware do
+    bamwcls = Class.new(described_class) do
+      def env_key = "yosoytest"
+    end
+
+    it "calls the inner app if the block passes" do
+      app = bamwcls.new(->(*) { true }).new(->(*) { [200, {}, "ok"] })
+      app = create_mw(app:)
+      expect(app.call(req)[0]).to eq(200)
+    end
+
+    it "returns unauthenticated if the block fails" do
+      app = bamwcls.new(->(*) { false }).new(->(*) { [200, {}, "ok"] })
+      app = create_mw(app:)
+      expect(app.call(req)[0]).to eq(401)
+    end
+  end
+end


### PR DESCRIPTION
Replace our client-only sessions with serverside sessions.

- Replaces Warden with a small home-rolled library called `yosoy`
- Adds columns to `member_sessions`
- On logout, store that a session is logged out. Do not allow login of logged out sessions.
- Store an incrementing 'last access' timestamp in the client session. Do not allow use of sessions that haven't been used in `max_session_age`. Previously `max_session_age` was just used for the cookie expires_at, meaning if someone got an old cookie value, they could keep reusing the cookie programatically.
- Migrate old sessions over to new sessions on their first access. After 30 days or so we can remove `LegacySessionAdapterMiddleware`, since any legacy sessions not used after that time would have expired.