### PR TITLE
Unify redis ssl verification workaround

### DIFF
--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -59,12 +59,7 @@ module Suma::Async
     after_configured do
       # Very hard to to test this, so it's not tested.
       url = self.sidekiq_redis_provider.present? ? ENV.fetch(self.sidekiq_redis_provider, nil) : self.sidekiq_redis_url
-      redis_params = {url:}
-      if url.start_with?("rediss:") && ENV["HEROKU_APP_ID"]
-        # rediss: schema is Redis with SSL. They use self-signed certs, so we have to turn off SSL verification.
-        # There is not a clear KB on this, you have to piece it together from Heroku and Sidekiq docs.
-        redis_params[:ssl_params] = {verify_mode: OpenSSL::SSL::VERIFY_NONE}
-      end
+      redis_params = Suma::Redis.conn_params(url)
       Sidekiq.configure_server do |config|
         config.redis = redis_params
         config.options[:job_logger] = Suma::Async::JobLogger

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -9,6 +9,7 @@ require "sidekiq"
 require "sidekiq-unique-jobs"
 
 require "suma"
+require "suma/redis"
 
 Sidekiq.strict_args!(true)
 

--- a/lib/suma/rack_attack.rb
+++ b/lib/suma/rack_attack.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rack/attack"
+require "suma/redis"
 
 module Suma::RackAttack
   include Appydays::Configurable
@@ -21,7 +22,7 @@ module Suma::RackAttack
       redis_url = self.redis_provider.present? ? ENV.fetch(self.redis_provider, nil) : self.redis_url
       Rack::Attack.cache.store =
         if redis_url.present?
-          ActiveSupport::Cache::RedisCacheStore.new(url: redis_url)
+          ActiveSupport::Cache::RedisCacheStore.new(**Suma::Redis.conn_params(redis_url))
         elsif self.enabled
           ActiveSupport::Cache::MemoryStore.new
         end

--- a/lib/suma/redis.rb
+++ b/lib/suma/redis.rb
@@ -2,25 +2,33 @@
 
 require "appydays/configurable"
 require "redis_client"
+require "suma/postgres/model"
 
 module Suma::Redis
   include Appydays::Configurable
 
   class << self
     attr_accessor :cache
+
+    def conn_params(url, **kw)
+      params = {url:}
+      if url.start_with?("rediss:") && ENV["HEROKU_APP_ID"]
+        # rediss: schema is Redis with SSL. They use self-signed certs, so we have to turn off SSL verification.
+        # There is not a clear KB on this, you have to piece it together from Heroku and Sidekiq docs.
+        params[:ssl_params] = {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+      end
+      params.merge!(kw)
+      return params
+    end
   end
 
   configurable(:redis) do
     setting :cache_url, "redis://localhost:22007/0"
     setting :cache_url_provider, "REDIS_URL"
-    setting :verify_ssl, false
 
     after_configured do
       url = ENV.fetch(self.cache_url_provider, self.cache_url)
-      cache_params = {url:, reconnect_attempts: 1}
-      cache_params[:ssl_params] = {verify_mode: OpenSSL::SSL::VERIFY_NONE} unless
-        self.verify_ssl
-      redis_config = RedisClient.config(**cache_params)
+      redis_config = RedisClient.config(**self.conn_params(url, reconnect_attempts: 1))
       self.cache = redis_config.new_pool(
         timeout: Suma::Postgres::Model.pool_timeout,
         size: Suma::Postgres::Model.max_connections,

--- a/spec/suma/redis_spec.rb
+++ b/spec/suma/redis_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "suma/redis"
+
+RSpec.describe Suma::Redis do
+  describe "#conn_params" do
+    it "returns keyword arguments" do
+      params = described_class.conn_params("redis://localhost:1234/0", reconnect_attempts: 1, timeout: 1.0)
+      puts params.inspect
+      expect(params[:url]).to eq("redis://localhost:1234/0")
+      expect(params[:reconnect_attempts]).to eq(1)
+      expect(params[:timeout]).to eq(1.0)
+    end
+
+    it "returns ssl_params when using heroku redis" do
+      ssl_schema_url = "rediss://"
+      none_ssl_schema_url = "redis://"
+
+      expect(described_class.conn_params(none_ssl_schema_url)[:ssl_params]).to be_nil
+      expect(described_class.conn_params(ssl_schema_url)[:ssl_params]).to be_nil
+      ENV["HEROKU_APP_ID"] = "a1b2bc"
+      expect(described_class.conn_params(ssl_schema_url)[:ssl_params]).to include(:verify_mode)
+      expect(described_class.conn_params(none_ssl_schema_url)[:ssl_params]).to be_nil
+    ensure
+      ENV.delete("HEROKU_APP_ID")
+    end
+  end
+end

--- a/spec/suma/redis_spec.rb
+++ b/spec/suma/redis_spec.rb
@@ -6,21 +6,18 @@ RSpec.describe Suma::Redis do
   describe "#conn_params" do
     it "returns keyword arguments" do
       params = described_class.conn_params("redis://localhost:1234/0", reconnect_attempts: 1, timeout: 1.0)
-      puts params.inspect
-      expect(params[:url]).to eq("redis://localhost:1234/0")
-      expect(params[:reconnect_attempts]).to eq(1)
-      expect(params[:timeout]).to eq(1.0)
+      expect(params).to include(url: "redis://localhost:1234/0", reconnect_attempts: 1, timeout: 1.0)
     end
 
     it "returns ssl_params when using heroku redis" do
       ssl_schema_url = "rediss://"
       none_ssl_schema_url = "redis://"
 
-      expect(described_class.conn_params(none_ssl_schema_url)[:ssl_params]).to be_nil
-      expect(described_class.conn_params(ssl_schema_url)[:ssl_params]).to be_nil
+      expect(described_class.conn_params(none_ssl_schema_url)).to_not include(:ssl_params)
+      expect(described_class.conn_params(ssl_schema_url)).to_not include(:ssl_params)
       ENV["HEROKU_APP_ID"] = "a1b2bc"
-      expect(described_class.conn_params(ssl_schema_url)[:ssl_params]).to include(:verify_mode)
-      expect(described_class.conn_params(none_ssl_schema_url)[:ssl_params]).to be_nil
+      expect(described_class.conn_params(ssl_schema_url)).to include(ssl_params: {verify_mode: 0})
+      expect(described_class.conn_params(none_ssl_schema_url)).to_not include(:ssl_params)
     ensure
       ENV.delete("HEROKU_APP_ID")
     end

--- a/webapp/src/pages/OneTimePassword.jsx
+++ b/webapp/src/pages/OneTimePassword.jsx
@@ -5,7 +5,7 @@ import FormSuccess from "../components/FormSuccess";
 import { t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import { maskPhoneNumber } from "../modules/maskPhoneNumber";
-import { extractErrorCode, extractLocalizedError, useError } from "../state/useError";
+import { extractLocalizedError, useError } from "../state/useError";
 import useLoginRedirectLink from "../state/useLoginRedirectLink";
 import useUser from "../state/useUser";
 import React from "react";


### PR DESCRIPTION
We know we have to use VERIFY_NONE on Heroku,
this adds `Suma::Redis.conn_params` to centralize the logic. Use it in `Suma::RackAttack`.