### PR TITLE
Rate limit the `/verify` endpoint by phone

### DIFF
--- a/lib/rack/remote_ip.rb
+++ b/lib/rack/remote_ip.rb
@@ -74,7 +74,7 @@ class Rack::RemoteIp
   # requests. For those requests that do need to know the IP, the
   # GetIp#calculate_ip method will calculate the memoized client IP address.
   def call(env)
-    env["rack.remote_ip"] = GetIp.new(env, self.check_ip, self.proxies)
+    env["rack.remote_ip"] ||= GetIp.new(env, self.check_ip, self.proxies)
     @app.call(env)
   end
 


### PR DESCRIPTION
We need to prohibit account takeover by someone using multiple IPs. Set a high limit since we don't want to interfere with a valid user normally (they will get locked out in the case of attack though).