### PR TITLE
Abort the controller with useEffect unmount

### DIFF
--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -133,7 +133,7 @@ function PrivateAccount({ account, onHelp }) {
           // Poll with a timeout, in case the server stops responding we want to try again.
           .pollForNewPrivateAccountMagicLink(
             { id: account.id },
-            { timeout: 12000, signal: pollingController.current.signal }
+            { timeout: 30000, signal: pollingController.current.signal }
           )
           .then((r) => {
             if (r.data.foundChange) {

--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -12,6 +12,7 @@ import ScrollTopOnMount from "../shared/ScrollToTopOnMount";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import useMountEffect from "../shared/react/useMountEffect";
 import useToggle from "../shared/react/useToggle";
+import useUnmountEffect from "../shared/react/useUnmountEffect";
 import { useError } from "../state/useError";
 import { CanceledError } from "axios";
 import get from "lodash/get";
@@ -112,20 +113,16 @@ export default function PrivateAccountsList() {
 function PrivateAccount({ account, onHelp }) {
   const { vendorImage } = account;
   const [buttonStatus, setButtonStatus] = React.useState(INITIAL);
-  const pollingController = React.useRef(null);
+  const pollingController = React.useRef(new AbortController());
   const [error, setError] = useError(null);
   const success = useToggle(false);
 
-  useMountEffect(() => {
-    return () => {
-      if (pollingController.current) {
-        pollingController.current.abort();
-      }
-    };
+  useUnmountEffect(() => {
+    pollingController.current.abort();
   });
 
   const pollingCallback = React.useCallback(() => {
-    // Abort any ongoing request when we unmount.
+    pollingController.current.abort();
     pollingController.current = new AbortController();
     function pollAndReplace() {
       return (

--- a/webapp/src/shared/react/useUnmountEffect.jsx
+++ b/webapp/src/shared/react/useUnmountEffect.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+/**
+ * Just a `React.useEffect(() => cb, [])` that is more declarative than
+ * doing it in line and disabling eslint.
+ * @param {function} cb
+ */
+export default function useUnmountEffect(cb) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => cb, []);
+}


### PR DESCRIPTION
Fixes #657 

The polling controller was aborting incorrectly through `React.useCallback`, fixed by aborting during unmount in a `React.useEffect`.