### PR TITLE
Fix DeepArmor unresolved security issues

### DIFF
--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -10,7 +10,9 @@ class Suma::API::Commerce < Suma::API::V1
 
   resource :commerce do
     helpers do
-      def new_context = Suma::Payment::CalculationContext.new(Time.now)
+      def new_context(t=Time.now)
+        return Suma::Payment::CalculationContext.new(t)
+      end
 
       def set_fulfillment_or_error(checkout, option_id, options)
         allow_nil = checkout.fulfillment_option.nil? && option_id.nil?
@@ -31,8 +33,9 @@ class Suma::API::Commerce < Suma::API::V1
 
       route_param :offering_id, type: Integer do
         helpers do
-          def lookup_offering!
+          def lookup_offering!(t)
             (offering = Suma::Commerce::Offering[params[:offering_id]]) or forbidden!
+            forbidden! unless offering.available_at?(t)
             check_eligibility!(offering, current_member)
             return offering
           end
@@ -47,11 +50,12 @@ class Suma::API::Commerce < Suma::API::V1
         # paginated items after the first page.
         get do
           current_member
-          offering = lookup_offering!
+          t = Time.now
+          offering = lookup_offering!(t)
           items = offering.offering_products_dataset.available.all
           cart = lookup_cart!(offering)
           vendors = items.map { |v| v.product.vendor }.uniq(&:id)
-          present offering, with: OfferingWithContextEntity, cart:, items:, vendors:, context: new_context
+          present offering, with: OfferingWithContextEntity, cart:, items:, vendors:, context: new_context(t)
         end
 
         resource :cart do
@@ -61,7 +65,8 @@ class Suma::API::Commerce < Suma::API::V1
             optional :timestamp, type: Float, allow_blank: true
           end
           put :item do
-            offering = lookup_offering!
+            t = Time.now
+            offering = lookup_offering!(t)
             cart = lookup_cart!(offering)
             product = Suma::Commerce::Product[params[:product_id]]
             begin
@@ -72,14 +77,15 @@ class Suma::API::Commerce < Suma::API::V1
               self.logger.info "out_of_order_update", product_id: product&.id, quantity: params[:quantity]
               nil
             end
-            present cart, with: CartEntity, context: new_context
+            present cart, with: CartEntity, context: new_context(t)
           end
         end
 
         post :checkout do
-          offering = lookup_offering!
+          t = Time.now
+          offering = lookup_offering!(t)
           cart = lookup_cart!(offering)
-          ctx = new_context
+          ctx = new_context(t)
           begin
             checkout = cart.create_checkout(ctx)
           rescue Suma::Commerce::Cart::EmptyCart

--- a/lib/suma/api/commerce.rb
+++ b/lib/suma/api/commerce.rb
@@ -10,7 +10,7 @@ class Suma::API::Commerce < Suma::API::V1
 
   resource :commerce do
     helpers do
-      def new_context(t=Time.now)
+      def new_context(t)
         return Suma::Payment::CalculationContext.new(t)
       end
 
@@ -120,7 +120,7 @@ class Suma::API::Commerce < Suma::API::V1
 
         get do
           checkout = lookup_editable!
-          present checkout, with: CheckoutEntity, cart: checkout.cart, context: new_context
+          present checkout, with: CheckoutEntity, cart: checkout.cart, context: new_context(Time.now)
         end
 
         params do
@@ -131,7 +131,7 @@ class Suma::API::Commerce < Suma::API::V1
           set_fulfillment_or_error(checkout, params[:option_id], checkout.available_fulfillment_options)
           checkout.save_changes
           status 200
-          present checkout, with: CheckoutEntity, cart: checkout.cart, context: new_context
+          present checkout, with: CheckoutEntity, cart: checkout.cart, context: new_context(Time.now)
         end
 
         params do

--- a/lib/suma/commerce/cart_item.rb
+++ b/lib/suma/commerce/cart_item.rb
@@ -37,7 +37,7 @@ class Suma::Commerce::CartItem < Suma::Postgres::Model(:commerce_cart_items)
 
   def available_at?(at)
     return false if self.offering_product.nil?
-    return false unless self.offering_product.offering.period.cover?(at)
+    return false unless self.offering_product.offering.available_at?(at)
     return self.offering_product.available?
   end
 end

--- a/lib/suma/commerce/offering.rb
+++ b/lib/suma/commerce/offering.rb
@@ -164,6 +164,10 @@ class Suma::Commerce::Offering < Suma::Postgres::Model(:commerce_offerings)
     return !self.begin_fulfillment_at.nil?
   end
 
+  def available_at?(t)
+    return self.period.cover?(t)
+  end
+
   # Call begin_fulfillment on all orders, if this is a 'timed fulfillment' offering.
   # Untimed offerings must have their orders processed manually.
   def begin_order_fulfillment(now:)

--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -40,7 +40,7 @@ class Suma::Member::Exporter
           # which can be confusing (name of "=1+1" would appear as "2")
           # and potentially dangerous. A space or tab char is not enough
           # to prevent macros for some csv software like Numbers app on mac.
-          v = "UNSAFE#{v}" if v.respond_to?(:start_with?) && v.start_with?("=")
+          v = "UNSAFE#{v}" if v.respond_to?(:start_with?) && v.start_with?(/\s?=/)
           v
         end
         csv << row

--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -35,11 +35,12 @@ class Suma::Member::Exporter
       @dataset.paged_each do |m|
         row = coercers.map do |c|
           v = c[m]
-          # If the string starts with an equal sign, add a space before it,
+          # If the string starts with an equal sign, add 'UNSAFE' before it,
           # so spreadsheet programs will not evaluate it as a macro
           # which can be confusing (name of "=1+1" would appear as "2")
-          # and potentially dangerous.
-          v = " #{v}" if v.respond_to?(:start_with?) && v.start_with?("=")
+          # and potentially dangerous. A space or tab char is not enough
+          # to prevent macros for some csv software like Numbers app on mac.
+          v = "UNSAFE#{v}" if v.respond_to?(:start_with?) && v.start_with?("=")
           v
         end
         csv << row

--- a/spec/suma/api/commerce_spec.rb
+++ b/spec/suma/api/commerce_spec.rb
@@ -208,8 +208,18 @@ RSpec.describe Suma::API::Commerce, :db do
         that_includes(error: include(code: "invalid_order_quantity", message: "max quantity exceeded"))
     end
 
-    it "409s if any product is no longer available due to offering reasons" do
+    it "409s if any product is unavailable due to offering reasons" do
       offering_product.delete
+
+      post "/v1/commerce/offerings/#{offering.id}/checkout"
+
+      expect(last_response).to have_status(409)
+      expect(last_response).to have_json_body.
+        that_includes(error: include(code: "invalid_order_quantity", message: "product unavailable"))
+    end
+
+    it "409s if product is unavailable due to it being closed" do
+      offering_product.update(closed_at: 1.day.ago)
 
       post "/v1/commerce/offerings/#{offering.id}/checkout"
 

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -33,8 +33,12 @@ RSpec.describe Suma::Member::Exporter, :db do
   end
 
   it "adds UNSAFE before values that start with an equal sign to avoid exporing a macro" do
-    member = Suma::Fixtures.member.create(name: "=1+1")
+    member1 = Suma::Fixtures.member.create(name: "=1+1")
+    member2 = Suma::Fixtures.member.create(name: " =1+1")
+    member3 = Suma::Fixtures.member.create(name: "\t=1+1")
     csv = described_class.new(Suma::Member.dataset).to_csv
-    expect(csv).to include("#{member.id},UNSAFE=1+1")
+    expect(csv).to include("#{member1.id},UNSAFE=1+1")
+    expect(csv).to include("#{member2.id},UNSAFE =1+1")
+    expect(csv).to include("#{member3.id},UNSAFE\t=1+1")
   end
 end

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Suma::Member::Exporter, :db do
     expect(csv).to eq(lines)
   end
 
-  it "adds a space before values that start with an equal sign to avoid exporing a macro" do
+  it "adds UNSAFE before values that start with an equal sign to avoid exporing a macro" do
     member = Suma::Fixtures.member.create(name: "=1+1")
     csv = described_class.new(Suma::Member.dataset).to_csv
-    expect(csv).to include("#{member.id}, =1+1")
+    expect(csv).to include("#{member.id},UNSAFE=1+1")
   end
 end


### PR DESCRIPTION
1. Restrict offering access if it is closed for `/api/v1/commerce/offerings/${id}`, `/api/v1/commerce/offerings/${id}/cart/item`, and `/api/v1/commerce/offerings/${id}/checkout`. Note that /checkout already checks, but only later when checking if the products are available.
2. CSV still not fixed - DA continue to observe the execution of equations that begin with an equal sign e.g. " =2+2" or "=2+2"

Not entirely sure how we can fix this CSV issue, it appears to be a security vulnerability with CSV softwares. https://georgemauer.net/2017/10/07/csv-injection.html