### PR TITLE
Handle all characters before executable macro sign

### DIFF
--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -40,7 +40,8 @@ class Suma::Member::Exporter
           # which can be confusing (name of "=1+1" would appear as "2")
           # and potentially dangerous. A space or tab char is not enough
           # to prevent macros for some csv software like Numbers app on mac.
-          v = "UNSAFE#{v}" if v.respond_to?(:match?) && /^\s*=/.match?(v)
+          unsafe_match = v =~ /^\s*=/
+          v = "UNSAFE#{v}" unless unsafe_match.nil?
           v
         end
         csv << row

--- a/lib/suma/member/exporter.rb
+++ b/lib/suma/member/exporter.rb
@@ -40,7 +40,7 @@ class Suma::Member::Exporter
           # which can be confusing (name of "=1+1" would appear as "2")
           # and potentially dangerous. A space or tab char is not enough
           # to prevent macros for some csv software like Numbers app on mac.
-          v = "UNSAFE#{v}" if v.respond_to?(:start_with?) && v.start_with?(/\s?=/)
+          v = "UNSAFE#{v}" if v.respond_to?(:match?) && /^\s*=/.match?(v)
           v
         end
         csv << row

--- a/spec/suma/member/exporter_spec.rb
+++ b/spec/suma/member/exporter_spec.rb
@@ -34,11 +34,15 @@ RSpec.describe Suma::Member::Exporter, :db do
 
   it "adds UNSAFE before values that start with an equal sign to avoid exporing a macro" do
     member1 = Suma::Fixtures.member.create(name: "=1+1")
-    member2 = Suma::Fixtures.member.create(name: " =1+1")
-    member3 = Suma::Fixtures.member.create(name: "\t=1+1")
+    member2 = Suma::Fixtures.member.create(name: "==1+1")
+    member3 = Suma::Fixtures.member.create(name: " =1+1")
+    member4 = Suma::Fixtures.member.create(name: "  =1+1")
+    member5 = Suma::Fixtures.member.create(name: "\t=1+1")
     csv = described_class.new(Suma::Member.dataset).to_csv
     expect(csv).to include("#{member1.id},UNSAFE=1+1")
-    expect(csv).to include("#{member2.id},UNSAFE =1+1")
-    expect(csv).to include("#{member3.id},UNSAFE\t=1+1")
+    expect(csv).to include("#{member2.id},UNSAFE==1+1")
+    expect(csv).to include("#{member3.id},UNSAFE =1+1")
+    expect(csv).to include("#{member4.id},UNSAFE  =1+1")
+    expect(csv).to include("#{member5.id},UNSAFE\t=1+1")
   end
 end


### PR DESCRIPTION
Add "UNSAFE" before values that have multiple characters before the equals executable sign. Like a string beginning with double space.