### PR TITLE
Payment trigger: fix bug with extra subsidy

### DIFF
--- a/lib/suma/commerce/checkout.rb
+++ b/lib/suma/commerce/checkout.rb
@@ -205,8 +205,7 @@ class Suma::Commerce::Checkout < Suma::Postgres::Model(:commerce_checkouts)
 
       # This will make member subledgers have a positive balance.
       # It will not debit the subledgers or cash ledger.
-      Suma::Payment::Trigger.gather(self.cart.member.payment_account!, apply_at:).
-        funding_plan(cash_charge_amount).
+      Suma::Payment::Trigger::Plan.new(steps: predicted_contrib.relevant_trigger_steps).
         execute(ledgers: predicted_contrib.all.map(&:ledger), at: apply_at)
 
       # See how much the member needs to pay across cash and noncash ledgers,


### PR DESCRIPTION
We had a bug where the intro subsidy was predicted to contribute just $19 on $24, but ended up
contributing all $24, if purchased along with
matchinv vouchers.

This was because:

- First, we calculated the ideal cash contribution on the intro at $5, which is correct ($19 subsidy).
- Then we calculated the ideal cash contribution on the match at $15, which is correct ($15 subsidy).
- This is $20 total cash.
- When we went to actually charge (not calculate the ideal), we'd use $20 as the cash contribution sent to the payment triggers. This led to $15 of match (because it had a $15 max), but $24 of intro (because it has a $38, or $19x2, max).
- So instead of $54 of credit ($20 cash, $19 + $15 subsidy), and $0 balance at the end, we end up with $59 of credit ($20 cash, $24 + $15 subsidy), and a $5 balance at the end.

This solution makes sure the funding triggers are recorded with the cash values that calculated them,
rather than being re-calculated with the total cash contribution (which can be larger than the cash amount that led to the 'correct' trigger result).