### PR TITLE
Add a url shortener app, hook it up to Lime

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -26,4 +26,7 @@ end
 map "/sidekiq" do
   run Suma::Apps::SidekiqWeb.to_app
 end
+map Suma::UrlShortener::ROOT_PATH do
+  run Suma::Apps::UrlRedirects.to_app
+end
 run Suma::Apps::Root.to_app

--- a/db/migrations/049_url_shortner.rb
+++ b/db/migrations/049_url_shortner.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    require "suma/url_shortener"
+
+    Suma::UrlShortener.new_shortener(conn: self).create_table
+  end
+
+  down do
+    require "suma/url_shortener"
+
+    drop_table Suma::UrlShortener.new_shortener.table
+  end
+end

--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -60,7 +60,8 @@ module Suma
     setting :log_format, nil
     setting :app_url, "http://localhost:22004"
     setting :admin_url, "http://localhost:22014"
-    setting :api_url, "http://localhost:#{ENV.fetch('PORT', 22_001)}/api"
+    setting :api_host, "http://localhost:#{ENV.fetch('PORT', 22_001)}"
+    setting :api_url, ENV.fetch("SUMA_API_HOST", "http://localhost:#{ENV.fetch('PORT', 22_001)}") + "/api"
     setting :default_currency, "USD", side_effect: ->(v) { Money.default_currency = v }
     setting :bust_idempotency, false
     setting :use_globals_cache, false

--- a/lib/suma/anon_proxy/message_handler/lime.rb
+++ b/lib/suma/anon_proxy/message_handler/lime.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "suma/messages/single_value"
+require "suma/url_shortener"
 
 class Suma::AnonProxy::MessageHandler::Lime < Suma::AnonProxy::MessageHandler
   def key = "lime"
@@ -31,11 +32,12 @@ class Suma::AnonProxy::MessageHandler::Lime < Suma::AnonProxy::MessageHandler
       result.handled = false
       return result
     end
-    vendor_account_message.vendor_account.replace_access_code(token, magic_link).save_changes
+    shortened_link = Suma::UrlShortener.shortener.shorten(magic_link).url
+    vendor_account_message.vendor_account.replace_access_code(token, shortened_link).save_changes
     msg = Suma::Messages::SingleValue.new(
       "anon_proxy",
       "lime-deep-link-access-code",
-      magic_link,
+      shortened_link,
     )
     vendor_account_message.vendor_account.member.message_preferences!.dispatch(msg)
     result.handled = true

--- a/lib/suma/apps.rb
+++ b/lib/suma/apps.rb
@@ -11,6 +11,7 @@ require "rack/simple_headers"
 require "rack/simple_redirect"
 require "rack/spa_app"
 require "rack/spa_rewrite"
+require "url_shortener/rack_app"
 require "sidekiq/web"
 
 require "suma/api"
@@ -51,6 +52,8 @@ require "suma/admin_api/roles"
 require "suma/admin_api/search"
 require "suma/admin_api/vendors"
 require "suma/admin_api/anon_proxy"
+
+require "suma/url_shortener"
 
 module Suma::Apps
   class API < Suma::Service
@@ -112,6 +115,11 @@ module Suma::Apps
     end
     use Rack::Session::Cookie, secret: Suma::Service.session_secret, same_site: true, max_age: 86_400
     run Sidekiq::Web
+  end
+
+  UrlRedirects = Rack::Builder.new do
+    shortener = Suma::UrlShortener.new_shortener
+    run ::UrlShortener::RackApp.new(shortener)
   end
 
   def self.emplace_dynamic_config

--- a/lib/suma/url_shortener.rb
+++ b/lib/suma/url_shortener.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "appydays/configurable"
+require "url_shortener"
+
+module Suma::UrlShortener
+  include Appydays::Configurable
+
+  ROOT_PATH = "/r"
+
+  configurable(:url_shortener) do
+    setting :database_url, ENV.fetch("DATABASE_URL", "postgres:/suma_test")
+    setting :table, :url_shortener
+    setting :not_found_url, "https://mysuma.org/404"
+    setting :byte_size, 2
+  end
+
+  class << self
+    # @return [UrlShortener]
+    def new_shortener(**kw)
+      opts = {
+        conn: Sequel.connect(self.database_url),
+        table: self.table,
+        root: Suma.api_host + ROOT_PATH,
+        not_found_url: self.not_found_url,
+        byte_size: self.byte_size,
+      }
+      opts.merge!(kw)
+      return ::UrlShortener.new(**opts)
+    end
+
+    # @return [UrlShortener]
+    def shortener = @shortener ||= new_shortener
+  end
+end

--- a/lib/url_shortener.rb
+++ b/lib/url_shortener.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+# UrlShortener is a simple Rack app for shortening URLs.
+# It should work with any Rack app and database.
+# URLs are always of the form "<root>/<id>",
+# and the ID is assumed to always be the last section of the request path.
+class UrlShortener
+  # When inserting unique IDs for shortened URLs, attempt to upsert this many times before
+  # giving up and raising +NoIdAvailable+. This happens when there are few available IDs
+  # for the given byte size.
+  MAX_UNIQUE_ID_ATTEMPTS = 5
+
+  class NoIdAvailable < StandardError; end
+
+  class << self
+    # Generate a new short id.
+    # The first 4 bytes (usually six characters) is the current second,
+    # the last +byte_size+ bytes are random.
+    # See +byte_size+ for more info.
+    def gen_short_id(byte_size)
+      # Encode numbers with a radix is 36, which gives us many available characters to encode with.
+      # For example, `414.to_s(16)` would hex encode.
+      epoch_second_encoded = Time.now.to_i.to_s(36)
+      # Encode random bytes as hex, then parse it as an integer,
+      # so we can encode the integer with a radix 36.
+      rand_part_hex = Digest.hexencode(SecureRandom.bytes(byte_size)).to_i(16).to_s(36)
+      return epoch_second_encoded + rand_part_hex
+    end
+  end
+
+  # Sequel database connection to the database hosting the shortener table.
+  # @type [Sequel::Connection]
+  attr_accessor :conn
+
+  # Name of the Sequel table, or a Sequel expression to the table.
+  # Default to +:url_shortener+.
+  # @type [Symbol,Sequel::SQL::Expression]
+  attr_accessor :table
+
+  # Root URL for redirect urls, to which the generated ID is appended.
+  # For example, a +root+ of "https://example.org/abc" would produce
+  # shortened URLs from +shortened_url+ like "https://example.org/abc/1cad243fo".
+  # Usually this would be the URL of the application and path hosting the +UrlShortener::RackApp+ app.
+  # @type [String]
+  attr_accessor :root
+
+  # When a short ID cannot be resolved, the middleware will redirect to this URL.
+  # Defaults to the path "/404".
+  # @type [String]
+  attr_accessor :not_found_url
+
+  # Size of the random part of the ID.
+  # The first, time-based portion of the ID changes each second, and is encoded 4 bytes (usually 6 characters).
+  # The second, random part of the ID, is encoded as another <byte_size> bytes,
+  # by default 2 bytes (usually 3 characters).
+  # This allows at least a few thousand URLs every second
+  # (you would never hit the 65k URLs/second because of randomness conflicts).
+  # This yields, by default, a total ID length of 9 characters.
+  # @type [Integer]
+  attr_accessor :byte_size
+
+  def initialize(conn:, root:, table: :url_shortener, not_found_url: "/404", byte_size: 2)
+    @conn = conn
+    @table = table
+    @root = root
+    @not_found_url = not_found_url
+    @byte_size = byte_size
+  end
+
+  # @return [Sequel::Dataset]
+  def dataset
+    return @conn[@table]
+  end
+
+  # Create the table using the database connection.
+  # Should usually be called from a migration.
+  def create_table
+    @conn.create_table(@table) do
+      column :short_id, :text, unique: true, null: false
+      column :url, :text, null: false
+      column :inserted_at, :timestamptz, null: false, default: Sequel.function(:now)
+    end
+  end
+
+  Shortened = Struct.new(:short_id, :url)
+
+  # Return the short ID and shortened URL pointing to the full url.
+  # @param [String] url
+  # @return [Shortened]
+  def shorten(url)
+    (MAX_UNIQUE_ID_ATTEMPTS - 1).times do
+      short_id = self.class.gen_short_id(@byte_size)
+      @conn[@table].insert(url:, short_id:)
+      return Shortened.new(short_id, "#{@root}/#{short_id}")
+    rescue Sequel::UniqueConstraintViolation
+      nil
+    end
+    msg = "Could not generate a valid short_id after #{MAX_UNIQUE_ID_ATTEMPTS} attempts, " \
+          "you are probably at or approaching the maximum number of shortened IDs for #{@bytesize} bytes. " \
+          "You should increase the :bytesize value."
+    raise NoIdAvailable, msg
+  end
+
+  # Given a shortened ID (tail of the URL),
+  # return the URL, or nil.
+  # @param [String,nil] short_id
+  # @return [String,nil]
+  def resolve_short_id(short_id)
+    row = @conn[@table].where(short_id:).select(:url).first
+    return nil if row.nil?
+    return row[:url]
+  end
+
+  # Given a short URL, return the full URL, or nil.
+  # @param [String,URI::Generic] url
+  # @return [String,nil]
+  def resolve_short_url(url)
+    uri = url.is_a?(URI) ? url : URI(url)
+    return self.resolve_short_id(uri.path.delete_suffix("/").split("/").last)
+  end
+end

--- a/lib/url_shortener/rack_app.rb
+++ b/lib/url_shortener/rack_app.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "url_shortener"
+
+class UrlShortener::RackApp
+  # @param [UrlShortener] url_shortener
+  def initialize(url_shortener)
+    @url_shortener = url_shortener
+  end
+
+  def call(env)
+    req = Rack::Request.new(env)
+    return [405, {}, [""]] unless ["HEAD", "GET"].include?(req.request_method)
+    resolved = @url_shortener.resolve_short_url(req.path)
+    location = resolved || @url_shortener.not_found_url
+    body = "<html><body>This content has moved to <a href=\"#{location}\">#{location}</a></body></html>"
+    return [302, {"Location" => location}, [body]]
+  end
+end

--- a/lib/url_shortener/spec_helpers.rb
+++ b/lib/url_shortener/spec_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "url_shortener"
+
+module UrlShortener::SpecHelpers
+  RSpec::Matchers.define(:be_a_shortlink_to) do |expected|
+    match do |str|
+      break false if str.blank?
+      short_id = str.split("/").last
+      resolved = url_shortener.resolve_short_id(short_id)
+      resolved == expected
+    end
+
+    failure_message do |str|
+      "No shortened URL found for #{str.inspect}"
+    end
+  end
+end

--- a/spec/suma/anon_proxy/message_handler_spec.rb
+++ b/spec/suma/anon_proxy/message_handler_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+require "url_shortener/spec_helpers"
+
 RSpec.describe Suma::AnonProxy::MessageHandler, :db do
+  include UrlShortener::SpecHelpers
+  let(:url_shortener) { Suma::UrlShortener.shortener }
+
   before(:each) do
     described_class::Fake.reset
   end
@@ -110,8 +115,12 @@ RSpec.describe Suma::AnonProxy::MessageHandler, :db do
       expect(got).to have_attributes(vendor_account:, outbound_delivery: nil)
       expect(vendor_account.refresh).to have_attributes(
         latest_access_code: "M1ZgpMepjL5kW9XgzCmnsBKQ",
-        latest_access_code_magic_link: "https://limebike.app.link/login?magic_link_token=M1ZgpMepjL5kW9XgzCmnsBKQ",
+        latest_access_code_magic_link: start_with("http://localhost:22001/r/"),
         latest_access_code_set_at: match_time(:now),
+      )
+      expect(Suma::UrlShortener.shortener.dataset.order(:inserted_at).last).to include(
+        url: "https://limebike.app.link/login?magic_link_token=M1ZgpMepjL5kW9XgzCmnsBKQ",
+        short_id: vendor_account.latest_access_code_magic_link.split("/").last,
       )
     end
 
@@ -123,8 +132,9 @@ RSpec.describe Suma::AnonProxy::MessageHandler, :db do
       expect(got).to have_attributes(vendor_account:, outbound_delivery: nil)
       expect(vendor_account.refresh).to have_attributes(
         latest_access_code: "hXYamQ1JGVifc6xuMv6qUrLZ",
-        latest_access_code_magic_link:
+        latest_access_code_magic_link: be_a_shortlink_to(
           "https://limebike.app.link/email_verification?authentication_code=hXYamQ1JGVifc6xuMv6qUrLZ",
+        ),
         latest_access_code_set_at: match_time(:now),
       )
       expect(vendor_account.contact.member.message_deliveries.last).to have_attributes(
@@ -142,7 +152,7 @@ RSpec.describe Suma::AnonProxy::MessageHandler, :db do
       expect(got).to have_attributes(vendor_account:, outbound_delivery: nil)
       expect(vendor_account.refresh).to have_attributes(
         latest_access_code: "M1ZgpMepjL5kX9XgzCmnsBKQ",
-        latest_access_code_magic_link: "https://web-production.lime.bike/api/rider/v2/magic-challenge?magic_link_token=M1ZgpMepjL5kX9XgzCmnsBKQ",
+        latest_access_code_magic_link: be_a_shortlink_to("https://web-production.lime.bike/api/rider/v2/magic-challenge?magic_link_token=M1ZgpMepjL5kX9XgzCmnsBKQ"),
         latest_access_code_set_at: match_time(:now),
       )
       expect(vendor_account.contact.member.message_deliveries.last).to have_attributes(

--- a/spec/url_shortener_spec.rb
+++ b/spec/url_shortener_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "url_shortener"
+require "url_shortener/rack_app"
+require "url_shortener/spec_helpers"
+require "rspec/matchers/fail_matchers"
+
+RSpec.describe UrlShortener do
+  before(:all) do
+    @conn = Sequel.connect(ENV.fetch("DATABASE_URL"))
+  end
+  let(:conn) { @conn }
+  let(:table) { :urlshortener }
+  let(:root) { "https://mysite.com" }
+  let(:not_found_url) { "https://not-found.com" }
+  let(:shortener) { described_class.new(conn:, table:, root:, not_found_url:) }
+
+  before(:each) do
+    conn.drop_table?(table)
+    shortener.create_table
+  end
+
+  it "uses the current time as the base of the random id" do
+    Timecop.freeze(100) do
+      id1 = described_class.gen_short_id(2)
+      id2 = described_class.gen_short_id(2)
+      expect(id1[...6]).to eq(id2[...6])
+      expect(id1[6..]).to_not eq(id2[6..])
+      Timecop.freeze(200) do
+        id3 = described_class.gen_short_id(2)
+        expect(id3[...6]).to_not eq(id1[...6])
+      end
+    end
+  end
+
+  it "can generate and resolve shortened urls" do
+    expect(described_class).to receive(:gen_short_id).and_return("abc123")
+    expect(shortener.shorten("https://x.y.z")).to have_attributes(short_id: "abc123", url: "https://mysite.com/abc123")
+    expect(shortener.resolve_short_id("abc123")).to eq("https://x.y.z")
+    expect(shortener.resolve_short_url("https://mysite.com/abc123")).to eq("https://x.y.z")
+  end
+
+  it "can resolve short urls with trailing slashes and query params" do
+    expect(described_class).to receive(:gen_short_id).and_return("abc123")
+    shortener.shorten("https://x.y.z")
+    expect(shortener.resolve_short_url("https://mysite.com/abc123")).to eq("https://x.y.z")
+    expect(shortener.resolve_short_url("https://mysite.com/abc123/")).to eq("https://x.y.z")
+    expect(shortener.resolve_short_url("https://mysite.com/abc123/?x=1")).to eq("https://x.y.z")
+    expect(shortener.resolve_short_url(URI("https://mysite.com/abc123/?x=1"))).to eq("https://x.y.z")
+  end
+
+  it "cannot resolve unknown ids" do
+    expect(shortener.resolve_short_id("abc123")).to be_nil
+  end
+
+  it "will not generate duplicates" do
+    expect(described_class).to receive(:gen_short_id).
+      exactly(4).times.
+      and_return(
+        "123",
+        "123",
+        "123",
+        "456",
+      )
+    expect(shortener.shorten("https://1")).to have_attributes(short_id: "123")
+    expect(shortener.shorten("https://2")).to have_attributes(short_id: "456")
+  end
+
+  it "errors if no unique id can be generated" do
+    expect(described_class).to receive(:gen_short_id).
+      exactly(described_class::MAX_UNIQUE_ID_ATTEMPTS).times.
+      and_return("123")
+    shortener.shorten("https://abc")
+    expect { shortener.shorten("https://abc") }.to raise_error(described_class::NoIdAvailable)
+  end
+
+  describe "RackApp" do
+    include Rack::Test::Methods
+
+    def app
+      @app ||= UrlShortener::RackApp.new(shortener)
+    end
+
+    it "405s on unexpected methods" do
+      patch "/abc"
+
+      expect(last_response).to have_attributes(status: 405)
+    end
+
+    it "redirects on matched urls" do
+      new_url = shortener.shorten("https://x.y.z").url
+      new_url.delete_prefix!(root)
+
+      get new_url
+
+      expect(last_response).to have_attributes(status: 302)
+      expect(last_response.headers).to include("Location" => "https://x.y.z")
+      expect(last_response.body).to eq(
+        "<html><body>This content has moved to <a href=\"https://x.y.z\">https://x.y.z</a></body></html>",
+      )
+    end
+
+    it "redirects to not found url on unmatched urls" do
+      get "/123"
+
+      expect(last_response).to have_attributes(status: 302)
+      expect(last_response.headers).to include("Location" => "https://not-found.com")
+    end
+  end
+
+  describe "be_a_shortlink_to" do
+    include RSpec::Matchers::FailMatchers
+
+    let(:url_shortener) { shortener }
+    it "passes if the actual value is a shortlink to the given value" do
+      raw_url = "https://me"
+      # Make sure empty works
+      expect("x").to_not be_a_shortlink_to(raw_url)
+      expect(described_class).to receive(:gen_short_id).and_return("abc123")
+      shorty = shortener.shorten(raw_url)
+      expect(shorty.short_id).to be_a_shortlink_to(raw_url)
+      expect(shorty.url).to be_a_shortlink_to(raw_url)
+
+      expect do
+        expect(nil).to be_a_shortlink_to(raw_url)
+      end.to fail_with("No shortened URL found for nil")
+
+      expect do
+        expect(shorty.short_id + "1").to be_a_shortlink_to(raw_url)
+      end.to fail_with("No shortened URL found for \"abc1231\"")
+
+      expect do
+        expect(shorty.url + "1").to be_a_shortlink_to(raw_url)
+      end.to fail_with("No shortened URL found for \"https://mysite.com/abc1231\"")
+
+      expect do
+        expect("").to be_a_shortlink_to(raw_url)
+      end.to fail_with("No shortened URL found for \"\"")
+    end
+  end
+end


### PR DESCRIPTION
SMS on Android are suddenly replacing links like `?magic_link=123` with `?magic link=123` (underscores to spaces), which is breaking link parsing in messaging/SMS apps causing the link to be unclickable.

This change solves that by using a url shortener,
so that `https://app.mysuna.org/r/abc123`
goes to the original Lime url.

This adds a new `UrlShortener` application
(which is not tied to Suma directly) to encapsulate a simple url shortner which can support a pretty decent throughput. Note that because we want to eliminate 3rd party dependencies where feasible, especially around privacy, hosting costs, and provisioning simplicity, this was simpler to build than integrate. The behavior, limitations, and implementation are
documented in the code and aren't worth repeating here.