### PR TITLE
Twilio verification check

### DIFF
--- a/lib/suma/api/auth.rb
+++ b/lib/suma/api/auth.rb
@@ -118,6 +118,7 @@ class Suma::API::Auth < Suma::API::V1
         elsif Suma::Member.matches_allowlist?(me, Suma::Member.skip_verification_allowlist)
           nil
         else
+          Suma::Member::ResetCode.valid_verification_check!(params[:phone], params[:token])
           Suma::Member::ResetCode.use_code_with_token(params[:token]) do |code|
             raise Suma::Member::ResetCode::Unusable unless code.member === me
           end

--- a/lib/suma/message/sms_transport.rb
+++ b/lib/suma/message/sms_transport.rb
@@ -18,7 +18,7 @@ class Suma::Message::SmsTransport < Suma::Message::Transport
     # If set, any message deliveries using this template will use Signalwire verify, not normal SMS.
     setting :verification_template, "verification"
     # This is used to extract the verification code from a template.
-    # Must be coordinated with with the code generator.
+    # Must be coordinated with the code generator.
     # Default: match a word of only digits, surrounded by spaces or line start/end.
     setting :verification_code_regex, '\b(\d+)\b'
     # If set, disable SMS (but allow verifications)

--- a/lib/suma/spec_helpers/message.rb
+++ b/lib/suma/spec_helpers/message.rb
@@ -41,4 +41,20 @@ module Suma::SpecHelpers::Message
     )
     return req
   end
+
+  module_function def stub_twilio_verification_check(opts={})
+    opts[:fixture] ||= "twilio/post_verification_check"
+    opts[:status] ||= 200
+
+    if (body = opts[:body]).nil?
+      body = load_fixture_data(opts[:fixture])
+    end
+
+    req = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/VerificationCheck")
+    req = req.to_return(
+      status: opts[:status],
+      body: body.to_json,
+    )
+    return req
+  end
 end

--- a/lib/suma/twilio.rb
+++ b/lib/suma/twilio.rb
@@ -40,4 +40,14 @@ module Suma::Twilio
         verifications(ve_id).
         update(**kw)
   end
+
+  # Once we send verification, a verification check will complete
+  # the verification lifecycle and prevent being rate limited by Twilio
+  def self.check_verification(to, code:)
+    return self.client.verify.
+        v2.
+        services(self.verification_sid).
+        verification_checks.
+        create(to:, code:)
+  end
 end

--- a/spec/data/twilio/post_verification_check.json
+++ b/spec/data/twilio/post_verification_check.json
@@ -1,0 +1,14 @@
+{
+  "sid": "VE123",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+15017122661",
+  "channel": "sms",
+  "status": "approved",
+  "valid": true,
+  "amount": null,
+  "payee": null,
+  "sna_attempts_error_codes": [],
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z"
+}

--- a/spec/data/twilio/post_verification_check_invalid.json
+++ b/spec/data/twilio/post_verification_check_invalid.json
@@ -1,0 +1,14 @@
+{
+  "sid": "VE123",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+15017122661",
+  "channel": "sms",
+  "status": "approved",
+  "valid": false,
+  "amount": null,
+  "payee": null,
+  "sna_attempts_error_codes": [],
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z"
+}

--- a/spec/suma/api/auth_spec.rb
+++ b/spec/suma/api/auth_spec.rb
@@ -174,7 +174,9 @@ RSpec.describe Suma::API::Auth, :db, reset_configuration: Suma::Member do
     it "returns 200 if twilio verification code is valid" do
       c = Suma::Fixtures.member.with_phone("15554443210").create
       code = Suma::Fixtures.reset_code(member: c).sms.create
-      req = stub_twilio_verification_check(status: 200)
+      req = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/VerificationCheck").
+        with(body: {"To" => "+#{c.phone}", "Code" => code.token}).
+        to_return(status: 200, body: load_fixture_data("twilio/post_verification_check", raw: true))
 
       post("/v1/auth/verify", phone: c.phone, token: code.token)
 

--- a/spec/suma/twilio_spec.rb
+++ b/spec/suma/twilio_spec.rb
@@ -13,4 +13,15 @@ RSpec.describe Suma::Twilio, :db do
       expect(result).to have_attributes(sid: "VE123")
     end
   end
+
+  describe "check_verification" do
+    it "checks the verification code" do
+      req = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/VerificationCheck").
+        with(body: {"To" => "+15554443210", "Code" => "123456"}).
+        to_return(status: 200, body: load_fixture_data("twilio/post_verification_check", raw: true))
+      result = described_class.check_verification("+15554443210", code: "123456")
+      expect(req).to have_been_made
+      expect(result).to have_attributes(sid: "VE123", valid: true)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #661 

Twilio's verification cycle includes sending and checking the code. Suma only sends the verification but didn't implement the checking. A suma member may send multiple verifications sms codes and Twilio will rate limit after 5 attempts if they are not checked during the OTP authentication. This change runs the Twilio verification check on the code to complete the verification lifecycle and prevent being rate limited. 