### PR TITLE
Remove legacy session code

### DIFF
--- a/lib/suma/service/auth.rb
+++ b/lib/suma/service/auth.rb
@@ -2,14 +2,34 @@
 
 require "suma/yosoy"
 
-class Suma::Service::Auth < Suma::Yosoy::Middleware
-  def serialize_into_session(session, _env) = session.token
+module Suma::Service::Auth
+  class LegacySessionAdapterMiddleware
+    def initialize(app)
+      @app = app
+    end
 
-  def serialize_from_session(key, _env)
-    Suma::Member::Session.dataset.valid[token: key]
+    def call(env)
+      rack_session = env["rack.session"]
+      if (legacy_member_key = rack_session["warden.user.member.key"])
+        if (member = Suma::Member[legacy_member_key])
+          dbsession = member.add_session(**Suma::Member::Session.params_for_request(Rack::Request.new(env)))
+          rack_session["yosoy.key"] = dbsession.token
+        end
+        rack_session.delete("warden.user.member.key")
+      end
+      @app.call(env)
+    end
   end
 
-  def inactivity_timeout
-    Suma::Service.max_session_age
+  class Middleware < Suma::Yosoy::Middleware
+    def serialize_into_session(session, _env) = session.token
+
+    def serialize_from_session(key, _env)
+      Suma::Member::Session.dataset.valid[token: key]
+    end
+
+    def inactivity_timeout
+      Suma::Service.max_session_age
+    end
   end
 end

--- a/lib/suma/service/auth.rb
+++ b/lib/suma/service/auth.rb
@@ -2,34 +2,16 @@
 
 require "suma/yosoy"
 
-module Suma::Service::Auth
-  class LegacySessionAdapterMiddleware
-    def initialize(app)
-      @app = app
-    end
+module Suma::Service::Auth; end
 
-    def call(env)
-      rack_session = env["rack.session"]
-      if (legacy_member_key = rack_session["warden.user.member.key"])
-        if (member = Suma::Member[legacy_member_key])
-          dbsession = member.add_session(**Suma::Member::Session.params_for_request(Rack::Request.new(env)))
-          rack_session["yosoy.key"] = dbsession.token
-        end
-        rack_session.delete("warden.user.member.key")
-      end
-      @app.call(env)
-    end
+class Suma::Service::Auth::Middleware < Suma::Yosoy::Middleware
+  def serialize_into_session(session, _env) = session.token
+
+  def serialize_from_session(key, _env)
+    Suma::Member::Session.dataset.valid[token: key]
   end
 
-  class Middleware < Suma::Yosoy::Middleware
-    def serialize_into_session(session, _env) = session.token
-
-    def serialize_from_session(key, _env)
-      Suma::Member::Session.dataset.valid[token: key]
-    end
-
-    def inactivity_timeout
-      Suma::Service.max_session_age
-    end
+  def inactivity_timeout
+    Suma::Service.max_session_age
   end
 end

--- a/lib/suma/service/auth.rb
+++ b/lib/suma/service/auth.rb
@@ -2,34 +2,14 @@
 
 require "suma/yosoy"
 
-module Suma::Service::Auth
-  class LegacySessionAdapterMiddleware
-    def initialize(app)
-      @app = app
-    end
+class Suma::Service::Auth < Suma::Yosoy::Middleware
+  def serialize_into_session(session, _env) = session.token
 
-    def call(env)
-      rack_session = env["rack.session"]
-      if (legacy_member_key = rack_session["warden.user.member.key"])
-        if (member = Suma::Member[legacy_member_key])
-          dbsession = member.add_session(**Suma::Member::Session.params_for_request(Rack::Request.new(env)))
-          rack_session["yosoy.key"] = dbsession.token
-        end
-        rack_session.delete("warden.user.member.key")
-      end
-      @app.call(env)
-    end
+  def serialize_from_session(key, _env)
+    Suma::Member::Session.dataset.valid[token: key]
   end
 
-  class Middleware < Suma::Yosoy::Middleware
-    def serialize_into_session(session, _env) = session.token
-
-    def serialize_from_session(key, _env)
-      Suma::Member::Session.dataset.valid[token: key]
-    end
-
-    def inactivity_timeout
-      Suma::Service.max_session_age
-    end
+  def inactivity_timeout
+    Suma::Service.max_session_age
   end
 end

--- a/lib/suma/service/middleware.rb
+++ b/lib/suma/service/middleware.rb
@@ -70,8 +70,7 @@ module Suma::Service::Middleware
   end
 
   def self.add_auth_middleware(builder)
-    builder.use Suma::Service::Auth::LegacySessionAdapterMiddleware
-    builder.use Suma::Service::Auth::Middleware
+    builder.use Suma::Service::Auth
   end
 
   def self.add_etag_middleware(builder)

--- a/lib/suma/service/middleware.rb
+++ b/lib/suma/service/middleware.rb
@@ -70,7 +70,6 @@ module Suma::Service::Middleware
   end
 
   def self.add_auth_middleware(builder)
-    builder.use Suma::Service::Auth::LegacySessionAdapterMiddleware
     builder.use Suma::Service::Auth::Middleware
   end
 

--- a/lib/suma/service/middleware.rb
+++ b/lib/suma/service/middleware.rb
@@ -70,7 +70,8 @@ module Suma::Service::Middleware
   end
 
   def self.add_auth_middleware(builder)
-    builder.use Suma::Service::Auth
+    builder.use Suma::Service::Auth::LegacySessionAdapterMiddleware
+    builder.use Suma::Service::Auth::Middleware
   end
 
   def self.add_etag_middleware(builder)

--- a/spec/suma/service_spec.rb
+++ b/spec/suma/service_spec.rb
@@ -760,31 +760,6 @@ RSpec.describe Suma::Service, :db do
       expect(last_response).to have_status(401)
     end
 
-    describe "with a legacy session" do
-      it "creates a new session and uses the new session format" do
-        # Need to set the id explicitly since the hash is appended to the cookie value string,
-        # and we're using a verbatim value rather than dynamically creating the encrypted cookie string.
-        member.this.update(id: 131)
-        member = Suma::Member[131]
-        Suma::Service.cookie_config[:coder].encode(
-          {
-            "session_id" => "e77affbdceca795a52e890e1a7565f2026907ebdf6b0b2724003249b6d57e8d5",
-            "_" => "_",
-            "warden.user.member.key" => 131,
-          },
-        )
-        header(
-          "Cookie",
-          # rubocop:disable Layout/LineLength
-          "suma.session=eJwNzFEKgzAMANC75FskjaaxXqY0JgURHVjGGLK7r1%2Fv7z3QvLX9deXdYAUXKbWqbb4VSVyYfEnooQhHroQUE4qr1aioJDQjTjQnjcbiizEMkHuTu59ym1%2Fju%2Fk9nn5q5%2FAvrGEKvz9CAyMe--18911f8d554fe3fea8ab59eda6d1f99ff6afcdcf",
-          # rubocop:enable Layout/LineLength
-        )
-        get "/current_member"
-        expect(last_response).to have_status(200)
-        expect(member.refresh.sessions).to include(have_attributes(token: start_with("ses_")))
-      end
-    end
-
     describe "session validation", reset_configuration: described_class do
       before(:each) do
         post "/set_member", id: member.id


### PR DESCRIPTION
Fixes #653 

Remove legacy sessions code, `LegacySessionAdapterMiddleware`. Check ticket above for details.