### PR TITLE
Configure url_shortener and restore lime url shortening

### DIFF
--- a/lib/suma/anon_proxy/message_handler/lime.rb
+++ b/lib/suma/anon_proxy/message_handler/lime.rb
@@ -32,12 +32,12 @@ class Suma::AnonProxy::MessageHandler::Lime < Suma::AnonProxy::MessageHandler
       result.handled = false
       return result
     end
-    shortened_link = Suma::UrlShortener.shortener.shorten(magic_link).url
-    vendor_account_message.vendor_account.replace_access_code(token, shortened_link).save_changes
+    link_to_use = Suma::UrlShortener.enabled? ? Suma::UrlShortener.shortener.shorten(magic_link).url : magic_link
+    vendor_account_message.vendor_account.replace_access_code(token, link_to_use).save_changes
     msg = Suma::Messages::SingleValue.new(
       "anon_proxy",
       "lime-deep-link-access-code",
-      shortened_link,
+      link_to_use,
     )
     vendor_account_message.vendor_account.member.message_preferences!.dispatch(msg)
     result.handled = true

--- a/lib/suma/url_shortener.rb
+++ b/lib/suma/url_shortener.rb
@@ -13,6 +13,7 @@ module Suma::UrlShortener
     setting :table, :url_shortener
     setting :not_found_url, "https://mysuma.org/404"
     setting :byte_size, 2
+    setting :disabled, false
   end
 
   class << self
@@ -29,7 +30,12 @@ module Suma::UrlShortener
       return ::UrlShortener.new(**opts)
     end
 
+    def enabled? = !self.disabled
+
     # @return [UrlShortener]
-    def shortener = @shortener ||= new_shortener
+    def shortener
+      return nil unless self.enabled?
+      return @shortener ||= new_shortener
+    end
   end
 end

--- a/spec/suma/anon_proxy/message_handler_spec.rb
+++ b/spec/suma/anon_proxy/message_handler_spec.rb
@@ -124,6 +124,20 @@ RSpec.describe Suma::AnonProxy::MessageHandler, :db do
       )
     end
 
+    it "can skip url shortening", reset_configuration: Suma::UrlShortener do
+      Suma::UrlShortener.disabled = true
+      got = Suma::AnonProxy::MessageHandler.handle(
+        Suma::AnonProxy::Relay.create!("fake-relay"),
+        signin_message,
+      )
+      expect(got).to have_attributes(vendor_account:, outbound_delivery: nil)
+      expect(vendor_account.refresh).to have_attributes(
+        latest_access_code: "M1ZgpMepjL5kW9XgzCmnsBKQ",
+        latest_access_code_magic_link: start_with("https://limebike.app.link"),
+        latest_access_code_set_at: match_time(:now),
+      )
+    end
+
     it "parses an confirmation access code code, assigns it to the vendor account, and sends it via SMS" do
       got = Suma::AnonProxy::MessageHandler.handle(
         Suma::AnonProxy::Relay.create!("fake-relay"),

--- a/spec/suma/url_shortener_spec.rb
+++ b/spec/suma/url_shortener_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "suma/url_shortener"
+
+RSpec.describe Suma::UrlShortener do
+  it "returns nil for the shortener if disabled", reset_configuration: Suma::UrlShortener do
+    described_class.disabled = true
+    expect(described_class.shortener).to be_nil
+    described_class.disabled = false
+    expect(described_class.shortener).to be_a(UrlShortener)
+  end
+end


### PR DESCRIPTION
Add configuration to enable/disable `UrlShortener.shorten` method. If setting is false, the method returns nil. Otherwise process the url shortening. Add test.

Add shortening back to lime msg handler based on the settings above and restore the tests.