### PR TITLE
Update twilio when reset codes are modified

### DIFF
--- a/db/migrations/050_reset_code_messages.rb
+++ b/db/migrations/050_reset_code_messages.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:member_reset_codes) do
+      add_foreign_key :message_delivery_id, :message_deliveries
+      add_column :canceled, :boolean, default: false
+    end
+  end
+end

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -33,6 +33,7 @@ module Suma::Async
     "suma/async/plaid_update_institutions",
     "suma/async/process_anon_proxy_inbound_webhookdb_relays",
     "suma/async/reset_code_create_dispatch",
+    "suma/async/reset_code_update_twilio",
     "suma/async/stripe_refunds_backfiller",
     "suma/async/sync_lime_free_bike_status_gbfs",
     "suma/async/sync_lime_geofencing_zones_gbfs",

--- a/lib/suma/async/reset_code_update_twilio.rb
+++ b/lib/suma/async/reset_code_update_twilio.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "amigo/job"
+
+class Suma::Async::ResetCodeUpdateTwilio
+  extend Amigo::Job
+
+  on "suma.member.resetcode.updated"
+
+  def _perform(event)
+    code = self.lookup_model(Suma::Member::ResetCode, event)
+    case event.payload[1]
+      when changed(:used, from: false, to: true)
+        self.update_verification(code, "approved")
+      when changed(:canceled, from: false, to: true)
+        self.update_verification(code, "canceled")
+    end
+  end
+
+  def update_verification(code, status)
+    md = code.message_delivery
+    return unless
+      # It's possible for a code to be expired before we have even sent the delivery
+      md &&
+        # email codes aren't using twilio verify, at least not yet (and probably never)
+        md.transport_type == "sms" &&
+        # We can send verifications using alternative templates; only the verification template uses
+        # the 'send via twilio verify' logic in SmsTransport, so we only update twilio when we use that template.
+        Suma::Message::SmsTransport.verification_delivery?(md)
+    verification_id = Suma::Message::SmsTransport.transport_message_id_to_verification_id(md.transport_message_id)
+    Suma::Twilio.update_verification(verification_id, status:)
+  end
+end

--- a/lib/suma/fixtures/message_deliveries.rb
+++ b/lib/suma/fixtures/message_deliveries.rb
@@ -71,4 +71,10 @@ module Suma::Fixtures::MessageDeliveries
   decorator :extra do |k, v|
     self.extra_fields[k.to_s] = v
   end
+
+  decorator :sent_to_verification do |verification_sid="VE#{SecureRandom.hex(4)}"|
+    self.transport_type = "sms"
+    self.template = Suma::Message::SmsTransport.verification_template
+    self.transport_message_id = Suma::Message::SmsTransport.verification_transport_message_id(verification_sid, "1")
+  end
 end


### PR DESCRIPTION
When a reset code is forcibly expired
(ie, another code is used, or a new code is requested), set the verification as canceled in Twilio.

When a code is successfully used,
set the verification as approved in Twilio.

This required a few changes:

- Reset codes track explicitly if they are canceled
- The message delivery the reset code dispatches is stored on the reset code.
- Verification ID, already stored in the delivery transport message id, are now 'structured', so we can get the verification id back out of them. This is sort of gross, but we don't have a better solution; and since twilio is coupled to SMS auth, it's fine.

Closes #672 and fixes #661 