### PR TITLE
Configure image blobs in CSP builder

### DIFF
--- a/lib/rack/csp.rb
+++ b/lib/rack/csp.rb
@@ -23,7 +23,7 @@ class Rack::Csp
   end
 
   class Policy
-    attr_reader :safe, :inline_scripts, :script_hashes, :img_data, :parts
+    attr_reader :safe, :inline_scripts, :script_hashes, :img_data, :img_blob, :parts
 
     def self.from_hash(h)
       explicit_parts = h[:parts]
@@ -46,6 +46,7 @@ class Rack::Csp
       inline_scripts: [],
       script_hashes: [],
       img_data: false,
+      img_blob: false,
       parts: {}
     )
       safe = safe.compact.join(" ") if safe.respond_to?(:to_ary)
@@ -53,6 +54,7 @@ class Rack::Csp
       @inline_scripts = inline_scripts
       @script_hashes = script_hashes
       @img_data = img_data
+      @img_blob = img_blob
       @parts = parts
     end
 
@@ -64,6 +66,7 @@ class Rack::Csp
 
       img_src = +safe.dup
       img_src << " data:" if img_data
+      img_src << " blob:" if img_blob
 
       script_src = +safe.dup
       all_script_hashes.each do |h|

--- a/lib/suma/apps.rb
+++ b/lib/suma/apps.rb
@@ -209,6 +209,7 @@ module Suma::Apps
         safe: ["'self' mysuma.org *.mysuma.org", Suma::Sentry.dsn_host],
         inline_scripts: [script],
         img_data: true,
+        img_blob: true,
         parts: {
           "style-src-elem" => "<SAFE> fonts.googleapis.com 'unsafe-inline'",
           "font-src" => "<SAFE> fonts.gstatic.com",

--- a/spec/rack/csp_spec.rb
+++ b/spec/rack/csp_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe Rack::Csp do
     expect(csp(mw)).to eq("hi")
   end
 
+  it "can set image blob with the policy hash settings" do
+    mw = described_class.new(app, policy: {img_blob: true})
+    expect(csp(mw)).to eq("default-src 'self'; img-src 'self' blob:; script-src 'self'")
+  end
+
   it "can use a policy object" do
     mw = described_class.new(app, policy: described_class::Policy.new)
     expect(csp(mw)).to eq("default-src 'self'; img-src 'self'; script-src 'self'")


### PR DESCRIPTION
Fixes #677 

Trying to upload and display an image in admin caused broken image since the content security policy was not allowing image ` blob:`. This change adds the `img_blob` setting to the CSP Policy builder allow blobs to be loaded and displayed. Then allow this setting in the admin app (not necessary for the normal app).

### Image displayed after choosing/setting image to upload
<img width="660" alt="Screenshot 2024-08-05 at 3 34 47 PM" src="https://github.com/user-attachments/assets/d6f44556-3b1c-4546-a49c-eea435945223">
