### PR TITLE
Allow admin image editing on all image resources

### DIFF
--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -61,6 +61,7 @@ import VendorDetailPage from "./pages/VendorDetailPage";
 import VendorEditPage from "./pages/VendorEditPage";
 import VendorListPage from "./pages/VendorListPage";
 import VendorServiceDetailPage from "./pages/VendorServiceDetailPage";
+import VendorServiceEditPage from "./pages/VendorServiceEditPage";
 import VendorServiceListPage from "./pages/VendorServiceListPage";
 import applyHocs from "./shared/applyHocs";
 import { installPromiseExtras } from "./shared/bluejay";
@@ -440,6 +441,11 @@ function PageSwitch() {
           withLayout(),
           VendorServiceDetailPage
         )}
+      />
+      <Route
+        exact
+        path="/vendor-service/:id/edit"
+        element={renderWithHocs(redirectIfUnauthed, withLayout(), VendorServiceEditPage)}
       />
       <Route
         exact

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -152,9 +152,9 @@ export default {
     post(`/adminapi/v1/commerce_offering_products/${id}`, data),
 
   getVendors: (data) => get(`/adminapi/v1/vendors`, data),
-  createVendor: (data) => post("/adminapi/v1/vendors/create", data),
+  createVendor: (data) => postForm("/adminapi/v1/vendors/create", data),
   getVendor: ({ id, ...data }) => get(`/adminapi/v1/vendors/${id}`, data),
-  updateVendor: ({ id, ...data }) => post(`/adminapi/v1/vendors/${id}`, data),
+  updateVendor: ({ id, ...data }) => postForm(`/adminapi/v1/vendors/${id}`, data),
 
   getVendibleGroups: (data) => get(`/adminapi/v1/vendible_groups`, data),
   createVendibleGroup: (data) => post("/adminapi/v1/vendible_groups/create", data),
@@ -164,6 +164,8 @@ export default {
 
   getVendorServices: (data) => get(`/adminapi/v1/vendor_services`, data),
   getVendorService: ({ id, ...data }) => get(`/adminapi/v1/vendor_services/${id}`, data),
+  updateVendorService: ({ id, ...data }) =>
+    postForm(`/adminapi/v1/vendor_services/${id}`, data),
   updateVendorServiceEligibilityConstraints: ({ id, ...data }) =>
     post(`/adminapi/v1/vendor_services/${id}/eligibilities`, data),
 

--- a/adminapp/src/components/ImageFileInput.jsx
+++ b/adminapp/src/components/ImageFileInput.jsx
@@ -1,8 +1,26 @@
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import { Button, FormHelperText, FormLabel, Stack, Typography } from "@mui/material";
+import isEmpty from "lodash/isEmpty";
 import React from "react";
 
+/**
+ * Image file input disguised as a custom upload button.
+ * If you pass in an image file object or blob, it will be displayed
+ * along with the image caption.
+ * @param image the image source file or image blob
+ * @param required sets the input field as required
+ * @param onImageChange callback func which passes image file
+ * @returns {JSX.Element}
+ * @constructor
+ */
 function ImageFileInput({ image, required, onImageChange }) {
+  let src = {};
+  if (image?.url) {
+    src = image.url;
+  }
+  if (image instanceof Blob) {
+    src = URL.createObjectURL(image);
+  }
   return (
     <Stack spacing={1}>
       <FormLabel>Image:</FormLabel>
@@ -10,9 +28,12 @@ function ImageFileInput({ image, required, onImageChange }) {
         Set image
         <input
           type="file"
-          name="image input"
+          name="image"
           accept=".jpg,.jpeg,.png"
-          hidden
+          // zero opacity hides the input and allows form validation
+          // error messages to popup, unlike 'hidden' attribute. 0px also
+          // prevents validation errors from popping up, so use 1px.
+          style={{ opacity: "0", width: "1px" }}
           required={required}
           onChange={(e) => onImageChange(e.target.files[0])}
         />
@@ -21,13 +42,14 @@ function ImageFileInput({ image, required, onImageChange }) {
         Use JPEG and PNG formats. Suggest using size 500x500 pixels or above to avoid
         display issues.
       </FormHelperText>
-      {Boolean(image) && (
+      {!isEmpty(src) && (
         <>
-          <img src={URL.createObjectURL(image)} alt={image.name} />
-          <Typography variant="body2">{image.name}</Typography>
+          <img src={src} alt={image.name || image.caption} />
+          <Typography variant="body2">{image.name || image.caption}</Typography>
         </>
       )}
     </Stack>
   );
 }
+
 export default ImageFileInput;

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -46,13 +46,10 @@ export default function OfferingForm({
     >
       <Stack spacing={2}>
         <ImageFileInput
-          image={resource.image instanceof Blob && resource.image}
+          image={resource.image}
           onImageChange={(f) => setField("image", f)}
           required={isCreate}
         />
-        {resource.image?.url && (
-          <img src={resource.image.url} alt={resource.image.caption} />
-        )}
         <FormLabel>Description (text in offering list)</FormLabel>
         <ResponsiveStack>
           <MultiLingualText

--- a/adminapp/src/pages/ProductForm.jsx
+++ b/adminapp/src/pages/ProductForm.jsx
@@ -39,13 +39,10 @@ export default function ProductForm({
     >
       <Stack spacing={2}>
         <ImageFileInput
-          image={resource.image instanceof Blob && resource.image}
+          image={resource.image}
           onImageChange={(f) => setField("image", f)}
           required={isCreate}
         />
-        {resource.image?.url && (
-          <img src={resource.image.url} alt={resource.image.caption} />
-        )}
         <Stack spacing={2}>
           <FormLabel>Name:</FormLabel>
           <ResponsiveStack>

--- a/adminapp/src/pages/VendorCreatePage.jsx
+++ b/adminapp/src/pages/VendorCreatePage.jsx
@@ -4,7 +4,6 @@ import VendorForm from "./VendorForm";
 import React from "react";
 
 export default function VendorCreatePage() {
-  const empty = { name: "" };
-
+  const empty = { image: null, name: "" };
   return <ResourceCreate empty={empty} apiCreate={api.createVendor} Form={VendorForm} />;
 }

--- a/adminapp/src/pages/VendorDetailPage.jsx
+++ b/adminapp/src/pages/VendorDetailPage.jsx
@@ -5,6 +5,7 @@ import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
+import SumaImage from "../shared/react/SumaImage";
 import theme from "../theme";
 import map from "lodash/map";
 import React from "react";
@@ -18,6 +19,19 @@ export default function VendorDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
+        {
+          label: "Image",
+          value: (
+            <SumaImage
+              image={model.image}
+              alt={model.image.name}
+              className="w-100"
+              params={{ crop: "center" }}
+              h={225}
+              width={225}
+            />
+          ),
+        },
         { label: "Name", value: model.name },
         { label: "Slug", value: model.slug },
       ]}

--- a/adminapp/src/pages/VendorForm.jsx
+++ b/adminapp/src/pages/VendorForm.jsx
@@ -1,10 +1,12 @@
 import FormLayout from "../components/FormLayout";
-import { TextField } from "@mui/material";
+import ImageFileInput from "../components/ImageFileInput";
+import { Stack, TextField } from "@mui/material";
 import React from "react";
 
 export default function VendorForm({
   isCreate,
   resource,
+  setField,
   setFieldFromInput,
   register,
   isBusy,
@@ -19,14 +21,21 @@ export default function VendorForm({
       onSubmit={onSubmit}
       isBusy={isBusy}
     >
-      <TextField
-        {...register("name")}
-        label="Name"
-        name="name"
-        value={resource.name}
-        fullWidth
-        onChange={setFieldFromInput}
-      />
+      <Stack spacing={2}>
+        <ImageFileInput
+          image={resource.image}
+          required={isCreate}
+          onImageChange={(f) => setField("image", f)}
+        />
+        <TextField
+          {...register("name")}
+          label="Name"
+          name="name"
+          value={resource.name}
+          fullWidth
+          onChange={setFieldFromInput}
+        />
+      </Stack>
     </FormLayout>
   );
 }

--- a/adminapp/src/pages/VendorServiceDetailPage.jsx
+++ b/adminapp/src/pages/VendorServiceDetailPage.jsx
@@ -13,6 +13,7 @@ export default function VendorServiceDetailPage() {
     <ResourceDetail
       apiGet={api.getVendorService}
       title={(model) => `Vendor Service ${model.id}`}
+      toEdit={(model) => `/vendor-service/${model.id}/edit`}
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },

--- a/adminapp/src/pages/VendorServiceEditPage.jsx
+++ b/adminapp/src/pages/VendorServiceEditPage.jsx
@@ -1,0 +1,14 @@
+import api from "../api";
+import ResourceEdit from "../components/ResourceEdit";
+import VendorServiceForm from "./VendorServiceForm.jsx";
+import React from "react";
+
+export default function VendorServiceEditPage() {
+  return (
+    <ResourceEdit
+      apiGet={api.getVendorService}
+      apiUpdate={api.updateVendorService}
+      Form={VendorServiceForm}
+    />
+  );
+}

--- a/adminapp/src/pages/VendorServiceForm.jsx.jsx
+++ b/adminapp/src/pages/VendorServiceForm.jsx.jsx
@@ -1,0 +1,61 @@
+import FormLayout from "../components/FormLayout";
+import ImageFileInput from "../components/ImageFileInput";
+import ResponsiveStack from "../components/ResponsiveStack";
+import { dayjsOrNull, formatOrNull } from "../modules/dayConfig";
+import RemoveIcon from "@mui/icons-material/Remove";
+import { Stack, TextField } from "@mui/material";
+import { DateTimePicker } from "@mui/x-date-pickers";
+import React from "react";
+
+export default function VendorServiceForm({
+  isCreate,
+  resource,
+  setField,
+  setFieldFromInput,
+  register,
+  isBusy,
+  onSubmit,
+}) {
+  return (
+    <FormLayout
+      title={isCreate ? "Create a Vendor Service" : "Update Vendor Service"}
+      subtitle="Vendor services are another type of 'good' that can be sold,
+       similar to commerce offerings. It is currently used for more complex
+       vendor service setups like the Lime integration."
+      onSubmit={onSubmit}
+      isBusy={isBusy}
+    >
+      <Stack spacing={2}>
+        <ImageFileInput
+          image={resource.image}
+          required={isCreate}
+          onImageChange={(f) => setField("image", f)}
+        />
+        <TextField
+          {...register("externalName")}
+          label="Name"
+          name="externalName"
+          value={resource.externalName}
+          fullWidth
+          onChange={setFieldFromInput}
+        />
+        <ResponsiveStack alignItems="center" divider={<RemoveIcon />}>
+          <DateTimePicker
+            label="Open Date"
+            value={dayjsOrNull(resource.periodBegin)}
+            closeOnSelect
+            onChange={(v) => setField("periodBegin", formatOrNull(v))}
+            sx={{ width: "100%" }}
+          />
+          <DateTimePicker
+            label="Close Date"
+            value={dayjsOrNull(resource.periodEnd)}
+            onChange={(v) => setField("periodEnd", formatOrNull(v))}
+            closeOnSelect
+            sx={{ width: "100%" }}
+          />
+        </ResponsiveStack>
+      </Stack>
+    </FormLayout>
+  );
+}

--- a/lib/suma/admin_api/vendor_services.rb
+++ b/lib/suma/admin_api/vendor_services.rb
@@ -23,6 +23,7 @@ class Suma::AdminAPI::VendorServices < Suma::AdminAPI::V1
 
   class DetailedVendorServiceEntity < VendorServiceEntity
     include Suma::AdminAPI::Entities
+    expose :external_name
     expose :internal_name
     expose :mobility_vendor_adapter_key
     expose :vendor_service_categories, as: :categories, with: VendorServiceCategoryEntity
@@ -38,9 +39,15 @@ class Suma::AdminAPI::VendorServices < Suma::AdminAPI::V1
       VendorServiceEntity,
       search_params: [:internal_name, :external_name],
     )
-
     Suma::AdminAPI::CommonEndpoints.get_one(self, Suma::Vendor::Service, DetailedVendorServiceEntity)
-
+    Suma::AdminAPI::CommonEndpoints.update(self, Suma::Vendor::Service, DetailedVendorServiceEntity) do
+      params do
+        optional :image, type: File
+        optional :external_name, type: String
+        optional :period_begin, type: Time
+        optional :period_end, type: Time
+      end
+    end
     Suma::AdminAPI::CommonEndpoints.eligibilities(
       self,
       Suma::Vendor::Service,

--- a/lib/suma/admin_api/vendors.rb
+++ b/lib/suma/admin_api/vendors.rb
@@ -12,6 +12,7 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
     expose :services, with: VendorServiceEntity
     expose :products, with: ProductEntity
     expose :configurations, with: VendorConfigurationEntity
+    expose :image, with: ImageEntity, &self.delegate_to(:images?, :first)
   end
 
   resource :vendors do
@@ -24,6 +25,7 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
 
     Suma::AdminAPI::CommonEndpoints.create(self, Suma::Vendor, DetailedVendorEntity) do
       params do
+        requires :image, type: File
         requires :name, type: String, allow_blank: false
       end
     end
@@ -32,6 +34,7 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
 
     Suma::AdminAPI::CommonEndpoints.update self, Suma::Vendor, DetailedVendorEntity do
       params do
+        optional :image, type: File
         optional :name, type: String, allow_blank: false
       end
     end

--- a/spec/suma/admin_api/vendor_services_spec.rb
+++ b/spec/suma/admin_api/vendor_services_spec.rb
@@ -90,6 +90,23 @@ RSpec.describe Suma::AdminAPI::VendorServices, :db do
     end
   end
 
+  describe "POST /v1/vendor_services/:id" do
+    it "updates a vendor service" do
+      v = Suma::Fixtures.vendor_service.create
+      photo_file = File.open("spec/data/images/photo.png", "rb")
+      image = Rack::Test::UploadedFile.new(photo_file, "image/png", true)
+
+      post "/v1/vendor_services/#{v.id}",
+           external_name: "test",
+           image: image,
+           period_begin: "2024-07-01T00:00:00-0700",
+           period_end: "2024-10-01T00:00:00-0700"
+
+      expect(last_response).to have_status(200)
+      expect(v.refresh).to have_attributes(external_name: "test")
+    end
+  end
+
   describe "POST /v1/vendor_services/:id/eligibilities" do
     it "replaces the eligibilities" do
       ec = Suma::Fixtures.eligibility_constraint.create

--- a/spec/suma/admin_api/vendors_spec.rb
+++ b/spec/suma/admin_api/vendors_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
 
   let(:app) { described_class.build_app }
   let(:admin) { Suma::Fixtures.member.admin.create }
+  let(:photo_file) { File.open("spec/data/images/photo.png", "rb") }
+  let(:image) { Rack::Test::UploadedFile.new(photo_file, "image/png", true) }
 
   before(:each) do
     login_as(admin)
@@ -63,7 +65,7 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
 
   describe "POST /v1/vendors/create" do
     it "creates a vendor" do
-      post "/v1/vendors/create", name: "test"
+      post "/v1/vendors/create", name: "test", image: image
 
       expect(last_response).to have_status(200)
       expect(Suma::Vendor.all).to have_length(1)
@@ -103,7 +105,7 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
     it "updates a vendor" do
       v = Suma::Fixtures.vendor.create
 
-      post "/v1/vendors/#{v.id}", name: "test"
+      post "/v1/vendors/#{v.id}", name: "test", image: image
 
       expect(last_response).to have_status(200)
       expect(v.refresh).to have_attributes(name: "test")


### PR DESCRIPTION
Add image uploading for:
- vendor create and edit routes
- vendor services edit route (we don't allow create route yet)

Also refactors the `ImageFileInput` to be reusable and fixes bug where the default browser validation error popup would not display due to the `hidden` attribute.

### Fixed image validation popup after form submission
<img width="647" alt="Screenshot 2024-08-05 at 6 46 00 PM" src="https://github.com/user-attachments/assets/ff9a35f1-9783-4615-9e32-cb045df5c773">
