### PR TITLE
Refactor how payment instruments are updated

### DIFF
--- a/lib/suma/api/entities.rb
+++ b/lib/suma/api/entities.rb
@@ -101,7 +101,6 @@ module Suma::API::Entities
     expose :ongoing_trip
     expose :read_only_mode?, as: :read_only_mode
     expose :read_only_reason
-    expose :usable_payment_instruments, with: PaymentInstrumentEntity
     expose :admin_member, expose_nil: false, with: Suma::Service::Entities::CurrentMember do |_|
       self.current_session.impersonation? ? self.current_session.member : nil
     end

--- a/lib/suma/api/payments.rb
+++ b/lib/suma/api/payments.rb
@@ -25,7 +25,6 @@ class Suma::API::Payments < Suma::API::V1
         instrument:,
         apply_at: Time.now,
       )
-      add_current_member_header
       status 200
       present fx, with: FundingTransactionEntity
     end

--- a/spec/suma/api/payments_spec.rb
+++ b/spec/suma/api/payments_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Suma::API::Payments, :db do
       end
 
       expect(last_response).to have_status(200)
-      expect(last_response.headers).to include("Suma-Current-Member")
       expect(last_response).to have_json_body.that_includes(status: "created")
 
       expect(member.payment_account.originated_funding_transactions).to contain_exactly(

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -87,6 +87,10 @@ export default {
   claimOrder: ({ orderId, ...data }) =>
     post(`/api/v1/commerce/orders/${orderId}/claim`, data),
 
+  getPaymentInstrument: ({ id, ...data }) =>
+    get(`/api/v1/payment_instruments/${id}`, data),
+  getPaymentInstruments: (data) => get(`/api/v1/payment_instruments`, data),
+
   createBankAccount: (data) =>
     post(`/api/v1/payment_instruments/bank_accounts/create`, data),
   deleteBankAccount: (data) =>

--- a/webapp/src/pages/FundingAddCard.jsx
+++ b/webapp/src/pages/FundingAddCard.jsx
@@ -6,7 +6,6 @@ import RLink from "../components/RLink";
 import { md, t } from "../localization";
 import { extractErrorCode, useError } from "../state/useError";
 import useScreenLoader from "../state/useScreenLoader";
-import useUser from "../state/useUser";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 import Button from "react-bootstrap/Button";
@@ -18,7 +17,6 @@ export default function FundingAddCard() {
   const returnTo = params.get("returnTo");
   const returnToImmediate = params.get("returnToImmediate");
   const [submitSuccessful, setSubmitSuccessful] = React.useState(null);
-  const { handleUpdateCurrentMember } = useUser();
   const screenLoader = useScreenLoader();
   const [error, setError] = useError();
 
@@ -28,7 +26,6 @@ export default function FundingAddCard() {
       setError("");
       api
         .createCardStripe({ token: stripeToken })
-        .tap(handleUpdateCurrentMember)
         .then((r) => {
           if (returnToImmediate) {
             navigate(
@@ -44,7 +41,7 @@ export default function FundingAddCard() {
         .catch((e) => setError(extractErrorCode(e)))
         .finally(screenLoader.turnOff);
     },
-    [handleUpdateCurrentMember, navigate, returnToImmediate, screenLoader, setError]
+    [navigate, returnToImmediate, screenLoader, setError]
   );
 
   return (

--- a/webapp/src/pages/FundingLinkBankAccount.jsx
+++ b/webapp/src/pages/FundingLinkBankAccount.jsx
@@ -12,7 +12,6 @@ import keepDigits from "../modules/keepDigits";
 import useHashToggle from "../shared/react/useHashToggle";
 import { extractErrorCode, useError } from "../state/useError";
 import useScreenLoader from "../state/useScreenLoader";
-import useUser from "../state/useUser";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 import Button from "react-bootstrap/Button";
@@ -74,7 +73,6 @@ function LinkBankAccount({ onSuccess, returnTo }) {
     mode: "all",
   });
   const [error, setError] = useError();
-  const { user, setUser, handleUpdateCurrentMember } = useUser();
 
   const screenLoader = useScreenLoader();
   const showCheckModalToggle = useHashToggle("check-details");
@@ -99,11 +97,9 @@ function LinkBankAccount({ onSuccess, returnTo }) {
         accountNumber,
         accountType,
       })
-      .tap(handleUpdateCurrentMember)
-      .then((r) => {
-        setUser({ ...user, usablePaymentInstruments: r.data.allPaymentInstruments });
-        onSuccess({ instrumentId: r.data.id, instrumentType: r.data.paymentMethodType });
-      })
+      .then((r) =>
+        onSuccess({ instrumentId: r.data.id, instrumentType: r.data.paymentMethodType })
+      )
       .catch((e) => setError(extractErrorCode(e)))
       .finally(screenLoader.turnOff);
   };

--- a/webapp/src/state/useUser.jsx
+++ b/webapp/src/state/useUser.jsx
@@ -12,5 +12,4 @@ export default useUser;
  * @property {boolean} ongoingTrip
  * @property {boolean} readOnlyMode
  * @property {string} readOnlyReason
- * @property {Array<object>} usablePaymentInstruments
  */


### PR DESCRIPTION
Fixes #312 

Instead of relying on current_member_header for exposing payment instruments, create API's that fetchs the instrument(s) when the appropriate page is loaded. Otherwise current_member_header could possibly hold large payment instrument data.

- Remove dependency of `add_current_member_header` (payment instruments can contain large data)
- Only fetch instruments when we're in the `Funding` page
- Only fetch instrument when we are adding funds to it
- Test api changes
- Test frontend checkout card adding