### PR TITLE
Check for card duplication, raise error if so

### DIFF
--- a/lib/suma/member/stripe_attributes.rb
+++ b/lib/suma/member/stripe_attributes.rb
@@ -95,4 +95,8 @@ class Suma::Member::StripeAttributes
     )
     self.update_customer_json(cust)
   end
+
+  def get_token(token_id)
+    return Stripe::Token.retrieve(token_id)
+  end
 end

--- a/lib/suma/member/stripe_attributes.rb
+++ b/lib/suma/member/stripe_attributes.rb
@@ -95,8 +95,4 @@ class Suma::Member::StripeAttributes
     )
     self.update_customer_json(cust)
   end
-
-  def get_token(token_id)
-    return Stripe::Token.retrieve(token_id)
-  end
 end

--- a/lib/suma/payment/card.rb
+++ b/lib/suma/payment/card.rb
@@ -49,6 +49,7 @@ class Suma::Payment::Card < Suma::Postgres::Model(:payment_cards)
   end
 
   def stripe_id = self.stripe_json.fetch("id")
+  def fingerprint = self.stripe_json.fetch("fingerprint")
   def last4  = self.stripe_json.fetch("last4")
   def brand  = self.stripe_json.fetch("brand")
   def name = "#{self.brand} x-#{self.last4}"

--- a/spec/suma/api/payment_instruments_spec.rb
+++ b/spec/suma/api/payment_instruments_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Suma::API::PaymentInstruments, :db, reset_configuration: Suma::Pa
     login_as(member)
   end
 
+  def stub_token_req
+    return stub_request(:get, "https://api.stripe.com/v1/tokens/tok_1AWuxsJd4nFN3COfSKY8195M").
+        to_return(fixture_response("stripe/token"))
+  end
+
   describe "POST /v1/payment_instruments/bank_accounts/create" do
     let(:account_number) { "99988877" }
     let(:routing_number) { "111222333" }
@@ -95,6 +100,7 @@ RSpec.describe Suma::API::PaymentInstruments, :db, reset_configuration: Suma::Pa
   describe "POST /v1/payment_instruments/cards/create_stripe" do
     it "creates a customer and card using a Stripe token" do
       reqs = [
+        stub_token_req,
         stub_request(:post, "https://api.stripe.com/v1/customers").
           to_return(fixture_response("stripe/customer")),
         stub_request(:post, "https://api.stripe.com/v1/customers/cus_D6eGmbqyejk8s9/sources").
@@ -115,6 +121,7 @@ RSpec.describe Suma::API::PaymentInstruments, :db, reset_configuration: Suma::Pa
     end
 
     it "handles a customer who is already registered" do
+      token_req = stub_token_req
       req = stub_request(:post, "https://api.stripe.com/v1/customers/cus_D6eGmbqyejk8s9/sources").
         to_return(fixture_response("stripe/card"))
 
@@ -122,27 +129,50 @@ RSpec.describe Suma::API::PaymentInstruments, :db, reset_configuration: Suma::Pa
       post "/v1/payment_instruments/cards/create_stripe", token: load_fixture_data("stripe/token.json", raw: true)
 
       expect(last_response).to have_status(200)
+      expect(token_req).to have_been_made
       expect(req).to have_been_made
       expect(member.refresh.cards).to contain_exactly(
         have_attributes(stripe_id: "card_1CgQyH2eZvKYlo2CYkDQhvma"),
       )
     end
 
-    it "409s if the card already exists with the given card fingerprint" do
-      token_req = stub_request(:get, "https://api.stripe.com/v1/tokens/tok_1AWuxsJd4nFN3COfSKY8195M").
-        to_return(fixture_response("stripe/token"))
-      # match the card fingerprint with the token fingerprint req
-      Suma::Fixtures.card.member(member).with_stripe({fingerprint: "EL88ufXeYTG02LOU"}).create
+    describe "with a token that has a fingerprint matching an existing card" do
+      let!(:existing_card) { Suma::Fixtures.card.member(member).with_stripe({fingerprint: "EL88ufXeYTG02LOU"}).create }
 
-      member.update(stripe_customer_json: load_fixture_data("stripe/customer"))
-      post "/v1/payment_instruments/cards/create_stripe", token: load_fixture_data("stripe/token.json", raw: true)
+      before(:each) do
+        member.update(stripe_customer_json: load_fixture_data("stripe/customer"))
+      end
 
-      expect(token_req).to have_been_made
-      expect(last_response).to have_status(409)
-      expect(last_response).to have_json_body.that_includes(error: include(code: "conflicting_stripe_card"))
+      it "returns the existing card" do
+        token_req = stub_token_req
+
+        post "/v1/payment_instruments/cards/create_stripe", token: load_fixture_data("stripe/token", raw: true)
+
+        expect(token_req).to have_been_made
+        expect(last_response).to have_status(200)
+        expect(last_response).to have_json_body.that_includes(id: existing_card.id)
+        expect(member.legal_entity.cards_dataset.all).to have_length(1)
+      end
+
+      it "creates a new card if the existing card is not usable" do
+        existing_card.soft_delete
+
+        token_req = stub_token_req
+        add_card_req = stub_request(:post, "https://api.stripe.com/v1/customers/cus_D6eGmbqyejk8s9/sources").
+          to_return(fixture_response("stripe/card"))
+
+        post "/v1/payment_instruments/cards/create_stripe", token: load_fixture_data("stripe/token", raw: true)
+
+        expect(token_req).to have_been_made
+        expect(add_card_req).to have_been_made
+        expect(last_response).to have_status(200)
+        expect(last_response).to have_json_body.that_includes(id: be > existing_card.id)
+        expect(member.legal_entity.cards_dataset.all).to have_length(2)
+      end
     end
 
     it "errors if Stripe errors on card create" do
+      token_req = stub_token_req
       req = stub_request(:post, "https://api.stripe.com/v1/customers/cus_D6eGmbqyejk8s9/sources").
         to_return(fixture_response("stripe/charge_error", status: 402))
 
@@ -150,6 +180,7 @@ RSpec.describe Suma::API::PaymentInstruments, :db, reset_configuration: Suma::Pa
 
       post "/v1/payment_instruments/cards/create_stripe", token: load_fixture_data("stripe/token.json", raw: true)
 
+      expect(token_req).to have_been_made
       expect(req).to have_been_made
       expect(last_response).to have_status(402)
       expect(last_response).to have_json_body.

--- a/webapp/public/locale/en/strings.json
+++ b/webapp/public/locale/en/strings.json
@@ -88,6 +88,7 @@
     "checkout_fatal_error": "Sorry, something went wrong trying to check out. Please go back and try again.",
     "checkout_no_items": "There are no items in your cart, or all of your items are unavailable. Please go back and try again.",
     "conflicting_bank_account": "You already have a bank account with that account and routing number. Please go back, or enter new account details.",
+    "conflicting_stripe_card": "You already have a card with that information. Please go back or enter new account details.",
     "disambiguation_required": "$t(strings:errors:unhandled_error)",
     "eligibility_violation": "$t(strings:errors:unhandled_error)",
     "forbidden": "You are forbidden from accessing these resources.",

--- a/webapp/public/locale/es/strings.json
+++ b/webapp/public/locale/es/strings.json
@@ -88,6 +88,7 @@
     "checkout_fatal_error": "Lo sentimos, algo salió mal al intentar comprobarlo. Por favor, regrese y vuelva a intentarlo.",
     "checkout_no_items": "No hay artículos en su carrito, o ninguno de sus artículos está disponible. Por favor, regrese y vuelva a intentarlo.",
     "conflicting_bank_account": "Tienes una cuenta bancaria con ese número de cuenta y clave bancaria ya. Intenta de nuevo, o entre los datos de otra cuenta.",
+    "conflicting_stripe_card": "Tienes una tarjeta con esa información ya. Intenta de nuevo, o entre los datos de otra cuenta.",
     "disambiguation_required": "$t(strings:errors:unhandled_error)",
     "eligibility_violation": "$t(strings:errors:unhandled_error)",
     "forbidden": "Acceso a estos recursos está restringido.",


### PR DESCRIPTION
Fixes #248 

We need to check if the token passed to the backend has an existing card fingerprint (unique to the card). Since the fingerprint isn't passed through the front-end for security reasons, we fetch it in the backend through Stripe API. Then check if it matches the existing cards for the member.