### PR TITLE
Replace GBFS row sync with MERGE

### DIFF
--- a/lib/suma/mobility/gbfs/component_sync.rb
+++ b/lib/suma/mobility/gbfs/component_sync.rb
@@ -5,4 +5,6 @@ class Suma::Mobility::Gbfs::ComponentSync
   def before_sync(client); end
   def model = raise NotImplementedError
   def yield_rows(_vendor_service) = raise NotImplementedError
+  def id_column = raise NotImplementedError
+  def sync_columns = raise NotImplementedError
 end

--- a/lib/suma/mobility/gbfs/component_sync.rb
+++ b/lib/suma/mobility/gbfs/component_sync.rb
@@ -5,6 +5,5 @@ class Suma::Mobility::Gbfs::ComponentSync
   def before_sync(client); end
   def model = raise NotImplementedError
   def yield_rows(_vendor_service) = raise NotImplementedError
-  def id_column = raise NotImplementedError
-  def sync_columns = raise NotImplementedError
+  def external_id_column = raise NotImplementedError
 end

--- a/lib/suma/mobility/gbfs/free_bike_status.rb
+++ b/lib/suma/mobility/gbfs/free_bike_status.rb
@@ -4,8 +4,7 @@ require "suma/mobility/gbfs/component_sync"
 
 class Suma::Mobility::Gbfs::FreeBikeStatus < Suma::Mobility::Gbfs::ComponentSync
   def model = Suma::Mobility::Vehicle
-  def id_column = :vehicle_id
-  def sync_columns = [:lat, :lng, :battery_level, :rental_uris]
+  def external_id_column = :vehicle_id
 
   def before_sync(client)
     @bikes = client.fetch_free_bike_status.dig("data", "bikes")

--- a/lib/suma/mobility/gbfs/free_bike_status.rb
+++ b/lib/suma/mobility/gbfs/free_bike_status.rb
@@ -29,7 +29,7 @@ class Suma::Mobility::Gbfs::FreeBikeStatus < Suma::Mobility::Gbfs::ComponentSync
         vehicle_id: bike["bike_id"],
         vehicle_type: "escooter",
         vendor_service_id: vendor_service.id,
-        battery_level:,
+        battery_level: Sequel.cast(battery_level, :smallint),
         rental_uris: Sequel.pg_jsonb(bike["rental_uris"] || {}),
       }
       yield row

--- a/lib/suma/mobility/gbfs/free_bike_status.rb
+++ b/lib/suma/mobility/gbfs/free_bike_status.rb
@@ -4,6 +4,8 @@ require "suma/mobility/gbfs/component_sync"
 
 class Suma::Mobility::Gbfs::FreeBikeStatus < Suma::Mobility::Gbfs::ComponentSync
   def model = Suma::Mobility::Vehicle
+  def id_column = :vehicle_id
+  def sync_columns = [:lat, :lng, :battery_level, :rental_uris]
 
   def before_sync(client)
     @bikes = client.fetch_free_bike_status.dig("data", "bikes")

--- a/lib/suma/mobility/gbfs/geofencing_zone.rb
+++ b/lib/suma/mobility/gbfs/geofencing_zone.rb
@@ -4,6 +4,8 @@ require "suma/mobility/gbfs/component_sync"
 
 class Suma::Mobility::Gbfs::GeofencingZone < Suma::Mobility::Gbfs::ComponentSync
   def model = Suma::Mobility::RestrictedArea
+  def id_column = :unique_id
+  def sync_columns = [:multipolygon, :restriction]
 
   def before_sync(client)
     @zones = client.fetch_geofencing_zones.dig("data", "geofencing_zones")

--- a/lib/suma/mobility/gbfs/geofencing_zone.rb
+++ b/lib/suma/mobility/gbfs/geofencing_zone.rb
@@ -4,8 +4,7 @@ require "suma/mobility/gbfs/component_sync"
 
 class Suma::Mobility::Gbfs::GeofencingZone < Suma::Mobility::Gbfs::ComponentSync
   def model = Suma::Mobility::RestrictedArea
-  def id_column = :unique_id
-  def sync_columns = [:multipolygon, :restriction]
+  def external_id_column = :unique_id
 
   def before_sync(client)
     @zones = client.fetch_geofencing_zones.dig("data", "geofencing_zones")

--- a/lib/suma/mobility/gbfs/vendor_sync.rb
+++ b/lib/suma/mobility/gbfs/vendor_sync.rb
@@ -40,6 +40,7 @@ class Suma::Mobility::Gbfs::VendorSync
         merge_insert(insert).
         merge
       found_ids = rows.map { |r| r[external_id_col] }
+      # Use MERGE WHEN NOT MATCHED BY SOURCE in Postgres 17 when available, after late 2024
       @component.model.where(vendor_service: @mobility_services).exclude(external_id_col => found_ids).delete
     end
     return rows.length

--- a/lib/suma/mobility/gbfs/vendor_sync.rb
+++ b/lib/suma/mobility/gbfs/vendor_sync.rb
@@ -18,8 +18,32 @@ class Suma::Mobility::Gbfs::VendorSync
       @component.yield_rows(vs) { |r| rows << r }
     end
     @component.model.db.transaction do
-      @component.model.where(vendor_service: @mobility_services).delete
-      @component.model.dataset.insert_conflict.multi_insert(rows)
+      if rows.empty?
+        @component.model.where(vendor_service: @mobility_services).delete
+        return 0
+      end
+      source_alias = :source
+      insert = {}
+      update = {}
+      rows.first.each_key { |c| insert[c] = c }
+      @component.sync_columns.each { |c| update[c] = Sequel[source_alias][c] }
+      # TODO: values must be passed as (1, 2), (3, 8) but the lit method converts array to ((1, 2), (3, 8))
+      # This merge execution will fail, needs to be formatted correctly. The advantage of using `.lit`
+      # is that row values are automatically formatted correctly, take this as example:
+      # {"web" => "https://abc.com"} -> '{"web": "https://abc.com"}'::jsonb
+      # The other alternative for merge_using +source+ is to build a temporary table
+      @component.model.dataset.
+        merge_using(
+          Sequel.as(
+            Sequel.lit("VALUES ?", rows.map(&:values)).with_parens,
+            source_alias,
+            rows.first.keys,
+          ),
+          Sequel[@component.model.table_name][@component.id_column] => Sequel[source_alias][@component.id_column],
+        ).
+        merge_insert(insert).
+        merge_update(update).
+        merge
     end
     return rows.length
   end

--- a/spec/suma/mobility/gbfs/free_bike_status_spec.rb
+++ b/spec/suma/mobility/gbfs/free_bike_status_spec.rb
@@ -69,6 +69,9 @@ RSpec.describe Suma::Mobility::Gbfs::FreeBikeStatus, :db do
         loc(12.34, 56.78).
         escooter.
         create(vehicle_id: "ghi799", battery_level: 0, rental_uris: {"web" => "update.me"})
+      Suma::Fixtures.mobility_vehicle(vendor_service: vs).
+        escooter.
+        create(vehicle_id: "ghi555")
       sync_gbfs
       expect(Suma::Mobility::Vehicle.all).to contain_exactly(
         have_attributes(

--- a/spec/suma/mobility/gbfs/free_bike_status_spec.rb
+++ b/spec/suma/mobility/gbfs/free_bike_status_spec.rb
@@ -65,16 +65,24 @@ RSpec.describe Suma::Mobility::Gbfs::FreeBikeStatus, :db do
     end
 
     it "gets and upserts vehicles" do
+      to_update = Suma::Fixtures.mobility_vehicle(vendor_service: vs).
+        loc(12.34, 56.78).
+        escooter.
+        create(vehicle_id: "ghi799", battery_level: 0, rental_uris: {"web" => "update.me"})
       sync_gbfs
       expect(Suma::Mobility::Vehicle.all).to contain_exactly(
         have_attributes(
-          vehicle_id: "ghi799",
+          vehicle_id: to_update.vehicle_id,
+          lat: 12.11,
+          lng: 56.81,
           vendor_service: be === vs,
           battery_level: 42,
           rental_uris: {"web" => "https://foo.bar"},
         ),
         have_attributes(
           vehicle_id: "ghi700",
+          lat: 12.38,
+          lng: 56.80,
           vendor_service: be === vs,
           battery_level: 55,
           rental_uris: {},


### PR DESCRIPTION
Instead of recreating all rows every time, use MERGE to update existing rows, insert new ones, and then a DELETE with everything not found.

The DELETE query can be replaced with `MERGE WHEN NOT MATCHED BY SOURCE` once we upgrade to Postgres 17.

Fixes https://github.com/lithictech/suma/issues/689