### PR TITLE
Update Twilio verification only when `transport_message_id` is present

### DIFF
--- a/lib/suma/async/reset_code_update_twilio.rb
+++ b/lib/suma/async/reset_code_update_twilio.rb
@@ -24,6 +24,8 @@ class Suma::Async::ResetCodeUpdateTwilio
       md &&
         # email codes aren't using twilio verify, at least not yet (and probably never)
         md.transport_type == "sms" &&
+        # deliveries can potentially be aborted therefore a having nil message id
+        md.transport_message_id &&
         # We can send verifications using alternative templates; only the verification template uses
         # the 'send via twilio verify' logic in SmsTransport, so we only update twilio when we use that template.
         Suma::Message::SmsTransport.verification_delivery?(md)

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -192,6 +192,14 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
       end.to perform_async_job(Suma::Async::ResetCodeUpdateTwilio)
     end
 
+    it "noops if the reset code message delivery transport message id is nil" do
+      template = Suma::Message::SmsTransport.verification_template
+      code = fac.create(message_delivery: Suma::Fixtures.message_delivery.via("sms").create(template:))
+      expect do
+        code.expire!
+      end.to perform_async_job(Suma::Async::ResetCodeUpdateTwilio)
+    end
+
     it "noops if the reset code message delivery does not use the verification template" do
       message_delivery = Suma::Fixtures.message_delivery.sent_to_verification.create
       message_delivery.update(template: "alt-verification")

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -182,21 +182,17 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
     let(:member) { Suma::Fixtures.member(phone: "12223334444").create }
     let(:fac) { Suma::Fixtures.reset_code(member:).sms }
 
-    it "noops if the code has no delivery or has an invalid message id" do
+    it "noops if the code has no delivery, has an invalid message id or the delivery was aborted" do
       no_delivery = fac.create
       bad_msg_id = fac.create
       bad_msg_id.update(message_delivery: Suma::Fixtures.message_delivery.create(transport_message_id: "MSGID"))
+      template = Suma::Message::SmsTransport.verification_template
+      message_delivery = Suma::Fixtures.message_delivery.via("sms").create(template:, transport_message_id: nil)
+      nil_msg_id = fac.create(message_delivery:)
       expect do
         no_delivery.expire!
         bad_msg_id.expire!
-      end.to perform_async_job(Suma::Async::ResetCodeUpdateTwilio)
-    end
-
-    it "noops if the reset code message delivery transport message id is nil" do
-      template = Suma::Message::SmsTransport.verification_template
-      code = fac.create(message_delivery: Suma::Fixtures.message_delivery.via("sms").create(template:))
-      expect do
-        code.expire!
+        nil_msg_id.expire!
       end.to perform_async_job(Suma::Async::ResetCodeUpdateTwilio)
     end
 


### PR DESCRIPTION
Fixes #698 

Adds a condition to check if a reset code message deliveries' `transport_message_id` exists. Otherwise we get an error (check issue ticket). Test.