### PR TITLE
Improve admin DateTimePicker to something safer to use

### DIFF
--- a/adminapp/src/components/SafeDateTimePicker.jsx
+++ b/adminapp/src/components/SafeDateTimePicker.jsx
@@ -22,10 +22,16 @@ export default function SafeDateTimePicker({ value, seconds, views, sx, ...rest 
   }
   value = dayjsOrNull(value);
   if (!views.includes("seconds")) {
-    value = value.second(0);
+    value = value?.second(0);
   }
   return (
-    <DateTimePicker value={value} closeOnSelect sx={{ width: "100%", ...sx }} {...rest} />
+    <DateTimePicker
+      value={value}
+      views={views}
+      closeOnSelect
+      sx={{ width: "100%", ...sx }}
+      {...rest}
+    />
   );
 }
 

--- a/adminapp/src/components/SafeDateTimePicker.jsx
+++ b/adminapp/src/components/SafeDateTimePicker.jsx
@@ -1,0 +1,32 @@
+import { dayjsOrNull } from "../modules/dayConfig";
+import { DateTimePicker } from "@mui/x-date-pickers";
+import React from "react";
+
+/**
+ * DateTimePicker with some better defaults:
+ * - 100% width (pass in 'sx.width' to override).
+ * - closeOnSelect is true (pass 'closeOnSelect=false' to override).
+ * - If 'views' is not given, then trucate the 'seconds' from the given dayjs value.
+ *   This prevents having hidden, un-editable seconds from persisting.
+ *   To add seconds to the default views, pass 'seconds=true', and do not pass 'views'.
+ * @param {*} value Null, dayjs, or anything that can be be passed to dayjs(value).
+ * @param {boolean=} seconds
+ * @param {Array<string>=}= views
+ * @param {object=} sx
+ * @param {object=} rest
+ */
+export default function SafeDateTimePicker({ value, seconds, views, sx, ...rest }) {
+  views = views || DEFAULT_VIEWS;
+  if (seconds && !views.includes("seconds")) {
+    views = [...views, "seconds"];
+  }
+  value = dayjsOrNull(value);
+  if (!views.includes("seconds")) {
+    value = value.second(0);
+  }
+  return (
+    <DateTimePicker value={value} closeOnSelect sx={{ width: "100%", ...sx }} {...rest} />
+  );
+}
+
+const DEFAULT_VIEWS = ["year", "month", "day", "hours", "minutes"];

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -3,7 +3,8 @@ import FormLayout from "../components/FormLayout";
 import ImageFileInput from "../components/ImageFileInput";
 import MultiLingualText from "../components/MultiLingualText";
 import ResponsiveStack from "../components/ResponsiveStack";
-import { dayjsOrNull, formatOrNull } from "../modules/dayConfig";
+import SafeDateTimePicker from "../components/SafeDateTimePicker";
+import { formatOrNull } from "../modules/dayConfig";
 import formHelpers from "../modules/formHelpers";
 import mergeAt from "../shared/mergeAt";
 import withoutAt from "../shared/withoutAt";
@@ -24,7 +25,6 @@ import {
   TextField,
 } from "@mui/material";
 import Box from "@mui/material/Box";
-import { DateTimePicker } from "@mui/x-date-pickers";
 import React from "react";
 
 export default function OfferingForm({
@@ -66,26 +66,21 @@ export default function OfferingForm({
           Orders can be placed between the offering begin and end times.
         </FormHelperText>
         <ResponsiveStack alignItems="center" divider={<RemoveIcon />}>
-          <DateTimePicker
+          <SafeDateTimePicker
             label="Open offering *"
-            value={dayjsOrNull(resource.periodBegin)}
-            closeOnSelect
+            value={resource.periodBegin}
             onChange={(v) => setField("periodBegin", formatOrNull(v))}
-            sx={{ width: "100%" }}
           />
-          <DateTimePicker
+          <SafeDateTimePicker
             label="Close offering *"
-            value={dayjsOrNull(resource.periodEnd)}
+            value={resource.periodEnd}
             onChange={(v) => setField("periodEnd", formatOrNull(v))}
-            closeOnSelect
-            sx={{ width: "100%" }}
           />
         </ResponsiveStack>
-        <DateTimePicker
+        <SafeDateTimePicker
           label="Begin Fulfillment At"
-          value={dayjsOrNull(resource.beginFulfillmentAt)}
+          value={resource.beginFulfillmentAt}
           onChange={(v) => setField("beginFulfillmentAt", formatOrNull(v))}
-          closeOnSelect
           sx={{ width: { xs: "100%", sm: "50%" } }}
         />
         <FormHelperText>

--- a/adminapp/src/pages/PaymentTriggerForm.jsx
+++ b/adminapp/src/pages/PaymentTriggerForm.jsx
@@ -4,11 +4,11 @@ import CurrencyTextField from "../components/CurrencyTextField";
 import FormLayout from "../components/FormLayout";
 import MultiLingualText from "../components/MultiLingualText";
 import ResponsiveStack from "../components/ResponsiveStack";
+import SafeDateTimePicker from "../components/SafeDateTimePicker";
 import config from "../config";
-import { dayjsOrNull, formatOrNull } from "../modules/dayConfig";
+import { formatOrNull } from "../modules/dayConfig";
 import { intToMoney } from "../shared/money";
 import { TextField, Stack, FormHelperText } from "@mui/material";
-import { DateTimePicker } from "@mui/x-date-pickers";
 import React from "react";
 
 export default function PaymentTriggerForm({
@@ -39,19 +39,15 @@ export default function PaymentTriggerForm({
           onChange={setFieldFromInput}
         />
         <ResponsiveStack>
-          <DateTimePicker
+          <SafeDateTimePicker
             label="Active starting"
-            value={dayjsOrNull(resource.activeDuringBegin)}
-            closeOnSelect
+            value={resource.activeDuringBegin}
             onChange={(v) => setField("activeDuringBegin", formatOrNull(v))}
-            sx={{ width: "100%" }}
           />
-          <DateTimePicker
+          <SafeDateTimePicker
             label="Active ending"
-            value={dayjsOrNull(resource.activeDuringEnd)}
+            value={resource.activeDuringEnd}
             onChange={(v) => setField("activeDuringEnd", formatOrNull(v))}
-            closeOnSelect
-            sx={{ width: "100%" }}
           />
         </ResponsiveStack>
         <ResponsiveStack>

--- a/adminapp/src/pages/VendorServiceForm.jsx.jsx
+++ b/adminapp/src/pages/VendorServiceForm.jsx.jsx
@@ -1,10 +1,10 @@
 import FormLayout from "../components/FormLayout";
 import ImageFileInput from "../components/ImageFileInput";
 import ResponsiveStack from "../components/ResponsiveStack";
-import { dayjsOrNull, formatOrNull } from "../modules/dayConfig";
+import SafeDateTimePicker from "../components/SafeDateTimePicker";
+import { formatOrNull } from "../modules/dayConfig";
 import RemoveIcon from "@mui/icons-material/Remove";
 import { Stack, TextField } from "@mui/material";
-import { DateTimePicker } from "@mui/x-date-pickers";
 import React from "react";
 
 export default function VendorServiceForm({
@@ -40,19 +40,15 @@ export default function VendorServiceForm({
           onChange={setFieldFromInput}
         />
         <ResponsiveStack alignItems="center" divider={<RemoveIcon />}>
-          <DateTimePicker
+          <SafeDateTimePicker
             label="Open Date"
-            value={dayjsOrNull(resource.periodBegin)}
-            closeOnSelect
+            value={resource.periodBegin}
             onChange={(v) => setField("periodBegin", formatOrNull(v))}
-            sx={{ width: "100%" }}
           />
-          <DateTimePicker
+          <SafeDateTimePicker
             label="Close Date"
-            value={dayjsOrNull(resource.periodEnd)}
+            value={resource.periodEnd}
             onChange={(v) => setField("periodEnd", formatOrNull(v))}
-            closeOnSelect
-            sx={{ width: "100%" }}
           />
         </ResponsiveStack>
       </Stack>


### PR DESCRIPTION
Fixes #699 

DateTimePicker values were formatted to the current date-time and was also leaving in the seconds e.g 12:25:44. Admin never had control over seconds and this caused issues e.g. multiple unexpected subsidy payment triggers active.

Since we only care about the hour and minute right now and we want to avoid adding a 'seconds' field to the DateTImePicker,  instead we re-created a safe reusable-component that can format time correctly, specially truncating seconds to 0.