### PR TITLE
Remove minimum funding limitations in admin API routes

### DIFF
--- a/lib/suma/admin_api/commerce_offering_products.rb
+++ b/lib/suma/admin_api/commerce_offering_products.rb
@@ -26,8 +26,8 @@ class Suma::AdminAPI::CommerceOfferingProducts < Suma::AdminAPI::V1
       params do
         requires(:offering, type: JSON) { use :model_with_id }
         requires(:product, type: JSON) { use :model_with_id }
-        requires(:customer_price, allow_blank: false, type: JSON) { use :funding_money }
-        requires(:undiscounted_price, allow_blank: false, type: JSON) { use :funding_money }
+        requires(:customer_price, allow_blank: false, type: JSON) { use :money }
+        requires(:undiscounted_price, allow_blank: false, type: JSON) { use :money }
       end
     end
 
@@ -39,8 +39,8 @@ class Suma::AdminAPI::CommerceOfferingProducts < Suma::AdminAPI::V1
 
     route_param :id, type: Integer do
       params do
-        optional(:customer_price, allow_blank: false, type: JSON) { use :funding_money }
-        optional(:undiscounted_price, allow_blank: false, type: JSON) { use :funding_money }
+        optional(:customer_price, allow_blank: false, type: JSON) { use :money }
+        optional(:undiscounted_price, allow_blank: false, type: JSON) { use :money }
         at_least_one_of :customer_price, :undiscounted_price
       end
       post do

--- a/lib/suma/admin_api/commerce_products.rb
+++ b/lib/suma/admin_api/commerce_products.rb
@@ -47,7 +47,7 @@ class Suma::AdminAPI::CommerceProducts < Suma::AdminAPI::V1
         requires :image, type: File
         requires(:name, type: JSON) { use :translated_text }
         requires(:description, type: JSON) { use :translated_text }
-        requires(:our_cost, type: JSON) { use :funding_money }
+        requires(:our_cost, type: JSON) { use :money }
         requires(:vendor, type: JSON) { use :model_with_id }
         optional(:vendor_service_categories, type: Array, coerce_with: lambda(&:values)) { use :model_with_id }
         optional :inventory, type: JSON do
@@ -74,7 +74,7 @@ class Suma::AdminAPI::CommerceProducts < Suma::AdminAPI::V1
         optional :image, type: File
         optional(:name, type: JSON) { use :translated_text }
         optional(:description, type: JSON) { use :translated_text }
-        optional(:our_cost, type: JSON) { use :funding_money }
+        optional(:our_cost, type: JSON) { use :money }
         optional(:vendor, type: JSON) { use :model_with_id }
         optional(:vendor_service_categories, type: Array, coerce_with: lambda(&:values)) { use :model_with_id }
         optional :inventory, type: JSON do

--- a/lib/suma/admin_api/funding_transactions.rb
+++ b/lib/suma/admin_api/funding_transactions.rb
@@ -27,9 +27,7 @@ class Suma::AdminAPI::FundingTransactions < Suma::AdminAPI::V1
     desc "Create a funding transaction and book transfer for the given instrument and its owner's cash ledger."
     params do
       use :payment_instrument
-      requires :amount, allow_blank: false, type: JSON do
-        use :funding_money
-      end
+      requires(:amount, allow_blank: false, type: JSON) { use :money }
     end
     post :create_for_self do
       check_role_access!(admin_member, :write, :admin_payments)


### PR DESCRIPTION
Fixes #702 

Admin API routes have params that set a minimum constraint of $5, but admin does not need this same limit as the public facing app, so use the `:money` param instead of the constrained `:funding_money` param in the AdminAPI routes.