### PR TITLE
Analytics models: charge, book/payout/funding transactions

### DIFF
--- a/db/migrations/054_analytics_payments.rb
+++ b/db/migrations/054_analytics_payments.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(Sequel[:analytics][:ledgers]) do
+      add_column :categories, "text[]"
+    end
+
+    create_table(Sequel[:analytics][:charges]) do
+      primary_key :pk
+      integer :charge_id, unique: true, null: false
+
+      timestamptz :created_at
+      text :opaque_id
+      integer :member_id
+      integer :order_id
+      integer :trip_id
+      decimal :discounted_subtotal
+      decimal :discount_amount
+      decimal :undiscounted_subtotal
+      decimal :cash_paid
+      decimal :noncash_paid
+    end
+
+    create_table(Sequel[:analytics][:book_transactions]) do
+      primary_key :pk
+      integer :book_transaction_id, unique: true, null: false
+
+      timestamptz :created_at
+      timestamptz :apply_at
+      text :opaque_id
+      integer :originating_member_id
+      integer :originating_ledger_id
+      integer :receiving_member_id
+      integer :receiving_ledger_id
+      integer :category_id
+      text :category_name
+      text :memo
+      decimal :amount
+      column :usage_codes, "text[]"
+
+      boolean :is_cash
+      boolean :platform_originating
+      boolean :platform_receiving
+    end
+
+    create_table(Sequel[:analytics][:funding_transactions]) do
+      primary_key :pk
+      integer :funding_transaction_id, unique: true, null: false
+
+      timestamptz :created_at
+      timestamptz :updated_at
+      text :status
+      decimal :amount
+      text :memo
+      integer :originating_payment_account_id
+      integer :originating_member_id
+      integer :platform_ledger_id
+      integer :originated_book_transaction_id
+      column :usage_codes, "text[]"
+      text :strategy_name
+    end
+
+    create_table(Sequel[:analytics][:payout_transactions]) do
+      primary_key :pk
+      integer :payout_transaction_id, unique: true, null: false
+
+      timestamptz :created_at
+      timestamptz :updated_at
+      text :status
+      decimal :amount
+      text :memo
+      integer :originating_payment_account_id
+      integer :originating_member_id
+      integer :platform_ledger_id
+      integer :originated_book_transaction_id
+      integer :crediting_book_transaction_id
+      integer :refunded_funding_transaction_id
+      text :strategy_name
+      text :classification
+    end
+  end
+end

--- a/lib/suma/analytics.rb
+++ b/lib/suma/analytics.rb
@@ -17,8 +17,10 @@ module Suma::Analytics
       eligible_olap_classes = self.olap_classes.select { |d| d.denormalize_from?(model_cls) }
       olap_classes = olap_classes.nil? ? eligible_olap_classes : (olap_classes & eligible_olap_classes)
       return nil if olap_classes.empty?
-      row_groups = olap_classes.map do |olap_cls|
-        oltp_models.flat_map { |o| olap_cls.to_rows(o) }
+      row_groups = SequelTranslatedText.language(SequelTranslatedText.default_language) do
+        olap_classes.map do |olap_cls|
+          oltp_models.flat_map { |o| olap_cls.to_rows(o) }
+        end
       end
       upserting = olap_classes.zip(row_groups)
       upserting.each { |(m, rows)| m.upsert_rows(*rows) }

--- a/lib/suma/analytics/book_transaction.rb
+++ b/lib/suma/analytics/book_transaction.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::BookTransaction < Suma::Analytics::Model(Sequel[:analytics][:book_transactions])
+  unique_key :book_transaction_id
+
+  destroy_from Suma::Payment::BookTransaction
+
+  denormalize Suma::Payment::BookTransaction, with: [
+    [:book_transaction_id, :id],
+    :created_at,
+    :apply_at,
+    :opaque_id,
+    :originating_ledger_id,
+    [:originating_member_id, [:originating_ledger, :account, :member_id]],
+    :receiving_ledger_id,
+    [:receiving_member_id, [:receiving_ledger, :account, :member_id]],
+    [:category_id, :associated_vendor_service_category_id],
+    [:category_name, [:associated_vendor_service_category, :name]],
+    :amount,
+    :memo,
+    [:usage_codes, ->(m) { m.usage_details.map(&:code) }],
+    [:is_cash, ->(m) { m.associated_vendor_service_category === Suma::Vendor::ServiceCategory.cash }],
+    [:platform_originating, ->(m) { m.originating_ledger.account.platform_account? }],
+    [:platform_receiving, ->(m) { m.receiving_ledger.account.platform_account? }],
+  ]
+end

--- a/lib/suma/analytics/charge.rb
+++ b/lib/suma/analytics/charge.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::Charge < Suma::Analytics::Model(Sequel[:analytics][:charges])
+  unique_key :charge_id
+
+  destroy_from Suma::Charge
+
+  denormalize Suma::Charge, with: [
+    [:charge_id, :id],
+    :opaque_id,
+    :created_at,
+    :member_id,
+    [:order_id, :commerce_order_id],
+    [:trip_id, :mobility_trip_id],
+    :undiscounted_subtotal,
+    :discounted_subtotal,
+    :discount_amount,
+    [:cash_paid, [:commerce_order, :cash_paid]],
+    [:noncash_paid, [:commerce_order, :noncash_paid]],
+  ]
+end

--- a/lib/suma/analytics/funding_transaction.rb
+++ b/lib/suma/analytics/funding_transaction.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::FundingTransaction < Suma::Analytics::Model(Sequel[:analytics][:funding_transactions])
+  unique_key :funding_transaction_id
+
+  destroy_from Suma::Payment::FundingTransaction
+
+  denormalize Suma::Payment::FundingTransaction, with: [
+    [:funding_transaction_id, :id],
+    :created_at,
+    :updated_at,
+    :status,
+    :amount,
+    :memo,
+    :originating_payment_account_id,
+    [:originating_member_id, [:originating_payment_account, :member_id]],
+    :platform_ledger_id,
+    :originated_book_transaction_id,
+    [:usage_codes, ->(m) { m.originated_book_transaction.usage_details.map(&:code).sort }],
+    [:strategy_name, [:strategy, :short_name]],
+  ]
+end

--- a/lib/suma/analytics/ledger.rb
+++ b/lib/suma/analytics/ledger.rb
@@ -7,20 +7,19 @@ class Suma::Analytics::Ledger < Suma::Analytics::Model(Sequel[:analytics][:ledge
 
   destroy_from Suma::Payment::Ledger
 
-  denormalize Suma::Payment::BookTransaction, with: :denormalize_booking_transaction
+  denormalize Suma::Payment::Ledger, with: :denormalize_ledger
 
-  def self.denormalize_booking_transaction(bx)
-    return [bx.originating_ledger, bx.receiving_ledger].map do |led|
-      {
-        ledger_id: led.id,
-        payment_account_id: led.account_id,
-        member_id: led.account.member_id,
-        name: led.name,
-        balance: led.balance,
-        total_credits: led.received_book_transactions.sum(Money.new(0), &:amount),
-        total_debits: led.originated_book_transactions.sum(Money.new(0), &:amount),
-      }
-    end
+  def self.denormalize_ledger(led)
+    return {
+      ledger_id: led.id,
+      payment_account_id: led.account_id,
+      member_id: led.account.member_id,
+      name: led.name,
+      balance: led.balance,
+      total_credits: led.received_book_transactions.sum(Money.new(0), &:amount),
+      total_debits: led.originated_book_transactions.sum(Money.new(0), &:amount),
+      categories: led.vendor_service_categories.map(&:name).sort,
+    }
   end
 end
 

--- a/lib/suma/analytics/member.rb
+++ b/lib/suma/analytics/member.rb
@@ -11,7 +11,7 @@ class Suma::Analytics::Member < Suma::Analytics::Model(Sequel[:analytics][:membe
     :created_at,
     :soft_deleted_at,
     :phone,
-    [:email, ->(m) { m.email&.downcase }],
+    [:email, :email],
     :name,
     :timezone,
   ]

--- a/lib/suma/analytics/order.rb
+++ b/lib/suma/analytics/order.rb
@@ -11,7 +11,7 @@ class Suma::Analytics::Order < Suma::Analytics::Model(Sequel[:analytics][:orders
     :created_at,
     :order_status,
     :fulfillment_status,
-    [:member_id, ->(o) { o.checkout.cart.member_id }],
+    [:member_id, [:checkout, :cart, :member_id]],
     :undiscounted_cost,
     :customer_cost,
     :savings,

--- a/lib/suma/analytics/payout_transaction.rb
+++ b/lib/suma/analytics/payout_transaction.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "suma/analytics/model"
+
+class Suma::Analytics::PayoutTransaction < Suma::Analytics::Model(Sequel[:analytics][:payout_transactions])
+  unique_key :payout_transaction_id
+
+  destroy_from Suma::Payment::PayoutTransaction
+
+  denormalize Suma::Payment::PayoutTransaction, with: [
+    [:payout_transaction_id, :id],
+    :created_at,
+    :updated_at,
+    :status,
+    :amount,
+    :memo,
+    :originating_payment_account_id,
+    [:originating_member_id, [:originating_payment_account, :member_id]],
+    :platform_ledger_id,
+    :originated_book_transaction_id,
+    :crediting_book_transaction_id,
+    :refunded_funding_transaction_id,
+    [:strategy_name, [:strategy, :short_name]],
+    :classification,
+  ]
+end

--- a/lib/suma/fixtures/images.rb
+++ b/lib/suma/fixtures/images.rb
@@ -13,6 +13,7 @@ module Suma::Fixtures::Images
 
   before_saving do |instance|
     instance.uploaded_file ||= Suma::Fixtures.uploaded_file.create
+    instance.associated_object ||= Suma::Fixtures.vendor.create
     instance
   end
 

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -114,10 +114,14 @@ module Suma::Postgres
     "suma/vendor/service_rate",
 
     # analytics models
+    "suma/analytics/book_transaction",
+    "suma/analytics/charge",
+    "suma/analytics/funding_transaction",
     "suma/analytics/ledger",
     "suma/analytics/member",
     "suma/analytics/order",
     "suma/analytics/order_item",
+    "suma/analytics/payout_transaction",
   ].freeze
 
   # If true, deferred model events publish immediately.

--- a/lib/suma/spec_helpers.rb
+++ b/lib/suma/spec_helpers.rb
@@ -11,6 +11,7 @@ RSpec::Matchers.define_negated_matcher(:not_include, :include)
 RSpec::Matchers.define_negated_matcher(:not_change, :change)
 RSpec::Matchers.define_negated_matcher(:not_be_nil, :be_nil)
 RSpec::Matchers.define_negated_matcher(:not_be_empty, :be_empty)
+RSpec::Matchers.define_negated_matcher(:not_be_a, :be_a)
 
 module Suma::SpecHelpers
   # The directory to look in for fixture data

--- a/spec/suma/analytics_spec.rb
+++ b/spec/suma/analytics_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Suma::Analytics, :db do
     it "noops if models is empty" do
       expect { described_class.upsert_from_transactional_model([]) }.to_not raise_error
     end
+
+    it "sets the current language while upserting and pulls it from a translated text field" do
+      m = Suma::Fixtures.book_transaction.create
+      m.memo.update(en: "this is the memo")
+      described_class.upsert_from_transactional_model(m)
+      expect(Suma::Analytics::BookTransaction.all).to contain_exactly(
+        have_attributes(memo: "this is the memo"),
+      )
+    end
   end
 
   describe "destroy_from_transactional_model" do

--- a/spec/suma/analytics_spec.rb
+++ b/spec/suma/analytics_spec.rb
@@ -111,12 +111,52 @@ RSpec.describe Suma::Analytics, :db do
   end
 
   describe "Ledger" do
-    it "can denormalize from book transactions" do
-      o = Suma::Fixtures.book_transaction.create
+    it "denormalizes from ledgers" do
+      o = Suma::Fixtures.ledger.create
       Suma::Analytics.upsert_from_transactional_model(o)
       expect(Suma::Analytics::Ledger.dataset.all).to contain_exactly(
-        include(ledger_id: o.receiving_ledger_id),
-        include(ledger_id: o.originating_ledger_id),
+        include(ledger_id: o.id),
+      )
+    end
+  end
+
+  describe "BookTransaction" do
+    it "denormalizes from book transactions" do
+      o = Suma::Fixtures.book_transaction.create
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::BookTransaction.dataset.all).to contain_exactly(
+        include(book_transaction_id: o.id),
+      )
+    end
+  end
+
+  describe "Charge" do
+    it "denormalizes from charges" do
+      o = Suma::Fixtures.charge.create
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::Charge.dataset.all).to contain_exactly(
+        include(charge_id: o.id),
+      )
+    end
+  end
+
+  describe "FundingTransaction" do
+    it "denormalizes from funding transactions" do
+      o = Suma::Fixtures.funding_transaction.with_fake_strategy.create
+      o.strategy.set_response(:originating_instrument, Suma::Fixtures.card.create)
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::FundingTransaction.dataset.all).to contain_exactly(
+        include(funding_transaction_id: o.id),
+      )
+    end
+  end
+
+  describe "PayoutTransactions" do
+    it "denormalizes from payout transactions" do
+      o = Suma::Fixtures.payout_transaction.with_fake_strategy.create
+      Suma::Analytics.upsert_from_transactional_model(o)
+      expect(Suma::Analytics::PayoutTransaction.dataset.all).to contain_exactly(
+        include(payout_transaction_id: o.id),
       )
     end
   end


### PR DESCRIPTION
Fixes the ledger model denormalization to ALL ledgers
show up in the table. What was there, was dumb,
stomping on the same ledger for every book transaction.

Add models for charges and book, payout, and funding transactions.

We may wish to denormalize things further in the future.
Useful queries are probably still going to require
some JOINs on other analytics tables.

---

Analytics: Add support for wrapping more types

Translated text, arrays, and more are now better supported.

Also improve the image fixture, add `not_be_a` matcher,
and some other misc improvements.
