### PR TITLE
Ignore twilio error codes correctly

### DIFF
--- a/lib/suma/twilio.rb
+++ b/lib/suma/twilio.rb
@@ -41,8 +41,12 @@ module Suma::Twilio
       update(**kw)
     return response
   rescue Twilio::REST::RestError => e
-    # ignore 404s, it means twilio has approved, expired or invalidated the code already
+    # ignores 20404s, it means twilio has approved, expired or invalidated the code already
     # https://www.twilio.com/docs/verify/api/verification-check#check-a-verification
-    raise(e) unless e.code === 404
+    raise(e) unless IGNORE_TWILIO_ERROR_CODES[e.code]
   end
+
+  IGNORE_TWILIO_ERROR_CODES = {
+    20_404 => "twilio_resource_not_found",
+  }.freeze
 end

--- a/spec/suma/twilio_spec.rb
+++ b/spec/suma/twilio_spec.rb
@@ -24,10 +24,11 @@ RSpec.describe Suma::Twilio, :db do
       expect(result).to have_attributes(sid: "VE123")
     end
 
-    it "raises twilio errors other than 404s" do
+    it "raises twilio errors other than code 20404" do
       req404 = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/Verifications/VE404").
         with(body: {"Status" => "approved"}).
-        to_return(status: 404)
+        # twilios API error codes are passed in the body
+        to_return(status: 404, body: {code: 20_404}.to_json)
       req500 = stub_request(:post, "https://verify.twilio.com/v2/Services/VA555test/Verifications/VE500").
         with(body: {"Status" => "approved"}).
         to_return(status: 500)


### PR DESCRIPTION
Our [fix for twilio verification update error](https://github.com/lithictech/suma/pull/714) regressed. This is because we checked for an HTTP 404 error but failed to check for twilio API specific error code. Fix and test.