### PR TITLE
Admin ability to soft delete and update phone of a member

### DIFF
--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -191,6 +191,7 @@ export default {
   getMembers: (data) => get(`/adminapi/v1/members`, data),
   getMember: ({ id, ...data }) => get(`/adminapi/v1/members/${id}`, data),
   updateMember: ({ id, ...data }) => post(`/adminapi/v1/members/${id}`, data),
+  softDeleteMember: ({ id, ...data }) => post(`/adminapi/v1/members/${id}/close`, data),
   changeMemberEligibility: ({ id, ...data }) =>
     post(`/adminapi/v1/members/${id}/eligibilities`, data),
 

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -15,10 +15,18 @@ import { dayjs } from "../modules/dayConfig";
 import Money from "../shared/react/Money";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import useToggle from "../shared/react/useToggle";
-import theme from "../theme";
-import EditIcon from "@mui/icons-material/Edit";
-import { Divider, Typography, Switch, Button, Chip, Modal } from "@mui/material";
-import Box from "@mui/material/Box";
+import DeleteIcon from "@mui/icons-material/Delete";
+import {
+  Divider,
+  Typography,
+  Switch,
+  Button,
+  Chip,
+  DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
@@ -104,7 +112,7 @@ export default function MemberDetailPage() {
                   value: (
                     <InlineSoftDelete
                       id={model.id}
-                      name={model.name.split(" ").slice(0, 2).join(" ")}
+                      name={model.name}
                       phone={formatPhoneNumber("+" + model.phone)}
                       softDeletedAt={model.softDeletedAt}
                       onSoftDelete={(member) => setModel(member)}
@@ -420,7 +428,6 @@ function ImpersonateButton({ id }) {
 function InlineSoftDelete({ id, name, phone, softDeletedAt, onSoftDelete }) {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
   const showModal = useToggle(false);
-  const classes = useStyles();
   const handleDelete = () => {
     api
       .softDeleteMember({ id: id })
@@ -437,7 +444,7 @@ function InlineSoftDelete({ id, name, phone, softDeletedAt, onSoftDelete }) {
       <>
         {"- "}
         <IconButton onClick={() => showModal.turnOn()}>
-          <EditIcon color="info" />
+          <DeleteIcon color="error" />
         </IconButton>
       </>
     );
@@ -445,40 +452,38 @@ function InlineSoftDelete({ id, name, phone, softDeletedAt, onSoftDelete }) {
   return (
     <>
       {softDeletedAt ? dayjs(softDeletedAt).format("lll") : display}
-      <Modal open={showModal.isOn}>
-        <Box className={classes.softDeleteModalBox}>
-          <Typography variant="h6">Confirm soft deletion</Typography>
+      <Dialog open={showModal.isOn} onClose={showModal.turnOff}>
+        <DialogTitle>Confirm Soft Deletion</DialogTitle>
+        <DialogContent>
           <Typography sx={{ mt: 1 }} color="error">
             Member deletion CANNOT be undone. Ensure that you know what you are doing
             before continuing.
           </Typography>
           <Typography sx={{ mt: 1 }}>
             "Soft delete" means an account is closed indefinitely but keeps some important
-            records attached to the account in case we need to use the data. It deletes
-            the members phone number and replaces it with an unreachable number that
-            cannot be logged into for security reasons.
+            records attached to the account in case we need to refer to past data. It
+            replaces the member's phone and email with unreachable values, preventing any
+            further account access.
           </Typography>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              marginTop: theme.spacing(2),
-            }}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDelete} variant="contained" color="error" size="small">
+            Soft Delete
+            <br />
+            {name}
+            <br />
+            {phone}
+          </Button>
+          <Button
+            variant="outlined"
+            color="secondary"
+            size="small"
+            onClick={showModal.turnOff}
           >
-            <Button onClick={handleDelete} variant="contained" color="error" size="small">
-              Soft Delete {name} {phone}
-            </Button>
-            <Button
-              variant="outlined"
-              color="secondary"
-              size="small"
-              onClick={() => showModal.turnOff()}
-            >
-              Cancel
-            </Button>
-          </div>
-        </Box>
-      </Modal>
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }
@@ -486,16 +491,5 @@ function InlineSoftDelete({ id, name, phone, softDeletedAt, onSoftDelete }) {
 const useStyles = makeStyles((theme) => ({
   impersonate: {
     marginLeft: theme.spacing(2),
-  },
-  softDeleteModalBox: {
-    position: "absolute",
-    top: "50%",
-    left: "50%",
-    transform: "translate(-50%, -50%)",
-    width: 500,
-    padding: "1rem",
-    backgroundColor: "white",
-    boxShadow: 24,
-    borderRadius: theme.spacing(1),
   },
 }));

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -104,7 +104,7 @@ export default function MemberDetailPage() {
                   value: (
                     <InlineSoftDelete
                       id={model.id}
-                      name={model.name}
+                      name={model.name.split(" ").slice(0, 2).join(" ")}
                       phone={formatPhoneNumber("+" + model.phone)}
                       softDeletedAt={model.softDeletedAt}
                       onSoftDelete={(member) => setModel(member)}
@@ -435,7 +435,7 @@ function InlineSoftDelete({ id, name, phone, softDeletedAt, onSoftDelete }) {
   if (canWrite("admin_members")) {
     display = (
       <>
-        -{" "}
+        {"- "}
         <IconButton onClick={() => showModal.turnOn()}>
           <EditIcon color="info" />
         </IconButton>

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -23,7 +23,7 @@ import IconButton from "@mui/material/IconButton";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
-import { formatPhoneNumberIntl } from "react-phone-number-input";
+import { formatPhoneNumber, formatPhoneNumberIntl } from "react-phone-number-input";
 import { useParams } from "react-router-dom";
 
 export default function MemberDetailPage() {
@@ -104,6 +104,8 @@ export default function MemberDetailPage() {
                   value: (
                     <InlineSoftDelete
                       id={model.id}
+                      name={model.name}
+                      phone={formatPhoneNumber("+" + model.phone)}
                       softDeletedAt={model.softDeletedAt}
                       onSoftDelete={(member) => setModel(member)}
                     />
@@ -415,7 +417,7 @@ function ImpersonateButton({ id }) {
   );
 }
 
-function InlineSoftDelete({ id, softDeletedAt, onSoftDelete }) {
+function InlineSoftDelete({ id, name, phone, softDeletedAt, onSoftDelete }) {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
   const showModal = useToggle(false);
   const classes = useStyles();
@@ -464,7 +466,7 @@ function InlineSoftDelete({ id, softDeletedAt, onSoftDelete }) {
             }}
           >
             <Button onClick={handleDelete} variant="contained" color="error" size="small">
-              Soft Delete Member {id}
+              Soft Delete {name} {phone}
             </Button>
             <Button
               variant="outlined"

--- a/adminapp/src/pages/MemberForm.jsx
+++ b/adminapp/src/pages/MemberForm.jsx
@@ -72,7 +72,7 @@ export default function MemberForm({
           type="tel"
           variant="outlined"
           fullWidth
-          helperText="10-digit US phone number. US numbers begin with 1."
+          helperText="11-digit US phone number, begins with 1."
           onChange={setFieldFromInput}
         />
         <Roles roles={resource.roles} setRoles={(r) => setField("roles", r)} />

--- a/adminapp/src/pages/MemberForm.jsx
+++ b/adminapp/src/pages/MemberForm.jsx
@@ -36,7 +36,7 @@ export default function MemberForm({
 }) {
   return (
     <FormLayout
-      title={"Update Member"}
+      title="Update Member"
       subtitle="Edit member account information"
       onSubmit={onSubmit}
       isBusy={isBusy}
@@ -64,6 +64,17 @@ export default function MemberForm({
             onChange={setFieldFromInput}
           />
         </ResponsiveStack>
+        <TextField
+          {...register("phone")}
+          label="Phone"
+          name="phone"
+          value={resource.phone || ""}
+          type="tel"
+          variant="outlined"
+          fullWidth
+          helperText="10-digit US phone number. US numbers begin with 1."
+          onChange={setFieldFromInput}
+        />
         <Roles roles={resource.roles} setRoles={(r) => setField("roles", r)} />
         <Divider />
         <FormLabel>Legal Entity</FormLabel>

--- a/adminapp/src/shared/react/useAsyncFetch.jsx
+++ b/adminapp/src/shared/react/useAsyncFetch.jsx
@@ -14,6 +14,8 @@ import React from "react";
  *   The state is cleared as soon as it is fetched, since it can get stale quickly
  *   as it does not behave like React state (ie it persists between refreshses).
  * @param {Location=} options.location Must be provided for pullFromState to be used.
+ * @param {boolean=} options.cache If true, cache the API response using the options as a key.
+ *   When caching, the arguments passed to makeRequest MUST be serializable using JSON.stringify.
  * @returns {{state, asyncFetch, error, loading}}
  */
 const useAsyncFetch = (makeRequest, options) => {
@@ -23,6 +25,7 @@ const useAsyncFetch = (makeRequest, options) => {
     location,
     pickData,
     pullFromState,
+    cache,
   } = options || {};
   if (pullFromState && get(location, ["state", pullFromState])) {
     defaultVal = location.state[pullFromState];
@@ -32,22 +35,42 @@ const useAsyncFetch = (makeRequest, options) => {
   const [state, setState] = React.useState(defaultVal);
   const [error, setError] = React.useState(null);
   const [loading, setLoading] = React.useState(!doNotFetchOnInit);
+  const cacheRef = React.useRef({});
 
   const asyncFetch = React.useCallback(
     (...args) => {
       setLoading(true);
       setError(false);
+      let cacheKey;
+      if (cache) {
+        // If we're caching, and the entry is in the cache,
+        // then return it from the cache. Use a 200ms delay to mimic a very fast
+        // network call, since when callers use this they normally expect some delay.
+        // We can add options to control this in the future.
+        cacheKey = "" + makeRequest + JSON.stringify(args);
+        if (cacheRef.current[cacheKey]) {
+          return Promise.delay(200).then(() => {
+            const st = cacheRef.current[cacheKey];
+            setState(st);
+            setLoading(false);
+            return st;
+          });
+        }
+      }
       return makeRequest(...args)
         .then((x) => {
           const st = pickData ? x.data : x;
           setState(st);
+          if (cache) {
+            cacheRef.current[cacheKey] = st;
+          }
           return st;
         })
         .tapCatch((e) => setError(e))
         .tap(() => setLoading(false))
         .tapCatch(() => setLoading(false));
     },
-    [makeRequest, pickData]
+    [cache, makeRequest, pickData]
   );
 
   React.useEffect(() => {

--- a/adminapp/src/shared/react/useUnmountEffect.jsx
+++ b/adminapp/src/shared/react/useUnmountEffect.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+/**
+ * Just a `React.useEffect(() => cb, [])` that is more declarative than
+ * doing it in line and disabling eslint.
+ * @param {function} cb
+ */
+export default function useUnmountEffect(cb) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => cb, []);
+}

--- a/adminapp/src/shared/setRef.js
+++ b/adminapp/src/shared/setRef.js
@@ -1,0 +1,15 @@
+import has from "lodash/has";
+
+/**
+ * Call ref(v) or ref.current = v;.
+ */
+export default function setRef(ref, value) {
+  if (!ref) {
+    return;
+  }
+  if (has(ref, "current")) {
+    ref.current = value;
+    return;
+  }
+  ref(value);
+}

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -154,7 +154,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
         optional :name, type: String
         optional :note, type: String
         optional :email, type: String
-        optional :phone, type: Integer
+        optional :phone, us_phone: true, type: String, coerce_with: NormalizedPhone
         optional :timezone, type: String, values: ALL_TIMEZONES
         optional :roles, type: Array[JSON] do
           use :model_with_id

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -154,7 +154,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
         optional :name, type: String
         optional :note, type: String
         optional :email, type: String
-        optional :phone, us_phone: true, type: String, coerce_with: NormalizedPhone
+        optional :phone, type: Integer
         optional :timezone, type: String, values: ALL_TIMEZONES
         optional :roles, type: Array[JSON] do
           use :model_with_id

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -389,7 +389,11 @@ class Suma::Member < Suma::Postgres::Model(:members)
   def validate
     super
     self.validates_presence(:phone)
-    self.validates_unique(:phone)
+    self.validates_unique(
+      :phone,
+      message: "is already taken. If you're trying to duplicate a member, " \
+               "make sure that you soft-delete their account first.",
+    )
     unless self.soft_deleted?
       self.validates_format(Suma::PhoneNumber::US::REGEXP, :phone, message: "is not an 11 digit US phone number")
     end

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -138,11 +138,11 @@ RSpec.describe Suma::AdminAPI::Members, :db do
     it "updates the member" do
       member = Suma::Fixtures.member.create
 
-      post "/v1/members/#{member.id}", name: "b 2", email: "b@gmail.com"
+      post "/v1/members/#{member.id}", name: "b 2", email: "b@gmail.com", phone: "12223334444"
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.
-        that_includes(id: member.id, name: "b 2", email: "b@gmail.com")
+        that_includes(id: member.id, name: "b 2", email: "b@gmail.com", phone: "12223334444")
     end
 
     it "replaces roles if given" do

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -145,6 +145,17 @@ RSpec.describe Suma::AdminAPI::Members, :db do
         that_includes(id: member.id, name: "b 2", email: "b@gmail.com", phone: "12223334444")
     end
 
+    it "400s if a phone number is taken, with instructions message for admins" do
+      member = Suma::Fixtures.member.create
+      member_taken = Suma::Fixtures.member.create(phone: "15553335555")
+
+      post "/v1/members/#{member.id}", phone: member_taken.phone
+
+      expect(last_response).to have_status(400)
+      message = /duplicate a member, make sure that you soft-delete their account first/
+      expect(last_response).to have_json_body.that_includes(error: include(message:))
+    end
+
     it "replaces roles if given" do
       existing = Suma::Role.create(name: "existing")
       to_remove = Suma::Role.create(name: "to_remove")


### PR DESCRIPTION
Right now, developers can manually soft delete and update a members phone number. We need the ability to do it through the admin portal. These changes add these abilities to helps suma staff mitigate member duplication during the member onboarding verification process.

### Member soft deleting steps
<img width="393" alt="Screenshot 2024-10-15 at 10 53 18 AM" src="https://github.com/user-attachments/assets/28a842cd-36fb-407a-87ee-1d2f010e98d9">
<img width="688" alt="Screenshot 2024-10-15 at 10 53 29 AM" src="https://github.com/user-attachments/assets/2d881de3-7a43-4a9b-a806-53e4bf5ef7a2">

### Update member phone number
<img width="684" alt="Screenshot 2024-10-15 at 10 54 28 AM" src="https://github.com/user-attachments/assets/26d60b41-2e4c-4e49-8976-52c60afa5d7a">
<img width="827" alt="Screenshot 2024-10-15 at 10 54 51 AM" src="https://github.com/user-attachments/assets/152610e0-8c22-4b6f-8ee7-a479c09e42c7">
