### PR TITLE
Exclude nil checkout fulfillment options from order

### DIFF
--- a/lib/suma/commerce/order.rb
+++ b/lib/suma/commerce/order.rb
@@ -168,7 +168,9 @@ class Suma::Commerce::Order < Suma::Postgres::Model(:commerce_orders)
   def fulfillment_options_for_editing
     return [] unless self.unfulfilled?
     opts = self.checkout.available_fulfillment_options
-    opts.prepend(self.checkout.fulfillment_option) unless opts.any? { |opt| opt === self.checkout.fulfillment_option }
+    if (checkout_opt = self.checkout.fulfillment_option) && opts.none? { |opt| opt === checkout_opt }
+      opts.prepend(checkout_opt)
+    end
     return opts
   end
 

--- a/spec/suma/commerce/order_spec.rb
+++ b/spec/suma/commerce/order_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe "Suma::Commerce::Order", :db do
       expect(order.fulfillment_options_for_editing).to have_same_ids_as(*offering.fulfillment_options)
     end
 
+    it "excludes nil checkout option" do
+      order.checkout.update(fulfillment_option: nil)
+      expect(order.fulfillment_options_for_editing).to have_same_ids_as(*offering.fulfillment_options)
+    end
+
     it "is empty for a non-unfulfilled order" do
       order.fulfillment_status = "fulfilling"
       expect(order.fulfillment_options_for_editing).to be_empty


### PR DESCRIPTION
Fixes #728 

This prevents nil checkout options from being added to the `Order#fulfillment_options_for_editing`, which caused front-end order detail page to break.