### PR TITLE
Create org memberships from member and org pages

### DIFF
--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -12,6 +12,7 @@ import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import useRoleAccess from "../hooks/useRoleAccess";
 import { useUser } from "../hooks/user";
 import { dayjs } from "../modules/dayConfig";
+import createRelativeUrl from "../shared/createRelativeUrl";
 import Money from "../shared/react/Money";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import useToggle from "../shared/react/useToggle";
@@ -127,7 +128,10 @@ export default function MemberDetailPage() {
               resource="member"
               enrollments={model.directProgramEnrollments}
             />
-            <OrganizationMemberships memberships={model.organizationMemberships} />
+            <OrganizationMemberships
+              memberships={model.organizationMemberships}
+              model={model}
+            />
             <Activities activities={model.activities} />
             <Orders orders={model.orders} />
             <Charges charges={model.charges} />
@@ -170,12 +174,18 @@ function LegalEntity({ address }) {
   );
 }
 
-function OrganizationMemberships({ memberships }) {
+function OrganizationMemberships({ memberships, model }) {
   return (
     <RelatedList
       title="Organization Memberships"
-      headers={["Id", "Created At", "Organization"]}
+      headers={["Id", "Created At", "Organization", "Organization Programs"]}
       rows={memberships}
+      addNewLabel="Create another membership"
+      addNewLink={createRelativeUrl(`/membership/new`, {
+        memberId: model.id,
+        memberLabel: `(${model.id}) ${model.name || "Name Unavailable"}`,
+      })}
+      addNewRole="organizationMembership"
       keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
@@ -187,6 +197,12 @@ function OrganizationMemberships({ memberships }) {
         ) : (
           row.unverifiedOrganizationName
         ),
+        row.verifiedOrganization?.programs?.map((program, idx) => (
+          <React.Fragment key={idx}>
+            <AdminLink model={program}>{program.program.name.en}</AdminLink>
+            {row.verifiedOrganization?.programs.length > idx + 1 && ", "}
+          </React.Fragment>
+        )),
       ]}
     />
   );
@@ -232,6 +248,7 @@ function Sessions({ sessions }) {
     <RelatedList
       title="Sessions"
       headers={["Started", "IP", "User Agent"]}
+      keyRowAttr="id"
       rows={sessions}
       toCells={(row) => [
         dayjs(row.createdAt).format("lll"),

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -178,12 +178,12 @@ function OrganizationMemberships({ memberships, model }) {
   return (
     <RelatedList
       title="Organization Memberships"
-      headers={["Id", "Created At", "Organization", "Organization Programs"]}
+      headers={["Id", "Created At", "Organization"]}
       rows={memberships}
       addNewLabel="Create another membership"
       addNewLink={createRelativeUrl(`/membership/new`, {
         memberId: model.id,
-        memberLabel: `(${model.id}) ${model.name || "Name Unavailable"}`,
+        memberLabel: `(${model.id}) ${model.name || "-"}`,
       })}
       addNewRole="organizationMembership"
       keyRowAttr="id"
@@ -197,12 +197,6 @@ function OrganizationMemberships({ memberships, model }) {
         ) : (
           row.unverifiedOrganizationName
         ),
-        row.verifiedOrganization?.programs?.map((program, idx) => (
-          <React.Fragment key={idx}>
-            <AdminLink model={program}>{program.program.name.en}</AdminLink>
-            {row.verifiedOrganization?.programs.length > idx + 1 && ", "}
-          </React.Fragment>
-        )),
       ]}
     />
   );

--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -33,7 +33,7 @@ export default function OrganizationDetailPage() {
             addNewLabel="Create another membership"
             addNewLink={createRelativeUrl(`/membership/new`, {
               organizationId: model.id,
-              organizationLabel: `(${model.id}) ${model.name || "Name Unavailable"}`,
+              organizationLabel: `(${model.id}) ${model.name || "-"}`,
             })}
             addNewRole="organizationMembership"
             headers={["Id", "Member", "Created At", "Updated At"]}

--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -4,6 +4,7 @@ import ProgramEnrollmentRelatedList from "../components/ProgramEnrollmentRelated
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import createRelativeUrl from "../shared/createRelativeUrl";
 import React from "react";
 
 export default function OrganizationDetailPage() {
@@ -29,6 +30,12 @@ export default function OrganizationDetailPage() {
           <RelatedList
             title={`Memberships (${model.memberships.length})`}
             rows={model.memberships}
+            addNewLabel="Create another membership"
+            addNewLink={createRelativeUrl(`/membership/new`, {
+              organizationId: model.id,
+              organizationLabel: `(${model.id}) ${model.name || "Name Unavailable"}`,
+            })}
+            addNewRole="organizationMembership"
             headers={["Id", "Member", "Created At", "Updated At"]}
             keyRowAttr="id"
             toCells={(row) => [

--- a/adminapp/src/pages/OrganizationMembershipForm.jsx
+++ b/adminapp/src/pages/OrganizationMembershipForm.jsx
@@ -24,13 +24,13 @@ export default function OrganizationMembershipForm({
     if (memberId > 0) {
       setField("member", {
         id: memberId,
-        label: searchParams.get("memberLabel"),
+        name: searchParams.get("memberLabel"),
       });
     }
     if (organizationId > 0) {
       setField("verifiedOrganization", {
         id: organizationId,
-        label: searchParams.get("organizationLabel"),
+        name: searchParams.get("organizationLabel"),
       });
     }
   }, [searchParams]);
@@ -52,26 +52,24 @@ export default function OrganizationMembershipForm({
           {...register("member")}
           label="Member"
           helperText="The member who is in an organization."
-          value={resource.member?.label || resource.member?.name}
+          value={resource.member?.name}
           disabled={!isCreate}
           required={isCreate}
           search={api.searchMembers}
           fullWidth
           style={{ flex: 1 }}
-          onValueSelect={(m) => setField("member", { id: m.id })}
+          onValueSelect={(m) => setField("member", m)}
         />
         <AutocompleteSearch
           {...register("organization")}
           label="Organization"
           helperText={orgText}
-          value={
-            resource.verifiedOrganization?.label || resource.verifiedOrganization?.name
-          }
+          value={resource.verifiedOrganization?.name}
           fullWidth
           required
           search={api.searchOrganizations}
           style={{ flex: 1 }}
-          onValueSelect={(org) => setField("verifiedOrganization", { id: org.id })}
+          onValueSelect={(org) => setField("verifiedOrganization", org)}
         />
       </ResponsiveStack>
     </FormLayout>

--- a/adminapp/src/pages/OrganizationMembershipForm.jsx
+++ b/adminapp/src/pages/OrganizationMembershipForm.jsx
@@ -2,7 +2,9 @@ import api from "../api";
 import AutocompleteSearch from "../components/AutocompleteSearch";
 import FormLayout from "../components/FormLayout";
 import ResponsiveStack from "../components/ResponsiveStack";
+import useMountEffect from "../shared/react/useMountEffect";
 import React from "react";
+import { useSearchParams } from "react-router-dom";
 
 export default function OrganizationMembershipForm({
   isCreate,
@@ -12,6 +14,26 @@ export default function OrganizationMembershipForm({
   isBusy,
   onSubmit,
 }) {
+  const [searchParams] = useSearchParams();
+  useMountEffect(() => {
+    if (searchParams.get("edit")) {
+      return;
+    }
+    const memberId = Number(searchParams.get("memberId") || -1);
+    const organizationId = Number(searchParams.get("organizationId") || -1);
+    if (memberId > 0) {
+      setField("member", {
+        id: memberId,
+        label: searchParams.get("memberLabel"),
+      });
+    }
+    if (organizationId > 0) {
+      setField("verifiedOrganization", {
+        id: organizationId,
+        label: searchParams.get("organizationLabel"),
+      });
+    }
+  }, [searchParams]);
   let orgText = "The organization the member is a part of.";
   if (resource.unverifiedOrganizationName) {
     orgText += ` The member has identified themselves with '${resource.unverifiedOrganizationName}.'`;
@@ -42,7 +64,9 @@ export default function OrganizationMembershipForm({
           {...register("organization")}
           label="Organization"
           helperText={orgText}
-          value={resource.verifiedOrganization?.name}
+          value={
+            resource.verifiedOrganization?.label || resource.verifiedOrganization?.name
+          }
           fullWidth
           required
           search={api.searchOrganizations}

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -60,14 +60,6 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :subscriptions, with: PreferencesSubscriptionEntity
   end
 
-  class DetailedOrganizationEntity < OrganizationEntity
-    expose :program_enrollments, as: :programs, with: Suma::AdminAPI::Entities::ProgramEnrollmentEntity
-  end
-
-  class DetailedOrganizationMembershipEntity < OrganizationMembershipEntity
-    expose :verified_organization, with: DetailedOrganizationEntity
-  end
-
   class DetailedMemberEntity < MemberEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
@@ -89,7 +81,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :message_deliveries, with: MessageDeliveryEntity
     expose :preferences!, as: :preferences, with: PreferencesEntity
     expose :anon_proxy_vendor_accounts, as: :vendor_accounts, with: MemberVendorAccountEntity
-    expose :organization_memberships, with: DetailedOrganizationMembershipEntity
+    expose :organization_memberships, with: OrganizationMembershipEntity
   end
 
   ALL_TIMEZONES = Set.new(TZInfo::Timezone.all_identifiers)

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -60,6 +60,14 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :subscriptions, with: PreferencesSubscriptionEntity
   end
 
+  class DetailedOrganizationEntity < OrganizationEntity
+    expose :program_enrollments, as: :programs, with: Suma::AdminAPI::Entities::ProgramEnrollmentEntity
+  end
+
+  class DetailedOrganizationMembershipEntity < OrganizationMembershipEntity
+    expose :verified_organization, with: DetailedOrganizationEntity
+  end
+
   class DetailedMemberEntity < MemberEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
@@ -81,7 +89,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :message_deliveries, with: MessageDeliveryEntity
     expose :preferences!, as: :preferences, with: PreferencesEntity
     expose :anon_proxy_vendor_accounts, as: :vendor_accounts, with: MemberVendorAccountEntity
-    expose :organization_memberships, with: OrganizationMembershipEntity
+    expose :organization_memberships, with: DetailedOrganizationMembershipEntity
   end
 
   ALL_TIMEZONES = Set.new(TZInfo::Timezone.all_identifiers)


### PR DESCRIPTION
Fixes #727 

Organization memberships can be created through a member or organization detail page.
Expose programs in member detail page organization memberships related list section.

### Member page
<img width="699" alt="Screenshot 2024-11-17 at 10 10 06 AM" src="https://github.com/user-attachments/assets/f40a6baa-5b31-4a43-9ddd-dcd91663e105">

### Organization page
<img width="702" alt="Screenshot 2024-11-17 at 10 10 53 AM" src="https://github.com/user-attachments/assets/f9f93103-fba5-423a-ab26-38ad928a1d78">

