### PR TITLE
Fix image sizing in dashboard

### DIFF
--- a/webapp/src/pages/Dashboard.jsx
+++ b/webapp/src/pages/Dashboard.jsx
@@ -123,7 +123,13 @@ function ProgramCard({ name, description, image, periodEnd, appLink, appLinkText
         {name}
       </h5>
       <Link to={appLink} className="flex-shrink-0 overflow-hidden position-relative">
-        <SumaImage image={image} h={150} style={{ maxWidth: "100%" }} />
+        <SumaImage
+          image={image}
+          w={450}
+          h={130}
+          style={{ maxWidth: "100%" }}
+          params={{ crop: "entropy" }}
+        />
       </Link>
       <p className="mt-3">{description}</p>
       <p className="small">


### PR DESCRIPTION
The dashboard images were processed with a height of 150px, essentially cropping the height, while full width. The image element was set to max width of 100% which makes the image render in different heights for different image sizes.

The goal is to make all the images appear with the same height. Cropping images to 450x130, and setting the image element max width to 100% allows images to render dynamically in different screen sizes (if we crop and set image height to 100px, and then change screen sizes, the image height stays the same and appears squished, image below)

Set the

### Images after fix
<img width="362" alt="Screenshot 2024-11-19 at 11 29 36 AM" src="https://github.com/user-attachments/assets/00abfa35-4dbe-47bd-a89f-3bdd069c0034">

### Image after fix (dynamic sizing)
<img width="243" alt="Screenshot 2024-11-19 at 11 31 28 AM" src="https://github.com/user-attachments/assets/1ebb6f38-db3e-49cb-b417-57a0d8bf9c1e">

### Image before fix
<img width="504" alt="Screenshot 2024-11-19 at 10 06 10 AM" src="https://github.com/user-attachments/assets/9cac0daf-a5fe-4a39-b0aa-553a4490d8a4">

### Image squished (if we had set an image height property)
<img width="243" alt="Screenshot 2024-11-19 at 11 31 03 AM" src="https://github.com/user-attachments/assets/ad871810-353c-4f3d-820d-d601e0d88c94">