### PR TITLE
Dynamic translation markdown, dashboard image fix, max quantity fix, better prod db restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ restore-db-from-dump:
 	@PGPASSWORD=suma psql postgres://suma:suma@localhost:22005/suma -c "CREATE SCHEMA IF NOT EXISTS heroku_ext"
 	PGPASSWORD=suma pg_restore --clean --no-acl --no-owner -h 127.0.0.1 -p 22005 -U suma -d suma temp/latest.dump || true
 	@PGPASSWORD=suma psql postgres://suma:suma@localhost:22005/suma -c "ALTER EXTENSION citext SET SCHEMA public"
+	@bundle exec rake release:prepare_prod_db_for_testing
 	@./bin/notify "Finished restoring database from production"
 
 

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -58,6 +58,7 @@ export default function OfferingForm({
             fullWidth
             value={resource.description}
             required
+            multiline
             onChange={(v) => setField("description", v)}
           />
         </ResponsiveStack>

--- a/adminapp/src/pages/ProductForm.jsx
+++ b/adminapp/src/pages/ProductForm.jsx
@@ -64,6 +64,7 @@ export default function ProductForm({
             fullWidth
             value={resource.description}
             required
+            multiline
             onChange={(v) => setField("description", v)}
           />
         </Stack>

--- a/adminapp/src/pages/ProgramForm.jsx
+++ b/adminapp/src/pages/ProgramForm.jsx
@@ -59,6 +59,7 @@ export default function ProgramForm({
             fullWidth
             value={resource.description}
             required
+            multiline
             onChange={(v) => setField("description", v)}
           />
         </ResponsiveStack>

--- a/adminapp/src/pages/VendorConfigurationDetailPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationDetailPage.jsx
@@ -30,6 +30,8 @@ export default function VendorConfigurationDetailPage() {
         { label: "Uses SMS?", value: <BoolCheckmark>{model.usesSms}</BoolCheckmark> },
         { label: "Uses Email?", value: <BoolCheckmark>{model.usesEmail}</BoolCheckmark> },
         { label: "Enabled?", value: <BoolCheckmark>{model.enabled}</BoolCheckmark> },
+        { label: "Instructions (En)", value: model.instructions.en },
+        { label: "Instructions (Es)", value: model.instructions.es },
       ]}
     >
       {(model, setModel) => (

--- a/lib/suma/admin_api/anon_proxy.rb
+++ b/lib/suma/admin_api/anon_proxy.rb
@@ -38,6 +38,7 @@ class Suma::AdminAPI::AnonProxy < Suma::AdminAPI::V1
   class DetailedVendorConfigurationEntity < VendorConfigurationEntity
     include Suma::AdminAPI::Entities
     expose :programs, with: ProgramEntity
+    expose :instructions, with: TranslatedTextEntity
   end
 
   class DetailedVendorAccountEntity < VendorAccountEntity

--- a/lib/suma/i18n.rb
+++ b/lib/suma/i18n.rb
@@ -299,4 +299,5 @@ module Suma::I18n
   end
 end
 
+require "suma/i18n/formatter"
 require "suma/i18n/resource_rewriter"

--- a/lib/suma/i18n/formatter.rb
+++ b/lib/suma/i18n/formatter.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "suma/i18n"
+require "suma/lru"
+
+# Describe an internationalization formatter.
+class Suma::I18n::Formatter
+  # Shorthand to indicate the formatter in static resource files.
+  # The frontend looks for this symbol to determine what component to use.
+  # @!attribute symbol
+  attr_reader :symbol
+
+  # Used to resolve the writer where strings are nested (like "xyz $(abc)" in static files).
+  # Higher weights have higher priority.
+  # @!attribute weight
+  attr_reader :weight
+
+  # The zero-width characters that are prepended inside `expose_translated` to indicate the formatter.
+  # The frontend looks for this string to determine what component to use, similar to +symbol+.
+  # See https://blog.bitsrc.io/how-to-hide-secrets-in-strings-modern-text-hiding-in-javascript-613a9faa5787
+  # for some examples of zero-width characters.
+  attr_reader :flag
+
+  def initialize(symbol:, weight:, flag:)
+    @symbol = symbol
+    @weight = weight
+    @flag = flag
+  end
+
+  # The localized string can be used verbatim.
+  STR = self.new(symbol: :s, weight: 10, flag: "")
+  # The localized string should be rendered with markdown.
+  # There should usually be NO outer paragraph tag (see +MD_MULTILINE+).
+  #
+  # Note that, if a localized string is plain (+STR+),
+  # but nests to another string (see +Suma::I18n::ResourceRewriter::KEY_LOCALIZE+) that uses +MD+,
+  # the 'nesting' outer string will also get a +MD+.
+  MD = self.new(symbol: :m, weight: 20, flag: "\u200C")
+
+  # The localized string should be rendered with markdown, WITH paragraph tags around each paragraph.
+  MD_MULTILINE = self.new(symbol: :mp, weight: 30, flag: "\u200D")
+
+  class << self
+    # Return a global HTML redcarpet instance.
+    def redcarpet
+      # noinspection RubyArgCount
+      return @redcarpet ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)
+    end
+
+    # @param s [String]
+    # @return [Formatter]
+    def for(s)
+      s = s.strip
+      hash = s.hash
+      if (cached = self.lru[hash])
+        return cached
+      end
+      md = self.redcarpet.render(s)
+      fmt = if md.blank? || md == "<p>#{s}</p>\n"
+              STR
+      elsif s.include?("\n\n") || md.match?(/<(div|ul|ol)>/)
+        MD_MULTILINE
+      else
+        MD
+      end
+      self.lru[hash] = fmt
+      return fmt
+    end
+
+    def lru
+      return @lru ||= Suma::Lru.new(300)
+    end
+  end
+end

--- a/lib/suma/lru.rb
+++ b/lib/suma/lru.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# LRU cache for Ruby.
+# Search for 'lru cache Ruby' for the implementations this was based on,
+# since Ruby hashes are ordered it's really easy to build
+# and there aren't really packages for it.
+class Suma::Lru
+  def initialize(max_size)
+    @max_size = max_size
+    @container = {}
+  end
+
+  def [](key)
+    found = true
+    value = @container.delete(key) { found = false }
+    return unless found
+    @container[key] = value
+    return value
+  end
+
+  def []=(key, val)
+    @container.delete(key)
+    @container[key] = val
+    @container.delete(@container.first[0]) if @container.length > @max_size
+    # rubocop:disable Lint/ReturnInVoidContext
+    # Mimic Ruby's hash, which works this way
+    return val
+    # rubocop:enable Lint/ReturnInVoidContext
+  end
+
+  def size = @container.size
+  def length = @container.length
+  def empty? = @container.empty?
+  def include?(key) = @container.include?(key)
+end

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "grape_entity"
+require "suma/i18n/formatter"
 
 module Suma::Service::Entities
   class Money < Grape::Entity
@@ -56,7 +57,9 @@ module Suma::Service::Entities
         else
           instance.send(name)
         end
-        txt&.string || ""
+        s = txt&.string || ""
+        i18n_fmt = Suma::I18n::Formatter.for(s)
+        "#{i18n_fmt.flag}#{s}"
       end
     end
   end

--- a/lib/suma/tasks/release.rb
+++ b/lib/suma/tasks/release.rb
@@ -5,11 +5,28 @@ require "rake/tasklib"
 require "suma/tasks"
 
 class Suma::Tasks::Release < Rake::TaskLib
+  PASSWORD = "suma1234"
+
   def initialize
     super
     desc "Run the release script against the current environment."
     task :release do
       Rake::Task["db:migrate"].invoke
+    end
+
+    namespace :release do
+      desc "Set every user password to #{PASSWORD}."
+      task :prepare_prod_db_for_testing do
+        Suma.load_app
+        m = Suma::Member.new
+        m.password = PASSWORD
+        Suma::Member.dataset.update(
+          password_digest: m.password_digest,
+          stripe_customer_json: nil,
+          frontapp_contact_id: "",
+        )
+        Suma::Member.where(email: "admin@lithic.tech").update(soft_deleted_at: nil)
+      end
     end
   end
 end

--- a/spec/suma/lru_spec.rb
+++ b/spec/suma/lru_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "suma/lru"
+
+RSpec.describe Suma::Lru do
+  it "acts like a sized-cache" do
+    # Depend on the algorithm to be correct for speed
+    h = described_class.new(2)
+    expect(h).to have_attributes(empty?: true, size: 0, length: 0)
+    expect(h[:a]).to be_nil
+    expect(h).to have_attributes(empty?: true, size: 0, length: 0)
+    expect(h[:a] = 1).to eq(1)
+    h[:b] = 2
+    expect(h).to have_attributes(size: 2)
+    h[:c] = 3
+    expect(h).to have_attributes(size: 2)
+    expect(h).to_not include(:a)
+    expect(h).to include(:b)
+    expect(h).to include(:c)
+    h[:b] = 2
+    h[:a] = 1
+    expect(h).to include(:a)
+    expect(h).to include(:b)
+    expect(h).to_not include(:c)
+  end
+end

--- a/webapp/src/localization/index.jsx
+++ b/webapp/src/localization/index.jsx
@@ -84,3 +84,27 @@ export function imageAltT(altKey, i18noptions = {}) {
   }
   return capitalize(altStr);
 }
+
+/**
+ * Render the dynamic translated string.
+ * Use the formatter specified by the flag at the start of the string.
+ * See Suma::I18n::ResourceRewriter for more info.
+ * @param {string} s
+ * @return {string|JSX.Element}
+ */
+export function dt(s) {
+  if (!s) {
+    return s;
+  }
+  const flag = s[0];
+  if (flag === "\u200C") {
+    return (
+      <SumaMarkdown options={{ forceWrapper: true, wrapper: React.Fragment }}>
+        {s.slice(1)}
+      </SumaMarkdown>
+    );
+  } else if (flag === "\u200D") {
+    return <SumaMarkdown options={{ forceBlock: true }}>{s.slice(1)}</SumaMarkdown>;
+  }
+  return s;
+}

--- a/webapp/src/pages/Dashboard.jsx
+++ b/webapp/src/pages/Dashboard.jsx
@@ -7,7 +7,7 @@ import PageLoader from "../components/PageLoader";
 import RLink from "../components/RLink";
 import SeeAlsoAlert from "../components/SeeAlsoAlert";
 import SumaImage from "../components/SumaImage";
-import { imageAltT, t } from "../localization";
+import { dt, imageAltT, t } from "../localization";
 import { dayjs } from "../modules/dayConfig";
 import externalLinks from "../modules/externalLinks";
 import readOnlyReason from "../modules/readOnlyReason";
@@ -131,7 +131,7 @@ function ProgramCard({ name, description, image, periodEnd, appLink, appLinkText
           style={{ maxWidth: "100%" }}
         />
       </Link>
-      <p className="mt-3">{description}</p>
+      <div className="mt-3">{dt(description)}</div>
       <p className="small">
         {t("dashboard:program_ends", { date: dayjs(periodEnd).format("ll") })}
       </p>

--- a/webapp/src/pages/Dashboard.jsx
+++ b/webapp/src/pages/Dashboard.jsx
@@ -123,7 +123,13 @@ function ProgramCard({ name, description, image, periodEnd, appLink, appLinkText
         {name}
       </h5>
       <Link to={appLink} className="flex-shrink-0 overflow-hidden position-relative">
-        <SumaImage image={image} h={150} style={{ maxWidth: "100%" }} />
+        <SumaImage
+          image={image}
+          h={200}
+          w={500}
+          params={{ crop: "entropy", resize: "fill" }}
+          style={{ maxWidth: "100%" }}
+        />
       </Link>
       <p className="mt-3">{description}</p>
       <p className="small">

--- a/webapp/src/pages/FoodDetails.jsx
+++ b/webapp/src/pages/FoodDetails.jsx
@@ -6,7 +6,7 @@ import LayoutContainer from "../components/LayoutContainer";
 import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
 import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
-import { t } from "../localization";
+import { dt, t } from "../localization";
 import makeTitle from "../modules/makeTitle";
 import { anyMoney, intToMoney } from "../shared/money";
 import Money from "../shared/react/Money";
@@ -109,7 +109,7 @@ export default function FoodDetails() {
         <Row>
           <h5>{t("food:from_vendor", { vendorName: vendor.name })}</h5>
           <h4>{t("food:details_header")}</h4>
-          <p>{product.description}</p>
+          <div>{dt(product.description)}</div>
         </Row>
       </LayoutContainer>
     </>


### PR DESCRIPTION
max_quantity_for takes into account the cart

When figuring out max quantity for a product,
we need to look at the other items already in the cart.
If we allow 3 items per offering,
and there is another cart item with a quantity of 1,
the other product should have a max quantity of 2, not 3.

---

Dynamic translations can use markdown

I18n formatters can hide unicode zero-width flags at the start
of translated strings, which will determine what formatter
to use on the frontend.

Allows us to continue to use `{product.description}`
but replace it with `{dt(product.description)}` if we want to
support markdown in a component.

The frontend cost of this is very minor (checking `str[0]`).
The backend cost is nontrivial (we have to render markdown
for every translated text), but it's fast enough,
and we have an LRU so we don't need to keep re-testing
strings that we repeatedly re-render
(in most cases, just a few hundred strings will be shown in
the app at a given time).

Support markdown in the program and product descriptions,
use multiline for some 'localized text' inputs in admin,
and fix a missing exposure of vendor configuration instructions.

---

Dashboard program image fix

Apply width, height, crop, and resize, so images are consistent.

---

Better process for restoring prod DB to local

Set all passwords, undelete the admin user,
stomp external (stripe, front) ids.
