### PR TITLE
Sort member dashboard enrollments by program ordinal

### DIFF
--- a/lib/suma/member/dashboard.rb
+++ b/lib/suma/member/dashboard.rb
@@ -14,6 +14,7 @@ class Suma::Member::Dashboard
   end
 
   def program_enrollments
-    return @program_enrollments ||= @member.combined_program_enrollments_dataset.active(as_of: @at).all
+    enrollments = @member.combined_program_enrollments_dataset.active(as_of: @at)
+    return @program_enrollments ||= enrollments.sort_by { |pe| pe.program.ordinal }
   end
 end

--- a/lib/suma/member/dashboard.rb
+++ b/lib/suma/member/dashboard.rb
@@ -14,7 +14,7 @@ class Suma::Member::Dashboard
   end
 
   def program_enrollments
-    enrollments = @member.combined_program_enrollments_dataset.active(as_of: @at)
-    return @program_enrollments ||= enrollments.sort_by { |pe| pe.program.ordinal }
+    return @program_enrollments ||= @member.combined_program_enrollments_dataset.active(as_of: @at).
+        all.sort_by { |pe| pe.program.ordinal }
   end
 end

--- a/spec/suma/member/dashboard_spec.rb
+++ b/spec/suma/member/dashboard_spec.rb
@@ -20,10 +20,9 @@ RSpec.describe Suma::Member::Dashboard, :db do
   end
 
   it "sorts enrollments by program ordinal" do
-    program_fac = Suma::Fixtures.program
-    p3 = program_fac.create(ordinal: 3)
-    p2 = program_fac.create(ordinal: 2)
-    p1 = program_fac.create(ordinal: 1)
+    p3 = Suma::Fixtures.program.create(ordinal: 3)
+    p1 = Suma::Fixtures.program.create(ordinal: 1)
+    p2 = Suma::Fixtures.program.create(ordinal: 2)
     pe3 = Suma::Fixtures.program_enrollment.create(member:, program: p3)
     pe1 = Suma::Fixtures.program_enrollment.create(member:, program: p1)
     pe2 = Suma::Fixtures.program_enrollment.create(member:, program: p2)

--- a/spec/suma/member/dashboard_spec.rb
+++ b/spec/suma/member/dashboard_spec.rb
@@ -18,4 +18,18 @@ RSpec.describe Suma::Member::Dashboard, :db do
       program_enrollments: have_same_ids_as(pe1, pe2),
     )
   end
+
+  it "sorts enrollments by program ordinal" do
+    program_fac = Suma::Fixtures.program
+    p3 = program_fac.create(ordinal: 3)
+    p2 = program_fac.create(ordinal: 2)
+    p1 = program_fac.create(ordinal: 1)
+    pe3 = Suma::Fixtures.program_enrollment.create(member:, program: p3)
+    pe1 = Suma::Fixtures.program_enrollment.create(member:, program: p1)
+    pe2 = Suma::Fixtures.program_enrollment.create(member:, program: p2)
+    enrollments = described_class.new(member, at: now).program_enrollments
+    expect(enrollments.first).to have_attributes(program: p1)
+    expect(enrollments.second).to have_attributes(program: p2)
+    expect(enrollments.last).to have_attributes(program: p3)
+  end
 end


### PR DESCRIPTION
Members `Suma::Member::Dashboard#program_enrollments` should be sorted by program ordinal integer, so that we have control over which programs show up first in the frontend dashboard.