### PR TITLE
Expose updated_at detail and render correctly

### DIFF
--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -3,7 +3,7 @@ import AdminLink from "../components/AdminLink";
 import ProgramEnrollmentRelatedList from "../components/ProgramEnrollmentRelatedList";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import { dayjs, dayjsOrNull } from "../modules/dayConfig";
+import { dayjs } from "../modules/dayConfig";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import React from "react";
 
@@ -16,7 +16,7 @@ export default function OrganizationDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        { label: "Updated At", value: dayjsOrNull(model.updatedAt) },
+        { label: "Updated At", value: dayjs(model.updatedAt) },
         { label: "Name", value: model.name },
       ]}
     >

--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -3,7 +3,7 @@ import AdminLink from "../components/AdminLink";
 import ProgramEnrollmentRelatedList from "../components/ProgramEnrollmentRelatedList";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import { dayjs } from "../modules/dayConfig";
+import { dayjs, dayjsOrNull } from "../modules/dayConfig";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import React from "react";
 
@@ -16,7 +16,7 @@ export default function OrganizationDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        { label: "Updated At", value: dayjs(model.updatedAt) },
+        { label: "Updated At", value: dayjsOrNull(model.updatedAt) },
         { label: "Name", value: model.name },
       ]}
     >
@@ -36,7 +36,7 @@ export default function OrganizationDetailPage() {
               organizationLabel: `(${model.id}) ${model.name || "-"}`,
             })}
             addNewRole="organizationMembership"
-            headers={["Id", "Member", "Created At", "Updated At"]}
+            headers={["Id", "Member", "Created At"]}
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink model={row} />,
@@ -44,7 +44,6 @@ export default function OrganizationDetailPage() {
                 {row.member.name}
               </AdminLink>,
               dayjs(row.createdAt).format("lll"),
-              dayjs(row.updatedAt).format("lll"),
             ]}
           />
         </>

--- a/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceDetail from "../components/ResourceDetail";
-import { dayjs, dayjsOrNull } from "../modules/dayConfig";
+import { dayjs } from "../modules/dayConfig";
 import React from "react";
 
 export default function OrganizationMembershipDetailPage() {
@@ -13,7 +13,7 @@ export default function OrganizationMembershipDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        { label: "Updated At", value: dayjsOrNull(model.updatedAt) },
+        { label: "Updated At", value: dayjs(model.updatedAt) },
         {
           label: "Member",
           value: (

--- a/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceDetail from "../components/ResourceDetail";
-import { dayjs } from "../modules/dayConfig";
+import { dayjs, dayjsOrNull } from "../modules/dayConfig";
 import React from "react";
 
 export default function OrganizationMembershipDetailPage() {
@@ -13,7 +13,7 @@ export default function OrganizationMembershipDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        { label: "Updated At", value: dayjs(model.updatedAt) },
+        { label: "Updated At", value: dayjsOrNull(model.updatedAt) },
         {
           label: "Member",
           value: (

--- a/adminapp/src/pages/PaymentTriggerDetailPage.jsx
+++ b/adminapp/src/pages/PaymentTriggerDetailPage.jsx
@@ -3,7 +3,7 @@ import AdminLink from "../components/AdminLink";
 import Programs from "../components/Programs";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import { dayjs, dayjsOrNull } from "../modules/dayConfig";
+import { dayjs } from "../modules/dayConfig";
 import { formatMoney, intToMoney } from "../shared/money";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import React from "react";
@@ -18,7 +18,7 @@ export default function PaymentTriggerDetailPage() {
         { label: "ID", value: model.id },
         { label: "Label", value: model.label },
         { label: "Created At", value: dayjs(model.createdAt) },
-        { label: "Updated At", value: dayjsOrNull(model.updatedAt) },
+        { label: "Updated At", value: dayjs(model.updatedAt) },
         { label: "Starting", value: dayjs(model.activeDuringBegin) },
         { label: "Ending", value: dayjs(model.activeDuringEnd) },
         { label: "Match Multiplier", value: model.matchMultiplier },

--- a/adminapp/src/pages/PaymentTriggerDetailPage.jsx
+++ b/adminapp/src/pages/PaymentTriggerDetailPage.jsx
@@ -3,7 +3,7 @@ import AdminLink from "../components/AdminLink";
 import Programs from "../components/Programs";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import { dayjs } from "../modules/dayConfig";
+import { dayjs, dayjsOrNull } from "../modules/dayConfig";
 import { formatMoney, intToMoney } from "../shared/money";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import React from "react";
@@ -18,7 +18,7 @@ export default function PaymentTriggerDetailPage() {
         { label: "ID", value: model.id },
         { label: "Label", value: model.label },
         { label: "Created At", value: dayjs(model.createdAt) },
-        { label: "Updated At", value: model.updatedAt && dayjs(model.updatedAt) },
+        { label: "Updated At", value: dayjsOrNull(model.updatedAt) },
         { label: "Starting", value: dayjs(model.activeDuringBegin) },
         { label: "Ending", value: dayjs(model.activeDuringEnd) },
         { label: "Match Multiplier", value: model.matchMultiplier },

--- a/lib/suma/admin_api/anon_proxy.rb
+++ b/lib/suma/admin_api/anon_proxy.rb
@@ -37,12 +37,14 @@ class Suma::AdminAPI::AnonProxy < Suma::AdminAPI::V1
 
   class DetailedVendorConfigurationEntity < VendorConfigurationEntity
     include Suma::AdminAPI::Entities
+    include AutoExposeDetail
     expose :programs, with: ProgramEntity
     expose :instructions, with: TranslatedTextEntity
   end
 
   class DetailedVendorAccountEntity < VendorAccountEntity
     include Suma::AdminAPI::Entities
+    include AutoExposeDetail
     expose :latest_access_code
     expose :latest_access_code_set_at
     expose :latest_access_code_requested_at

--- a/lib/suma/admin_api/commerce_offering_products.rb
+++ b/lib/suma/admin_api/commerce_offering_products.rb
@@ -9,6 +9,7 @@ class Suma::AdminAPI::CommerceOfferingProducts < Suma::AdminAPI::V1
   class DetailedCommerceOfferingProductEntity < BaseEntity
     include Suma::AdminAPI::Entities
     include AutoExposeBase
+    include AutoExposeDetail
     expose :offering, with: OfferingEntity
     expose :product, with: ProductEntity
     expose :customer_price, with: MoneyEntity

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -25,7 +25,9 @@ module Suma::AdminAPI::Entities
   # detailed entities, or limited lists.
   module AutoExposeDetail
     def self.included(ctx)
-      ctx.expose :updated_at, if: ->(o) { o.respond_to?(:updated_at) }
+      ctx.expose :updated_at, if: ->(o) { o.respond_to?(:updated_at) } do |inst|
+        inst.updated_at || inst.created_at
+      end
       # Always expose an external links array when we mix this in
       ctx.expose :external_links do |inst|
         inst.respond_to?(:external_links) ? inst.external_links : []
@@ -302,7 +304,6 @@ module Suma::AdminAPI::Entities
 
   class OrganizationMembershipEntity < BaseEntity
     include AutoExposeBase
-    include AutoExposeDetail
     expose :member, with: MemberEntity
     expose :verified_organization, with: OrganizationEntity
     expose :unverified_organization_name

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -302,6 +302,7 @@ module Suma::AdminAPI::Entities
 
   class OrganizationMembershipEntity < BaseEntity
     include AutoExposeBase
+    include AutoExposeDetail
     expose :member, with: MemberEntity
     expose :verified_organization, with: OrganizationEntity
     expose :unverified_organization_name

--- a/lib/suma/admin_api/organizations.rb
+++ b/lib/suma/admin_api/organizations.rb
@@ -8,6 +8,7 @@ class Suma::AdminAPI::Organizations < Suma::AdminAPI::V1
 
   class DetailedOrganizationEntity < OrganizationEntity
     include Suma::AdminAPI::Entities
+    include AutoExposeDetail
     expose :memberships, with: OrganizationMembershipEntity
     expose :program_enrollments, with: ProgramEnrollmentEntity
   end

--- a/lib/suma/admin_api/program_enrollments.rb
+++ b/lib/suma/admin_api/program_enrollments.rb
@@ -4,8 +4,10 @@ require "suma/admin_api"
 
 class Suma::AdminAPI::ProgramEnrollments < Suma::AdminAPI::V1
   include Suma::AdminAPI::Entities
+
   class DetailedProgramEnrollmentEntity < ProgramEnrollmentEntity
     include Suma::AdminAPI::Entities
+    include AutoExposeDetail
     expose :approved?, as: :approved
     expose :approved_by, with: MemberEntity
     expose :unenrolled?, as: :unenrolled

--- a/lib/suma/admin_api/roles.rb
+++ b/lib/suma/admin_api/roles.rb
@@ -6,7 +6,11 @@ require "suma/admin_api"
 
 class Suma::AdminAPI::Roles < Suma::AdminAPI::V1
   class RoleEntity < Suma::AdminAPI::Entities::RoleEntity; end
-  class DetailedRoleEntity < RoleEntity; end
+
+  class DetailedRoleEntity < RoleEntity
+    include Suma::AdminAPI::Entities
+    include AutoExposeDetail
+  end
 
   resource :roles do
     desc "Return all roles, ordered by name"

--- a/lib/suma/admin_api/vendor_services.rb
+++ b/lib/suma/admin_api/vendor_services.rb
@@ -9,6 +9,7 @@ class Suma::AdminAPI::VendorServices < Suma::AdminAPI::V1
   class DetailedMobilityTripEntity < BaseEntity
     include Suma::AdminAPI::Entities
     include AutoExposeBase
+    include AutoExposeDetail
     expose :vehicle_id
     expose :vendor_service_rate, as: :rate, with: VendorServiceRateEntity
     expose :begin_lat
@@ -23,6 +24,7 @@ class Suma::AdminAPI::VendorServices < Suma::AdminAPI::V1
 
   class DetailedVendorServiceEntity < VendorServiceEntity
     include Suma::AdminAPI::Entities
+    include AutoExposeDetail
     expose :external_name
     expose :internal_name
     expose :mobility_vendor_adapter_key

--- a/lib/suma/admin_api/vendors.rb
+++ b/lib/suma/admin_api/vendors.rb
@@ -8,6 +8,7 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
 
   class DetailedVendorEntity < VendorEntity
     include Suma::AdminAPI::Entities
+    include AutoExposeDetail
     expose :slug
     expose :services, with: VendorServiceEntity
     expose :products, with: ProductEntity


### PR DESCRIPTION
Fixes #737 

Some 'updated_at' values were not being exposed for some resources by the backend, which means:
1. Their value is `undefined`
2. The frontend `dayjsOrNull(date)` function fails since the date value is `undefined`, and function checks for `null` only

Solution is to ensure we expose `updated_at` when we intend to use/render it, and use `dayjsOrNull` in the frontend to render the value correctly.

Also removes 'updated at' field from the organization page membership related list. Don't think we need it there.