### PR TITLE
Expose preferred language in member admin

### DIFF
--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -106,6 +106,10 @@ export default function MemberDetailPage() {
             <DetailGrid
               title="Other Information"
               properties={[
+                {
+                  label: "Preferred Language",
+                  value: model.preferences.preferredLanguageName,
+                },
                 { label: "Timezone", value: model.timezone },
                 { label: "Created At", value: dayjs(model.createdAt) },
                 {

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -58,6 +58,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
   class PreferencesEntity < BaseEntity
     expose :public_url
     expose :subscriptions, with: PreferencesSubscriptionEntity
+    expose :preferred_language_name
   end
 
   class DetailedMemberEntity < MemberEntity

--- a/lib/suma/i18n.rb
+++ b/lib/suma/i18n.rb
@@ -39,12 +39,6 @@ module Suma::I18n
     end
   end
 
-  def self.locale_or_default(locale_code)
-    locale = Suma::I18n::SUPPORTED_LOCALES.fetch(locale_code)
-    default = Suma::I18n::SUPPORTED_LOCALES.fetch(self.base_locale_code)
-    return [locale, default].compact.first
-  end
-
   def self.reformat_files
     Dir.glob(LOCALE_DIR + "**/*.json") do |path|
       self.reformat_file(path)

--- a/lib/suma/i18n.rb
+++ b/lib/suma/i18n.rb
@@ -39,6 +39,12 @@ module Suma::I18n
     end
   end
 
+  def self.locale_or_default(locale_code)
+    locale = Suma::I18n::SUPPORTED_LOCALES.fetch(locale_code)
+    default = Suma::I18n::SUPPORTED_LOCALES.fetch(self.base_locale_code)
+    return [locale, default].compact.first
+  end
+
   def self.reformat_files
     Dir.glob(LOCALE_DIR + "**/*.json") do |path|
       self.reformat_file(path)

--- a/lib/suma/message/preferences.rb
+++ b/lib/suma/message/preferences.rb
@@ -57,6 +57,8 @@ class Suma::Message::Preferences < Suma::Postgres::Model(:message_preferences)
 
   def public_url = "#{Suma.app_url}/preferences-public?token=#{self.access_token}"
 
+  def preferred_language_name = Browser::AcceptLanguage.parse(self.preferred_language).first.name
+
   def validate
     super
     self.validates_includes Suma::I18n.enabled_locale_codes, :preferred_language

--- a/lib/suma/message/preferences.rb
+++ b/lib/suma/message/preferences.rb
@@ -57,7 +57,11 @@ class Suma::Message::Preferences < Suma::Postgres::Model(:message_preferences)
 
   def public_url = "#{Suma.app_url}/preferences-public?token=#{self.access_token}"
 
-  def preferred_language_name = Suma::I18n.locale_or_default(self.preferred_language).language
+  def preferred_language_name
+    return Suma::I18n::SUPPORTED_LOCALES.fetch(self.preferred_language).language
+  rescue KeyError
+    return "Invalid (#{self.preferred_language})"
+  end
 
   def validate
     super

--- a/lib/suma/message/preferences.rb
+++ b/lib/suma/message/preferences.rb
@@ -57,7 +57,7 @@ class Suma::Message::Preferences < Suma::Postgres::Model(:message_preferences)
 
   def public_url = "#{Suma.app_url}/preferences-public?token=#{self.access_token}"
 
-  def preferred_language_name = Browser::AcceptLanguage.parse(self.preferred_language).first.name
+  def preferred_language_name = Suma::I18n.locale_or_default(self.preferred_language).language
 
   def validate
     super

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -124,12 +124,14 @@ RSpec.describe Suma::AdminAPI::Members, :db do
       cash_ledger = Suma::Fixtures.ledger.member(admin).category(:cash).create
       charge1 = Suma::Fixtures.charge(member: admin).create
       charge1.add_book_transaction(Suma::Fixtures.book_transaction.from(cash_ledger).create)
+      admin.preferences!.update(preferred_language: "es")
 
       get "/v1/members/#{admin.id}"
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
         sessions: contain_exactly(include(:ip_lookup_link)),
+        preferences: include(preferred_language_name: "Spanish"),
       )
     end
   end

--- a/spec/suma/message/preferences_spec.rb
+++ b/spec/suma/message/preferences_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe "Suma::Message::Preferences", :db, :messaging do
     deliveries = Suma::Fixtures.member.create.message_preferences!.update(preferred_language: "fr").dispatch(msg)
     expect(deliveries).to contain_exactly(have_attributes(template: "specs/localized", template_language: "fr"))
   end
+
+  describe "preferred_language_name" do
+    it "returns the language name" do
+      pref = Suma::Fixtures.member.create.message_preferences!
+      pref.preferred_language = "es"
+      expect(pref).to have_attributes(preferred_language_name: "Spanish")
+    end
+
+    it "uses a clear value if the message is set to an invalid locale" do
+      pref = Suma::Fixtures.member.create.message_preferences!
+      pref.preferred_language = "zz"
+      expect(pref).to have_attributes(preferred_language_name: "Invalid (zz)")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #745 

Expose member preferred language in admin member detail page. Converts the language code `en` to the language name `English` for readability.

![Screenshot 2024-11-25 at 3 25 09 PM](https://github.com/user-attachments/assets/c416b437-cd73-486c-bb8b-c82322b425e9)
