### PR TITLE
Role program access

### DIFF
--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -219,6 +219,7 @@ export default {
   searchVendors: (data) => post(`/adminapi/v1/search/vendors`, data),
   searchMembers: (data) => post(`/adminapi/v1/search/members`, data),
   searchOrganizations: (data) => post(`/adminapi/v1/search/organizations`, data),
+  searchRoles: (data) => post(`/adminapi/v1/search/roles`, data),
   searchVendorServices: (data) => post(`/adminapi/v1/search/vendor_services`, data),
   searchCommerceOffering: (data) => post(`/adminapi/v1/search/commerce_offerings`, data),
   searchPrograms: (data) => post(`/adminapi/v1/search/programs`, data),

--- a/adminapp/src/pages/ProgramDetailPage.jsx
+++ b/adminapp/src/pages/ProgramDetailPage.jsx
@@ -113,9 +113,9 @@ export default function ProgramDetailPage() {
           />
           <RelatedList
             title="Program Enrollments"
-            headers={["Id", "Member", "Organization", "Approved At", "Unenrolled At"]}
+            headers={["Id", "Enrollee", "Enrollee Type", "Approved At", "Unenrolled At"]}
             rows={model.enrollments}
-            addNewLabel="Enroll member or organization"
+            addNewLabel="Enroll member, organization or role"
             addNewLink={createRelativeUrl(`/program-enrollment/new`, {
               programId: model.id,
               programLabel: `(${model.id}) ${model.name.en}`,
@@ -124,8 +124,8 @@ export default function ProgramDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
-              <AdminLink model={row.member}>{row.member?.name}</AdminLink>,
-              <AdminLink model={row.organization}>{row.organization?.name}</AdminLink>,
+              <AdminLink model={row.enrollee}>{row.enrollee?.name}</AdminLink>,
+              row.enrolleeType,
               dayjsOrNull(row.approvedAt)?.format("lll"),
               dayjsOrNull(row.unenrolledAt)?.format("lll"),
             ]}

--- a/adminapp/src/pages/ProgramEnrollmentCreatePage.jsx
+++ b/adminapp/src/pages/ProgramEnrollmentCreatePage.jsx
@@ -8,6 +8,7 @@ export default function ProgramEnrollmentCreatePage() {
     program: {},
     member: {},
     organization: {},
+    role: {},
   };
   return (
     <ResourceCreate

--- a/adminapp/src/pages/ProgramEnrollmentDetailPage.jsx
+++ b/adminapp/src/pages/ProgramEnrollmentDetailPage.jsx
@@ -32,19 +32,10 @@ export default function ProgramEnrollmentDetailPage() {
           label: "Program Name ES",
           value: <AdminLink model={model.program}>{model.program.name.es}</AdminLink>,
         },
-        model.member
-          ? {
-              label: "Enrolled Member",
-              value: <AdminLink model={model.member}>{model.member?.name}</AdminLink>,
-            }
-          : {
-              label: "Enrolled Organization",
-              value: (
-                <AdminLink model={model.organization}>
-                  {model.organization?.name}
-                </AdminLink>
-              ),
-            },
+        {
+          label: "Enrolled " + model.enrolleeType,
+          value: <AdminLink model={model.enrollee}>{model.enrollee?.name}</AdminLink>,
+        },
         {
           label: "Approved",
           children: (

--- a/adminapp/src/pages/ProgramEnrollmentForm.jsx
+++ b/adminapp/src/pages/ProgramEnrollmentForm.jsx
@@ -53,9 +53,9 @@ export default function ProgramEnrollmentForm({
   return (
     <FormLayout
       title={isCreate ? "Create a Program Enrollment" : "Update a Program Enrollment"}
-      subtitle="Program enrollment that are approved gives access to a member
-      or members in an organization to resources connected with an active program.
-      After creation, you can approve the enrollment and/or unenroll."
+      subtitle="Program enrollment that are approved gives access to a member,
+      members in an organization, or members with a role to resources connected
+      with an active program. After creation, you can approve the enrollment and/or unenroll."
       onSubmit={onSubmit}
       isBusy={isBusy}
     >
@@ -82,15 +82,16 @@ export default function ProgramEnrollmentForm({
               control={<Radio />}
               label="Organization"
             />
+            <FormControlLabel value="role" control={<Radio />} label="Role" />
           </RadioGroup>
         </FormControl>
-        {enrolleeType === "member" ? (
+        {enrolleeType === "member" && (
           <AutocompleteSearch
             key="member"
             {...register("member")}
             label="Member"
             helperText="Who can access this program?"
-            value={resource.member?.label || ""}
+            value={resource.member.label || ""}
             fullWidth
             search={api.searchMembers}
             disabled={fixedEnrollee}
@@ -98,7 +99,8 @@ export default function ProgramEnrollmentForm({
             onValueSelect={(mem) => setField("member", mem)}
             onTextChange={() => setField("member", {})}
           />
-        ) : (
+        )}
+        {enrolleeType === "organization" && (
           <AutocompleteSearch
             key="org"
             {...register("organization")}
@@ -111,6 +113,22 @@ export default function ProgramEnrollmentForm({
             style={{ flex: 1 }}
             onValueSelect={(org) => setField("organization", org)}
             onTextChange={() => setField("organization", {})}
+          />
+        )}
+        {enrolleeType === "role" && (
+          <AutocompleteSearch
+            key="role"
+            {...register("role")}
+            label="Role"
+            helperText="What members with this role can access this program?"
+            value={resource.role.label || ""}
+            fullWidth
+            search={api.searchRoles}
+            searchEmpty={true}
+            disabled={fixedEnrollee}
+            style={{ flex: 1 }}
+            onValueSelect={(role) => setField("role", role)}
+            onTextChange={() => setField("role", {})}
           />
         )}
       </Stack>

--- a/adminapp/src/pages/ProgramEnrollmentListPage.jsx
+++ b/adminapp/src/pages/ProgramEnrollmentListPage.jsx
@@ -26,19 +26,17 @@ export default function ProgramEnrollmentListPage() {
           render: (c) => <AdminLink model={c.program}>{c.program.name.en}</AdminLink>,
         },
         {
-          id: "member",
-          label: "Member",
+          id: "enrollee",
+          label: "Enrollee",
           align: "left",
-          render: (c) => <AdminLink model={c.member}>{c.member?.name}</AdminLink>,
+          render: (c) => <AdminLink model={c.enrollee}>{c.enrollee?.name}</AdminLink>,
           hideEmpty: true,
         },
         {
-          id: "organization",
-          label: "Organization",
+          id: "enrollee_type",
+          label: "Enrollee Type",
           align: "left",
-          render: (c) => (
-            <AdminLink model={c.organization}>{c.organization?.name}</AdminLink>
-          ),
+          render: (c) => c.enrolleeType,
           hideEmpty: true,
         },
         {

--- a/db/migrations/056_role_based_program_access.rb
+++ b/db/migrations/056_role_based_program_access.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "sequel/unambiguous_constraint"
+
+Sequel.migration do
+  up do
+    alter_table(:program_enrollments) do
+      add_foreign_key :role_id, :roles, on_delete: :cascade, index: true
+
+      drop_constraint(:one_enrollee_set)
+      add_constraint(
+        :one_enrollee_set,
+        Sequel.unambiguous_constraint([:member_id, :organization_id, :role_id]),
+      )
+
+      drop_index(:program_id, name: :unique_enrollee_in_program_idx)
+      add_index [
+        Sequel.function(:coalesce, :member_id, 0),
+        Sequel.function(:coalesce, :organization_id, 0),
+        Sequel.function(:coalesce, :role_id, 0),
+        :program_id,
+      ],
+                name: :unique_enrollee_in_program_idx,
+                unique: true
+    end
+  end
+
+  down do
+    alter_table(:program_enrollments) do
+      drop_index(:program_id, name: :unique_enrollee_in_program_idx)
+      add_index [
+        Sequel.function(:coalesce, :member_id, 0),
+        Sequel.function(:coalesce, :organization_id, 0),
+        :program_id,
+      ],
+                name: :unique_enrollee_in_program_idx,
+                unique: true
+
+      drop_constraint(:one_enrollee_set)
+      add_constraint(
+        :one_enrollee_set,
+        Sequel.unambiguous_constraint([:member_id, :organization_id]),
+      )
+      drop_column(:role_id)
+    end
+  end
+end

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -130,13 +130,19 @@ module Suma::AdminAPI::Entities
     expose :app_link_text, with: TranslatedTextEntity
   end
 
+  class ProgramEnrolleeEntity < BaseEntity
+    include AutoExposeBase
+    expose :name do |inst|
+      inst.is_a?(Suma::Role) ? inst.name.titleize : inst.name
+    end
+  end
+
   class ProgramEnrollmentEntity < BaseEntity
     include AutoExposeBase
     expose :admin_link
     expose :program, with: ProgramEntity
-    expose :member, with: MemberEntity
-    expose :organization, with: OrganizationEntity
-    expose :role, with: RoleEntity
+    expose :enrollee, with: ProgramEnrolleeEntity
+    expose :enrollee_type
     expose :approved_at
     expose :unenrolled_at
     expose :program_active do |pe|

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -136,6 +136,7 @@ module Suma::AdminAPI::Entities
     expose :program, with: ProgramEntity
     expose :member, with: MemberEntity
     expose :organization, with: OrganizationEntity
+    expose :role, with: RoleEntity
     expose :approved_at
     expose :unenrolled_at
     expose :program_active do |pe|

--- a/lib/suma/admin_api/program_enrollments.rb
+++ b/lib/suma/admin_api/program_enrollments.rb
@@ -30,7 +30,8 @@ class Suma::AdminAPI::ProgramEnrollments < Suma::AdminAPI::V1
         requires(:program, type: JSON) { use :model_with_id }
         optional(:member, type: JSON) { use :model_with_id }
         optional(:organization, type: JSON) { use :model_with_id }
-        exactly_one_of :member, :organization
+        optional(:role, type: JSON) { use :model_with_id }
+        exactly_one_of :member, :organization, :role
       end
     end
 

--- a/lib/suma/admin_api/search.rb
+++ b/lib/suma/admin_api/search.rb
@@ -227,6 +227,20 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
     params do
       optional :q, type: String
     end
+    post :roles do
+      check_role_access!(admin_member, :read, :admin_members)
+      # role names are sluggified by default.
+      params[:q] = Suma.to_slug(params[:q]) if params[:q].present?
+      ds = Suma::Role.dataset
+      ds = ds_search_or_order_by(:name, ds, params)
+      ds = ds.limit(15)
+      status 200
+      present_collection ds, with: SearchRoleEntity
+    end
+
+    params do
+      optional :q, type: String
+    end
     post :vendor_services do
       check_role_access!(admin_member, :read, :admin_commerce)
       ds = Suma::Vendor::Service.dataset
@@ -333,6 +347,14 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
     expose :admin_link
     expose :name
     expose :name, as: :label
+  end
+
+  class SearchRoleEntity < BaseEntity
+    expose :key, &self.delegate_to(:id, :to_s)
+    expose :id
+    expose :admin_link
+    expose :name
+    expose :label
   end
 
   class SearchVendorServiceEntity < BaseEntity

--- a/lib/suma/fixtures/program_enrollments.rb
+++ b/lib/suma/fixtures/program_enrollments.rb
@@ -12,7 +12,7 @@ module Suma::Fixtures::ProgramEnrollments
   end
 
   before_saving do |instance|
-    instance.member ||= Suma::Fixtures.member.create if instance.organization_id.nil?
+    instance.member ||= Suma::Fixtures.member.create if instance.organization_id.nil? && instance.role_id.nil?
     instance.program ||= Suma::Fixtures.program.create
     instance
   end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -126,7 +126,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
                 ).union(
                   self.program_enrollments_via_roles_dataset,
                   alias: :program_enrollments,
-                ).order(:program_id, :member_id).distinct(:program_id)
+                ).order(:program_id, :member_id, :organization_id).distinct(:program_id)
               },
               eager_loader: (proc do |eo|
                 eo[:rows].each { |p| p.associations[:combined_program_enrollments] = [] }
@@ -135,7 +135,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
                   # Get unique enrollments for a program. Prefer direct/member enrollments,
                   # so sort the rows by member_id so NULL member_id rows (indirect/org enrollments)
                   # sort last and are eliminated by the DISTINCT.
-                  order(:program_id, :member_id).
+                  order(:program_id, :member_id, :organization_id).
                   distinct(:program_id)
                 ds.all do |en|
                   m = eo[:id_map][en.member_id || en.values.fetch(:annotated_member_id)].first

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -103,6 +103,15 @@ class Suma::Member < Suma::Postgres::Model(:members)
                     right_primary_key: :organization_id,
                     read_only: true
 
+  many_through_many :program_enrollments_via_roles,
+                    [
+                      [:roles_members, :member_id, :role_id],
+                    ],
+                    class: "Suma::Program::Enrollment",
+                    left_primary_key: :id,
+                    right_primary_key: :role_id,
+                    read_only: true
+
   one_to_many :combined_program_enrollments,
               class: "Suma::Program::Enrollment",
               read_only: true,
@@ -114,8 +123,10 @@ class Suma::Member < Suma::Postgres::Model(:members)
                 self.direct_program_enrollments_dataset.union(
                   self.program_enrollments_via_organizations_dataset,
                   alias: :program_enrollments,
-                ).order(:program_id, :member_id).
-                  distinct(:program_id)
+                ).union(
+                  self.program_enrollments_via_roles_dataset,
+                  alias: :program_enrollments,
+                ).order(:program_id, :member_id).distinct(:program_id)
               },
               eager_loader: (proc do |eo|
                 eo[:rows].each { |p| p.associations[:combined_program_enrollments] = [] }

--- a/lib/suma/program/enrollment.rb
+++ b/lib/suma/program/enrollment.rb
@@ -74,8 +74,10 @@ class Suma::Program::Enrollment < Suma::Postgres::Model(:program_enrollments)
     self.unenrolled_at = v ? Time.now : nil
   end
 
-  # @return [Suma::Member,Suma::Organization]
-  def enrollee = self.member || self.organization
+  # @return [Suma::Member,Suma::Organization,Suma::Role]
+  def enrollee = self.member || self.organization || self.role
+
+  def enrollee_type = self.enrollee.class.name.demodulize
 
   def rel_admin_link = "/program-enrollment/#{self.id}"
 end

--- a/lib/suma/role.rb
+++ b/lib/suma/role.rb
@@ -44,6 +44,8 @@ class Suma::Role < Suma::Postgres::Model(:roles)
                class: "Suma::Member",
                join_table: :roles_members
 
+  one_to_many :program_enrollments, class: "Suma::Program::Enrollment"
+
   def rel_admin_link = "/role/#{self.id}"
 
   def label = self.name.titleize

--- a/spec/suma/admin_api/program_enrollments_spec.rb
+++ b/spec/suma/admin_api/program_enrollments_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe Suma::AdminAPI::ProgramEnrollments, :db do
       expect(last_response.headers).to include("Created-Resource-Admin")
       expect(Suma::Program::Enrollment.all).to have_length(1)
     end
+
+    it "creates the program enrollment for role" do
+      role = Suma::Role.create(name: "test")
+      program = Suma::Fixtures.program.create
+
+      post "/v1/program_enrollments/create", program: {id: program.id}, role: {id: role.id}
+
+      expect(last_response).to have_status(200)
+      expect(last_response.headers).to include("Created-Resource-Admin")
+      expect(Suma::Program::Enrollment.all).to have_length(1)
+    end
   end
 
   describe "GET /v1/program_enrollments/:id" do

--- a/spec/suma/admin_api/program_enrollments_spec.rb
+++ b/spec/suma/admin_api/program_enrollments_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Suma::AdminAPI::ProgramEnrollments, :db do
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
         id: enrollment.id,
-        member: include(id: enrollment.member.id),
+        enrollee: include(id: enrollment.member.id),
       )
     end
 

--- a/spec/suma/admin_api/search_spec.rb
+++ b/spec/suma/admin_api/search_spec.rb
@@ -353,23 +353,14 @@ RSpec.describe Suma::AdminAPI::Search, :db do
       expect(last_response).to have_json_body.that_includes(error: include(code: "role_check"))
     end
 
-    it "returns matching roles" do
-      r1 = Suma::Role.create(name: "spongebob")
+    it "returns matching roles, using slug naming" do
+      r1 = Suma::Role.create(name: "sponge_bob")
       r2 = Suma::Role.create(name: "patrick")
 
-      post "/v1/search/roles", q: "bob"
+      post "/v1/search/roles", q: "sponge bob"
 
       expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(items: have_same_ids_as(r1))
-    end
-
-    it "returns matching roles label" do
-      Suma::Role.create(name: "hard worker")
-
-      post "/v1/search/roles", q: "hard"
-
-      expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(items: [include(label: "Hard Worker")])
+      expect(last_response).to have_json_body.that_includes(items: [include(id: r1.id, label: "Sponge Bob")])
     end
 
     it "returns all results in descending order if no query" do

--- a/spec/suma/fixtures_spec.rb
+++ b/spec/suma/fixtures_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Suma::Fixtures do
     Suma::Fixtures.bank_account.with_legal_entity.create
     Suma::Fixtures.card.with_legal_entity.create
     Suma::Fixtures.funding_transaction.with_fake_strategy.member(member).create
-    Suma::Fixtures.geolocation.latlng(10, 2).create
+    Suma::Fixtures.geolocation.latlng(10, 2).instance
     Suma::Fixtures.legal_entity.with_contact_info.with_address.create
     Suma::Fixtures.member_activity.create
     Suma::Fixtures.member.password.plus_sign.with_email.with_phone.terms_agreed.create

--- a/spec/suma/program/enrollment_spec.rb
+++ b/spec/suma/program/enrollment_spec.rb
@@ -78,4 +78,19 @@ RSpec.describe "Suma::Program::Enrollment", :db do
       expect(pe.program.enrollment_for(m, as_of:, include: :all)).to be === pe
     end
   end
+
+  it "can describe its enrollees" do
+    pe = Suma::Fixtures.program_enrollment.instance
+    member = Suma::Fixtures.member.create
+    organization = Suma::Fixtures.organization.create
+    role = Suma::Role.create(name: "test role")
+    pe.set(member:)
+    expect(pe).to have_attributes(enrollee_type: "Member", enrollee: be === member)
+    pe.set(member: nil, organization:)
+    expect(pe).to have_attributes(enrollee_type: "Organization", enrollee: be === organization)
+    pe.set(organization: nil, role:)
+    expect(pe).to have_attributes(enrollee_type: "Role", enrollee: be === role)
+    pe.set(role: nil)
+    expect(pe).to have_attributes(enrollee_type: "NilClass", enrollee: nil)
+  end
 end

--- a/spec/suma/program/enrollment_spec.rb
+++ b/spec/suma/program/enrollment_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Suma::Program::Enrollment", :db do
     end
   end
 
-  it "can enroll members and organizations" do
+  it "can enroll members, organizations and roles" do
     org1 = Suma::Fixtures.organization.create
     org1_mem1 = Suma::Fixtures.organization_membership.verified(org1).create
     org1_mem2 = Suma::Fixtures.organization_membership.verified(org1).create
@@ -31,9 +31,13 @@ RSpec.describe "Suma::Program::Enrollment", :db do
     org2 = Suma::Fixtures.organization.create
     org2_mem1 = Suma::Fixtures.organization_membership.verified(org2).create
 
+    role = Suma::Role.create(name: "test")
+    member_with_role = Suma::Fixtures.member.with_role(role).create
+
     program = Suma::Fixtures.program.create
     member_enrollment = Suma::Fixtures.program_enrollment(program:, member: org1_mem1.member).create
     org_enrollment = Suma::Fixtures.program_enrollment(program:, organization: org2).create
+    role_enrollment = Suma::Fixtures.program_enrollment(program:, role:).create
     as_of = Time.now
     # This member should find the direct enrollment
     expect(program.enrollment_for(org1_mem1.member, as_of:)).to be === member_enrollment
@@ -44,6 +48,9 @@ RSpec.describe "Suma::Program::Enrollment", :db do
     # The organization and its members should all find the enrollment
     expect(program.enrollment_for(org2_mem1.member, as_of:)).to be === org_enrollment
     expect(program.enrollment_for(org2, as_of:)).to be === org_enrollment
+
+    expect(program.enrollment_for(member_with_role, as_of:)).to be === role_enrollment
+    expect(program.enrollment_for(role, as_of:)).to be === role_enrollment
   end
 
   describe "enrollment_for" do


### PR DESCRIPTION
Fixes #736 

Allow roles to have program enrollments. Members with the same role should have access
to the enrollment program resources. This is similar to the member enrollments via organization
memberships.

* Add migration for roles in program enrollments
* Associate the member, enrollment and role models
* Refactor dataset methods to also access role enrollments
* Test
* Expose :roles in program enrollments entity

---

Refactor how `enrollee`s are exposed and listed in the frontend.
Ensure that roles are reflected in programs and enrollments CRUD pages.

### Program Enrollment List
![Screenshot 2024-12-02 at 1 01 20 PM](https://github.com/user-attachments/assets/1adefb53-0a80-4d53-a650-a9632ff13c7e)

### Program Detail Page - Enrollment RelatedList
![Screenshot 2024-12-02 at 1 00 51 PM](https://github.com/user-attachments/assets/674b33f7-89e4-40ca-8033-342e2c48264c)

### Program Enrollment Detail Page
![Screenshot 2024-12-02 at 1 01 32 PM](https://github.com/user-attachments/assets/1360afe3-65ff-45fc-a6ae-d837635b0029)
