### PR TITLE
Fix EOF errors loading images

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,5 +24,6 @@ on_worker_boot do
     Suma::Postgres.each_model_superclass do |modelclass|
       modelclass.db&.disconnect
     end
+    Suma::UploadedFile.blob_database.disconnect
   end
 end


### PR DESCRIPTION
When a puma worker (subprocess) boots, we need to disconnect all database connections so they can be re-established.

We were already doing this for models,
but this is a separate set of database connections we need to worry about.

Fixes https://github.com/lithictech/suma/issues/754