### PR TITLE
Add error handling for frontapp contact upsert

### DIFF
--- a/lib/suma/frontapp/list_sync.rb
+++ b/lib/suma/frontapp/list_sync.rb
@@ -27,7 +27,7 @@ class Suma::Frontapp::ListSync
       existing_group = groups.find { |g| g.fetch("name") == spec.full_name }
       raise Suma::InvalidPostcondition, "cannot find the group we just created: #{spec.full_name}" if
         existing_group.nil?
-      contact_ids = spec.dataset.select_map(:frontapp_contact_id)
+      contact_ids = spec.dataset.all.map { |m| m.frontapp.contact_id }
       next if contact_ids.empty?
       Suma::Frontapp.client.add_contacts_to_contact_group!(existing_group.fetch("id"), {contact_ids:})
     end

--- a/spec/data/front/contact_conflict_error.json
+++ b/spec/data/front/contact_conflict_error.json
@@ -1,0 +1,7 @@
+{
+  "_error": {
+    "status": 409,
+    "title": "Conflict",
+    "message": "Your request contains a conflict with the contact(s): crd_123"
+  }
+}

--- a/spec/data/front/contact_not_found_error.json
+++ b/spec/data/front/contact_not_found_error.json
@@ -1,0 +1,6 @@
+{
+  "_error": {
+    "status": 404,
+    "title": "Not found"
+  }
+}

--- a/spec/suma/frontapp/list_sync_spec.rb
+++ b/spec/suma/frontapp/list_sync_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Suma::Frontapp::ListSync, :db, reset_configuration: Suma::Frontap
 
   describe "syncing lists" do
     it "creates the specified lists in Front" do
+      m = Suma::Fixtures.member.onboarding_verified.create(frontapp_contact_id: "crd_123")
+      m.preferences!
+
       get_groups = stub_request(:get, "https://api2.frontapp.com/contact_groups").
         to_return(
           json_response({}),
@@ -28,11 +31,8 @@ RSpec.describe Suma::Frontapp::ListSync, :db, reset_configuration: Suma::Frontap
         with(body: "{\"name\":\"Marketing - SMS - English\"}").
         to_return(json_response({}))
       add_ids = stub_request(:post, "https://api2.frontapp.com/contact_groups/grp_en/contacts").
-        with(body: "{\"contact_ids\":[\"crd_123\"]}").
+        with(body: "{\"contact_ids\":[\"alt:phone:+#{m.phone}\"]}").
         to_return(json_response({}))
-
-      m = Suma::Fixtures.member.onboarding_verified.create(frontapp_contact_id: "crd_123")
-      m.preferences!
 
       described_class.new(now:).run
 
@@ -42,6 +42,9 @@ RSpec.describe Suma::Frontapp::ListSync, :db, reset_configuration: Suma::Frontap
     end
 
     it "first deletes lists with the same name" do
+      m = Suma::Fixtures.member.onboarding_verified.create(frontapp_contact_id: "crd_123")
+      m.preferences!
+
       get_groups = stub_request(:get, "https://api2.frontapp.com/contact_groups").
         to_return(
           json_response(
@@ -67,11 +70,8 @@ RSpec.describe Suma::Frontapp::ListSync, :db, reset_configuration: Suma::Frontap
         with(body: "{\"name\":\"Marketing - SMS - English\"}").
         to_return(json_response({}))
       add_ids = stub_request(:post, "https://api2.frontapp.com/contact_groups/grp_en2/contacts").
-        with(body: "{\"contact_ids\":[\"crd_123\"]}").
+        with(body: "{\"contact_ids\":[\"alt:phone:+#{m.phone}\"]}").
         to_return(json_response({}))
-
-      m = Suma::Fixtures.member.onboarding_verified.create(frontapp_contact_id: "crd_123")
-      m.preferences!
 
       described_class.new(now:).run
 

--- a/spec/suma/member/frontapp_attributes_spec.rb
+++ b/spec/suma/member/frontapp_attributes_spec.rb
@@ -4,55 +4,112 @@ RSpec.describe Suma::Member::FrontappAttributes, :db do
   let(:member) { Suma::Fixtures.member.create }
 
   describe "upsert front contacts" do
-    it "creates Front contact if member is missing contact id" do
-      contact_req = stub_request(:post, "https://api2.frontapp.com/contacts").
-        with(body: hash_including(
-          "name" => member.name,
-          "links" => [member.admin_link],
-          "handles" => [
-            {"source" => "phone", "handle" => member.phone},
-            {"source" => "email", "handle" => member.email},
-          ],
-        )).to_return(fixture_response("front/contact"))
+    context "when the member contact id is missing" do
+      it "creates a Front contact" do
+        contact_req = stub_request(:post, "https://api2.frontapp.com/contacts").
+          with(body: hash_including(
+            "name" => member.name,
+            "links" => [member.admin_link],
+            "handles" => [
+              {"source" => "phone", "handle" => member.phone},
+              {"source" => "email", "handle" => member.email},
+            ],
+          )).to_return(fixture_response("front/contact"))
 
-      member.frontapp.upsert_contact
-      expect(member).to have_attributes(frontapp_contact_id: "crd_123")
-      expect(contact_req).to have_been_made
+        member.frontapp.upsert_contact
+        expect(member).to have_attributes(frontapp_contact_id: "crd_123")
+        expect(contact_req).to have_been_made
+      end
+
+      it "falls back to updating a contact if a ConflictError is raised" do
+        create_req = stub_request(:post, "https://api2.frontapp.com/contacts").
+          with(body: hash_including(
+            "name" => member.name,
+            "links" => [member.admin_link],
+            "handles" => [
+              {"source" => "phone", "handle" => member.phone},
+              {"source" => "email", "handle" => member.email},
+            ],
+          )).to_return(fixture_response("front/contact_conflict_error", status: 409))
+        update_req = stub_request(:patch, "https://api2.frontapp.com/contacts/#{member.frontapp.contact_id}").
+          with(body: hash_including(
+            "name" => member.name,
+            "links" => [member.admin_link],
+          )).to_return(status: 200)
+        handles_url = "https://api2.frontapp.com/contacts/#{member.frontapp.contact_id}/handles"
+        handle_req = stub_request(:post, handles_url).
+          with(body: hash_including({"source" => "phone", "handle" => member.phone})).
+          to_return(status: 200)
+        handle_req2 = stub_request(:post, handles_url).
+          with(body: hash_including({"source" => "email", "handle" => member.email})).
+          to_return(status: 200)
+
+        member.frontapp.upsert_contact
+        expect(create_req).to have_been_made
+        expect(member.frontapp_contact_id).to not_be_empty
+        expect(update_req).to have_been_made
+        expect(handle_req).to have_been_made
+        expect(handle_req2).to have_been_made
+      end
     end
 
-    it "updates Front contact if member contains contact id" do
-      member = Suma::Fixtures.member.create(frontapp_contact_id: "crd_123")
-      contact_req = stub_request(:patch, "https://api2.frontapp.com/contacts/#{member.frontapp_contact_id}").
-        with(body: hash_including(
-          "name" => member.name,
-          "links" => [member.admin_link],
-        )).to_return(status: 200)
-      handles_url = "https://api2.frontapp.com/contacts/#{member.frontapp_contact_id}/handles"
-      handle_req = stub_request(:post, handles_url).
-        with(body: hash_including({"source" => "phone", "handle" => member.phone})).
-        to_return(status: 200)
-      handle_req2 = stub_request(:post, handles_url).
-        with(body: hash_including({"source" => "email", "handle" => member.email})).
-        to_return(status: 200)
+    context "when the member contact id is present" do
+      it "updates Front contact" do
+        member = Suma::Fixtures.member.create(frontapp_contact_id: "crd_123")
+        contact_req = stub_request(:patch, "https://api2.frontapp.com/contacts/#{member.frontapp.contact_id}").
+          with(body: hash_including(
+            "name" => member.name,
+            "links" => [member.admin_link],
+          )).to_return(status: 200)
+        handles_url = "https://api2.frontapp.com/contacts/#{member.frontapp.contact_id}/handles"
+        handle_req = stub_request(:post, handles_url).
+          with(body: hash_including({"source" => "phone", "handle" => member.phone})).
+          to_return(status: 200)
+        handle_req2 = stub_request(:post, handles_url).
+          with(body: hash_including({"source" => "email", "handle" => member.email})).
+          to_return(status: 200)
 
-      member.frontapp.upsert_contact
-      expect(contact_req).to have_been_made
-      expect(handle_req).to have_been_made
-      expect(handle_req2).to have_been_made
-    end
+        member.frontapp.upsert_contact
+        expect(contact_req).to have_been_made
+        expect(handle_req).to have_been_made
+        expect(handle_req2).to have_been_made
+      end
 
-    it "does not add Front contact handles if member is missing them" do
-      member = Suma::Fixtures.member.create(frontapp_contact_id: "crd_123")
-      member.email = nil
-      member.phone = nil
-      contact_req = stub_request(:patch, "https://api2.frontapp.com/contacts/#{member.frontapp_contact_id}").
-        with(body: hash_including(
-          "name" => member.name,
-          "links" => [member.admin_link],
-        )).to_return(status: 200)
+      it "falls back to creating a contact if a NotFound error is raised" do
+        member = Suma::Fixtures.member.create(frontapp_contact_id: "crd_234")
+        update_req = stub_request(:patch, "https://api2.frontapp.com/contacts/#{member.frontapp.contact_id}").
+          with(body: hash_including(
+            "name" => member.name,
+            "links" => [member.admin_link],
+          )).to_return(fixture_response("front/contact_not_found_error", status: 404))
+        create_req = stub_request(:post, "https://api2.frontapp.com/contacts").
+          with(body: hash_including(
+            "name" => member.name,
+            "links" => [member.admin_link],
+            "handles" => [
+              {"source" => "phone", "handle" => member.phone},
+              {"source" => "email", "handle" => member.email},
+            ],
+          )).to_return(fixture_response("front/contact"))
 
-      member.frontapp.upsert_contact
-      expect(contact_req).to have_been_made
+        member.frontapp.upsert_contact
+        expect(update_req).to have_been_made
+        expect(create_req).to have_been_made
+      end
+
+      it "does not add Front contact handles if member is missing them" do
+        member = Suma::Fixtures.member.create(frontapp_contact_id: "crd_123")
+        member.email = nil
+        member.phone = nil
+        contact_req = stub_request(:patch, "https://api2.frontapp.com/contacts/#{member.frontapp.contact_id}").
+          with(body: hash_including(
+            "name" => member.name,
+            "links" => [member.admin_link],
+          )).to_return(status: 200)
+
+        member.frontapp.upsert_contact
+        expect(contact_req).to have_been_made
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #760

Add error handling for when creating or updating a frontapp contact. Also update `contact_id` to use an alternative resource id (for reliability). Use this id when syncing contact group lists to frontapp.