### PR TITLE
Lyft: Use multiple Pass programs; create vehicles for stations

### DIFF
--- a/db/migrations/062_lyftpass_programs.rb
+++ b/db/migrations/062_lyftpass_programs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:programs) do
+      add_column :lyft_pass_program_id, :text, null: false, default: ""
+    end
+  end
+end

--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -111,6 +111,15 @@ module Suma
     return result
   end
 
+  # Force-set a value in the cache.
+  def self.cached_set(key, value, delete: false)
+    if delete
+      self.globals_cache.delete(key)
+      return
+    end
+    self.globals_cache[key] = value
+  end
+
   #
   # :section: Errors
   #

--- a/lib/suma/admin_api/programs.rb
+++ b/lib/suma/admin_api/programs.rb
@@ -10,6 +10,7 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
     expose :image, with: ImageEntity, &self.delegate_to(:images?, :first)
+    expose :lyft_pass_program_id
     expose :commerce_offerings, with: OfferingEntity
     expose :vendor_services, with: VendorServiceEntity
     expose :anon_proxy_vendor_configurations, as: :configurations, with: VendorConfigurationEntity

--- a/lib/suma/anon_proxy/auth_to_vendor.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor.rb
@@ -35,7 +35,7 @@ class Suma::AnonProxy::AuthToVendor
   def needs_polling? = raise NotImplementedError
   # True if the vendor account needs attention; like if it needs to be created
   # or relinked.
-  def needs_attention? = raise NotImplementedError
+  def needs_attention?(now:) = raise NotImplementedError
 
   # Helper for AuthToVendor implementations that use anonymous emails.
   def ensure_anonymous_email_contact

--- a/lib/suma/anon_proxy/auth_to_vendor/fake.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/fake.rb
@@ -24,5 +24,5 @@ class Suma::AnonProxy::AuthToVendor::Fake < Suma::AnonProxy::AuthToVendor
 
   def auth = self.class._auth
   def needs_polling? = self.class.needs_polling
-  def needs_attention? = self.class.needs_attention
+  def needs_attention?(*) = self.class.needs_attention
 end

--- a/lib/suma/anon_proxy/auth_to_vendor/lime.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lime.rb
@@ -18,5 +18,5 @@ class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
   end
 
   def needs_polling? = true
-  def needs_attention? = self.vendor_account.contact.nil?
+  def needs_attention?(*) = self.vendor_account.contact.nil?
 end

--- a/lib/suma/anon_proxy/auth_to_vendor/lyft_pass.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lyft_pass.rb
@@ -4,13 +4,40 @@ require "suma/lyft/pass"
 
 class Suma::AnonProxy::AuthToVendor::LyftPass < Suma::AnonProxy::AuthToVendor
   def auth
-    return if self.vendor_account.registered_with_vendor.present?
-    lp = Suma::Lyft::Pass.from_config
-    lp.authenticate
-    lp.invite_member(self.vendor_account.member)
-    self.vendor_account.update(registered_with_vendor: Time.now.iso8601)
+    now = Time.now.utc
+    enrollments, registered = self.enrollments_requiring_attention(now:)
+    unless enrollments.empty?
+      lp = Suma::Lyft::Pass.from_config
+      lp.authenticate
+      enrollments.each do |pe|
+        program_id = pe.program.lyft_pass_program_id
+        lp.invite_member(self.vendor_account.member, program_id:)
+        registered[program_id] = now.iso8601
+      end
+    end
+    self.vendor_account.update(registered_with_vendor: registered.to_json)
   end
 
   def needs_polling? = false
-  def needs_attention? = self.vendor_account.registered_with_vendor.blank?
+
+  def needs_attention?(now:)
+    self.vendor_account.registered_with_vendor.blank? ||
+      self.enrollments_requiring_attention(now:)[0].any?
+  end
+
+  # Return a tuple of <array of enrollments> and <parsed registered_with_vendor>
+  def enrollments_requiring_attention(now:)
+    begin
+      registered = JSON.parse(self.vendor_account.registered_with_vendor)
+    rescue JSON::ParserError, TypeError
+      registered = {}
+    end
+    registered = {} unless registered.is_a?(Hash)
+    unregistered_programs = Suma::Lyft::Pass.programs_dataset.exclude(lyft_pass_program_id: registered.keys)
+    enrollments = self.vendor_account.member.combined_program_enrollments_dataset.
+      active(as_of: now).
+      where(program_id: unregistered_programs.select(:id)).
+      all
+    return enrollments, registered
+  end
 end

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -101,7 +101,7 @@ class Suma::API::Mobility < Suma::API::V1
       else
         vehicle = matches[0]
       end
-      present vehicle, with: MobilityVehicleEntity, member:, request:
+      present vehicle, with: MobilityVehicleEntity, member:, request:, current_time:
     end
 
     params do
@@ -192,7 +192,8 @@ class Suma::API::Mobility < Suma::API::V1
     end
     expose :goto_private_account do |vehicle, options|
       member = options.fetch(:member)
-      vehicle.vendor_service.mobility_adapter.anon_proxy_vendor_account_requires_attention?(member)
+      now = options.fetch(:current_time)
+      vehicle.vendor_service.mobility_adapter.anon_proxy_vendor_account_requires_attention?(member, now:)
     end
   end
 end

--- a/lib/suma/async/lyft_pass_trip_sync.rb
+++ b/lib/suma/async/lyft_pass_trip_sync.rb
@@ -13,6 +13,8 @@ class Suma::Async::LyftPassTripSync
     return if Suma::Lyft.pass_email.blank?
     lp = Suma::Lyft::Pass.from_config
     lp.authenticate
-    lp.sync_trips
+    Suma::Lyft::Pass.programs_dataset.each do |program|
+      lp.sync_trips(program.lyft_pass_program_id)
+    end
   end
 end

--- a/lib/suma/fixtures/program_enrollments.rb
+++ b/lib/suma/fixtures/program_enrollments.rb
@@ -24,4 +24,9 @@ module Suma::Fixtures::ProgramEnrollments
   decorator :unenrolled do |at=1.minute.ago|
     self.unenrolled_at = at
   end
+
+  decorator :in do |program={}|
+    program = Suma::Fixtures.program(program).create unless program.is_a?(Suma::Program)
+    self.program = program
+  end
 end

--- a/lib/suma/lime.rb
+++ b/lib/suma/lime.rb
@@ -27,9 +27,16 @@ module Suma::Lime
     end
   end
 
+  class LimeGbfsHttpClient < Suma::Mobility::Gbfs::HttpClient
+    # Lime 404's on these. Maybe we should be looking at the gbfs meta/index file to see what's supported.
+    # Can add in the future.
+    def fetch_station_status = nil
+    def fetch_station_information = nil
+  end
+
   # @return [Suma::Mobility::Gbfs::HttpClient]
   def self.gbfs_http_client
-    return Suma::Mobility::Gbfs::HttpClient.new(api_host: self.gbfs_root, auth_token: self.auth_token)
+    return LimeGbfsHttpClient.new(api_host: self.gbfs_root, auth_token: self.auth_token)
   end
 
   def self.api_headers

--- a/lib/suma/lyft.rb
+++ b/lib/suma/lyft.rb
@@ -14,7 +14,6 @@ module Suma::Lyft
     setting :pass_authorization, ""
     setting :pass_email, ""
     setting :pass_org_id, ""
-    setting :pass_program_id, ""
     setting :pass_vendor_service_rate_id, 0
   end
 

--- a/lib/suma/mobility/gbfs/client.rb
+++ b/lib/suma/mobility/gbfs/client.rb
@@ -4,4 +4,6 @@ class Suma::Mobility::Gbfs::Client
   def fetch_geofencing_zones = raise NotImplementedError
   def fetch_free_bike_status = raise NotImplementedError
   def fetch_vehicle_types = raise NotImplementedError
+  def fetch_station_information = raise NotImplementedError
+  def fetch_station_status = raise NotImplementedError
 end

--- a/lib/suma/mobility/gbfs/fake_client.rb
+++ b/lib/suma/mobility/gbfs/fake_client.rb
@@ -3,16 +3,24 @@
 require "suma/mobility/gbfs/client"
 
 class Suma::Mobility::Gbfs::FakeClient < Suma::Mobility::Gbfs::Client
-  def initialize(fake_geofencing_json: nil, fake_free_bike_status_json: nil, fake_vehicle_types_json: nil)
+  def initialize(
+    fake_geofencing_json: nil,
+    fake_free_bike_status_json: nil,
+    fake_vehicle_types_json: nil,
+    fake_station_information_json: nil,
+    fake_station_status_json: nil
+  )
     super()
     @fake_geofencing_json = fake_geofencing_json
     @fake_free_bike_status_json = fake_free_bike_status_json
     @fake_vehicle_types_json = fake_vehicle_types_json
+    @fake_station_information_json = fake_station_information_json
+    @fake_station_status_json = fake_station_status_json
   end
 
   def fetch_geofencing_zones = @fake_geofencing_json
-
   def fetch_free_bike_status = @fake_free_bike_status_json
-
   def fetch_vehicle_types = @fake_vehicle_types_json
+  def fetch_station_information = @fake_station_information_json
+  def fetch_station_status = @fake_station_status_json
 end

--- a/lib/suma/mobility/gbfs/free_bike_status.rb
+++ b/lib/suma/mobility/gbfs/free_bike_status.rb
@@ -9,25 +9,27 @@ class Suma::Mobility::Gbfs::FreeBikeStatus < Suma::Mobility::Gbfs::ComponentSync
   def before_sync(client)
     @bikes = client.fetch_free_bike_status.dig("data", "bikes")
     @vehicle_types = client.fetch_vehicle_types.dig("data", "vehicle_types")
+    @station_information = client.fetch_station_information&.dig("data", "stations")
+    @station_status = client.fetch_station_status&.dig("data", "stations")
   end
 
   def yield_rows(vendor_service)
-    bikes = @bikes
+    bikes = @bikes + self._bikes_from_stations.to_a
     vehicle_types = @vehicle_types
     valid_vehicle_types = vehicle_types.select { |vt| vendor_service.satisfies_constraints?(vt) }
     vehicle_types_by_id = valid_vehicle_types.index_by { |vt| vt["vehicle_type_id"] }
     bikes.each do |bike|
-      next unless (vehicle_type = vehicle_types_by_id[bike["vehicle_type_id"]])
+      next unless (vehicle_type = vehicle_types_by_id[bike.fetch("vehicle_type_id")])
       battery_level = nil
       if (current_range = bike["current_range_meters"]) && (max_range = vehicle_type["max_range_meters"])
         battery_level = ((current_range.to_f / max_range) * 100).round.clamp(0, 100)
       end
       row = {
-        lat: bike["lat"],
-        lng: bike["lon"],
-        lat_int: Suma::Mobility.coord2int(bike["lat"]),
-        lng_int: Suma::Mobility.coord2int(bike["lon"]),
-        vehicle_id: bike["bike_id"],
+        lat: bike.fetch("lat"),
+        lng: bike.fetch("lon"),
+        lat_int: Suma::Mobility.coord2int(bike.fetch("lat")),
+        lng_int: Suma::Mobility.coord2int(bike.fetch("lon")),
+        vehicle_id: bike.fetch("bike_id"),
         vehicle_type: self.class.derive_vehicle_type(vehicle_type).to_s,
         vendor_service_id: vendor_service.id,
         battery_level: Sequel.cast(battery_level, :smallint),
@@ -35,6 +37,30 @@ class Suma::Mobility::Gbfs::FreeBikeStatus < Suma::Mobility::Gbfs::ComponentSync
       }
       yield row
     end
+  end
+
+  def _bikes_from_stations
+    return [] if @station_information.blank?
+    station_infos_by_id = @station_information.to_h { |st| [st.fetch("station_id"), st] }
+    result = []
+    @station_status.each do |station|
+      next if (station["is_renting"] || 0).zero?
+      station_info = station_infos_by_id.fetch(station.fetch("station_id"))
+      station.fetch("vehicle_types_available").each do |station_vt|
+        vehicle_type_id = station_vt.fetch("vehicle_type_id")
+        Array.new(station_vt.fetch("count")) do |i|
+          bike = {
+            "bike_id" => "#{station.fetch('station_id')}-#{vehicle_type_id}-#{i}",
+            "vehicle_type_id" => vehicle_type_id,
+            "lat" => station_info.fetch("lat"),
+            "lon" => station_info.fetch("lon"),
+            "rental_uris" => station_info.fetch("rental_uris"),
+          }
+          result << bike
+        end
+      end
+    end
+    return result
   end
 
   def self.derive_vehicle_type(vehicle_type_json)

--- a/lib/suma/mobility/gbfs/http_client.rb
+++ b/lib/suma/mobility/gbfs/http_client.rb
@@ -21,30 +21,18 @@ class Suma::Mobility::Gbfs::HttpClient < Suma::Mobility::Gbfs::Client
     return h
   end
 
-  def fetch_geofencing_zones
+  def fetch_json(part)
     response = Suma::Http.get(
-      self.api_host.to_s + "/geofencing_zones.json",
+      "#{self.api_host}/#{part}.json",
       headers: self.headers,
       logger: self.logger,
     )
     return response.parsed_response
   end
 
-  def fetch_free_bike_status
-    response = Suma::Http.get(
-      self.api_host.to_s + "/free_bike_status.json",
-      headers: self.headers,
-      logger: self.logger,
-    )
-    return response.parsed_response
-  end
-
-  def fetch_vehicle_types
-    response = Suma::Http.get(
-      self.api_host.to_s + "/vehicle_types.json",
-      headers: self.headers,
-      logger: self.logger,
-    )
-    return response.parsed_response
-  end
+  def fetch_geofencing_zones = self.fetch_json("geofencing_zones")
+  def fetch_free_bike_status = self.fetch_json("free_bike_status")
+  def fetch_vehicle_types = self.fetch_json("vehicle_types")
+  def fetch_station_status = self.fetch_json("station_status")
+  def fetch_station_information = self.fetch_json("station_information")
 end

--- a/lib/suma/mobility/vendor_adapter.rb
+++ b/lib/suma/mobility/vendor_adapter.rb
@@ -44,11 +44,11 @@ module Suma::Mobility::VendorAdapter
   # @return [nil,Suma::AnonProxy::VendorAccount]
   def find_anon_proxy_vendor_account(member) = raise NotImplementedError
 
-  def anon_proxy_vendor_account_requires_attention?(member)
+  def anon_proxy_vendor_account_requires_attention?(member, now:)
     return false unless self.uses_deep_linking?
     account = self.find_anon_proxy_vendor_account(member)
     return true if account.nil?
-    return account.auth_to_vendor.needs_attention?
+    return account.auth_to_vendor.needs_attention?(now:)
   end
 
   require_relative "vendor_adapter/fake"

--- a/lib/suma/tasks/integration.rb
+++ b/lib/suma/tasks/integration.rb
@@ -16,7 +16,9 @@ class Suma::Tasks::Integration < Rake::TaskLib
         Suma::Vendor::Service.where(mobility_vendor_adapter_key: "lyft_deeplink").update(charge_after_fulfillment: true)
         lp = Suma::Lyft::Pass.from_config
         lp.authenticate
-        lp.sync_trips
+        Suma::Lyft::Pass.programs_dataset.each do |program|
+          lp.sync_trips(program.lyft_pass_program_id)
+        end
       end
     end
   end

--- a/spec/data/lyft/free_bike_status.json
+++ b/spec/data/lyft/free_bike_status.json
@@ -1,0 +1,28 @@
+{
+  "last_updated":1609866247,
+  "ttl":0,
+  "version":"2.2",
+  "data":{
+    "bikes":[
+      {
+        "bike_id":"ghi789",
+        "last_reported":1609866109,
+        "lat":12.34,
+        "lon":56.78,
+        "is_reserved":false,
+        "is_disabled":false,
+        "vehicle_type_id":"abc123"
+      },
+      {
+        "bike_id":"jkl012",
+        "last_reported":1609866204,
+        "is_reserved":false,
+        "is_disabled":false,
+        "vehicle_type_id":"def456",
+        "current_range_meters":6543,
+        "station_id":"86",
+        "pricing_plan_id":"plan3"
+      }
+    ]
+  }
+}

--- a/spec/data/lyft/geofencing_zone.json
+++ b/spec/data/lyft/geofencing_zone.json
@@ -1,0 +1,79 @@
+{
+  "last_updated": 1604198100,
+  "ttl": 60,
+  "version": "2.2",
+  "data": {
+    "geofencing_zones": {
+      "type": "FeatureCollection",
+      "features": [{
+          "type": "Feature",
+          "geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [
+                  -122.578067,
+                  45.562982
+                ],
+                [
+                  -122.661838,
+                  45.562741
+                ],
+                [
+                  -122.661151,
+                  45.504542
+                ],
+                [
+                  -122.578926,
+                  45.5046625
+                ],
+                [
+                  -122.578067,
+                  45.562982
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  -122.650680,
+                  45.548197
+                ],
+                [
+                  -122.650852,
+                  45.534731
+                ],
+                [
+                  -122.630939,
+                  45.535212
+                ],
+                [
+                  -122.630424,
+                  45.548197
+                ],
+                [
+                  -122.650680,
+                  45.548197
+                ]
+              ]
+            ]
+          ]
+        },
+        "properties": {
+          "name": "NE 24th/NE Knott",
+          "start": 1593878400,
+          "end": 1593907260,
+          "rules": [
+            {
+              "vehicle_type_id": ["abc123"],
+              "ride_allowed": false,
+              "ride_through_allowed": true,
+              "maximum_speed_kph": 10
+            }
+          ]
+        }
+      }]
+    }
+  }
+}

--- a/spec/data/lyft/station_information.json
+++ b/spec/data/lyft/station_information.json
@@ -1,0 +1,8 @@
+{
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "2.2",
+  "data": {
+    "stations": []
+  }
+}

--- a/spec/data/lyft/station_status.json
+++ b/spec/data/lyft/station_status.json
@@ -1,0 +1,8 @@
+{
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "2.2",
+  "data": {
+    "stations": []
+  }
+}

--- a/spec/data/lyft/vehicle_types.json
+++ b/spec/data/lyft/vehicle_types.json
@@ -1,0 +1,16 @@
+{
+  "last_updated": 1609866247,
+  "ttl": 0,
+  "version": "2.2",
+  "data": {
+    "vehicle_types": [
+      {
+        "vehicle_type_id": "abc123",
+        "form_factor": "scooter",
+        "propulsion_type": "electric",
+        "name": "Example E-scooter V2",
+        "max_range_meters": 12345
+      }
+    ]
+  }
+}

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -158,7 +158,6 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
       Suma::Lyft.pass_authorization = "Basic xyz"
       Suma::Lyft.pass_email = "a@b.c"
       Suma::Lyft.pass_org_id = "1234"
-      Suma::Lyft.pass_program_id = "5678"
 
       vendor_service_rate = Suma::Fixtures.vendor_service_rate.create
       vendor_service_rate.add_service(
@@ -167,6 +166,7 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
         ),
       )
       Suma::Lyft.pass_vendor_service_rate_id = vendor_service_rate.id
+      Suma::Fixtures.program.create(lyft_pass_program_id: "5678")
 
       Suma::ExternalCredential.create(
         service: "lyft-pass-access-token",

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -445,15 +445,13 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
 
     it "sync lyft scooters gbfs" do
       Suma::Lyft.sync_enabled = true
-      free_bike_status_req = stub_request(:get, "https://gbfs.lyft.com/gbfs/2.3/pdx/en/free_bike_status.json").
-        to_return(fixture_response("lime/free_bike_status"))
-      vehicle_types_req = stub_request(:get, "https://gbfs.lyft.com/gbfs/2.3/pdx/en/vehicle_types.json").
-        to_return(fixture_response("lime/vehicle_types"))
+      reqs = ["free_bike_status", "vehicle_types", "station_information", "station_status"].map do |s|
+        stub_request(:get, "https://gbfs.lyft.com/gbfs/2.3/pdx/en/#{s}.json").
+          to_return(fixture_response("lyft/#{s}"))
+      end
 
       Suma::Async::SyncLyftFreeBikeStatusGbfs.new.perform(true)
-      expect(free_bike_status_req).to have_been_made
-      expect(vehicle_types_req).to have_been_made
-      expect(Suma::Mobility::Vehicle.all).to have_length(1)
+      expect(reqs).to all(have_been_made)
     end
 
     it "noops if Lyft is not configured" do

--- a/spec/suma/mobility/gbfs/http_client_spec.rb
+++ b/spec/suma/mobility/gbfs/http_client_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "suma/mobility/gbfs"
+require "suma/mobility/gbfs/http_client"
+
+RSpec.describe Suma::Mobility::Gbfs::HttpClient do
+  let(:client) { described_class.new(api_host: "https://mysuma.org", auth_token: "tok") }
+
+  describe "fetch_json" do
+    it "fetches" do
+      req = stub_request(:get, "https://mysuma.org/foo.json").
+        with(headers: {"Authorization" => "Bearer tok"}).
+        to_return(json_response({x: 1}))
+
+      got = client.fetch_json("foo")
+      expect(got).to eq({"x" => 1})
+      expect(req).to have_been_made
+    end
+
+    it "handles a nil token (no authorization header)" do
+      client = described_class.new(api_host: "https://mysuma.org", auth_token: nil)
+      req = stub_request(:get, "https://mysuma.org/foo.json").
+        # Not sure how to test *not* sending a header.
+        to_return(json_response({x: 1}))
+      got = client.fetch_json("foo")
+      expect(got).to eq({"x" => 1})
+      expect(req).to have_been_made
+    end
+  end
+
+  describe "lime" do
+    it "returns nil for station information and status" do
+      req = stub_request(:get, "https://data.lime.bike/api/partners/v2/gbfs_transit/free_bike_status.json").
+        to_return(json_response({x: 1}))
+      expect(Suma::Lime.gbfs_http_client.fetch_free_bike_status).to eq({"x" => 1})
+      expect(req).to have_been_made
+      expect(Suma::Lime.gbfs_http_client.fetch_station_information).to be_nil
+      expect(Suma::Lime.gbfs_http_client.fetch_station_status).to be_nil
+    end
+  end
+
+  describe "lyft" do
+    it "fetches" do
+      req = stub_request(:get, "https://gbfs.lyft.com/gbfs/2.3/pdx/en/station_information.json").
+        to_return(json_response({x: 1}))
+
+      expect(Suma::Lyft.gbfs_http_client.fetch_station_information).to eq({"x" => 1})
+      expect(req).to have_been_made
+    end
+  end
+end

--- a/spec/suma/mobility/vendor_adapter_spec.rb
+++ b/spec/suma/mobility/vendor_adapter_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
     let(:ad) { Suma::Mobility::VendorAdapter::Fake.new }
 
     it "is false if not using deep linking" do
-      expect(ad).to_not be_anon_proxy_vendor_account_requires_attention(member)
+      expect(ad).to_not be_anon_proxy_vendor_account_requires_attention(member, now: Time.now)
     end
 
     describe "when using deep linking" do
@@ -57,7 +57,7 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
       end
 
       it "is true when there is no vendor account" do
-        expect(ad).to be_anon_proxy_vendor_account_requires_attention(member)
+        expect(ad).to be_anon_proxy_vendor_account_requires_attention(member, now: Time.now)
       end
 
       it "delegates to the vendor account configuration" do
@@ -65,11 +65,11 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
 
         Suma::AnonProxy::AuthToVendor::Fake.needs_attention = true
         Suma::Mobility::VendorAdapter::Fake.find_anon_proxy_vendor_account_results << va
-        expect(ad).to be_anon_proxy_vendor_account_requires_attention(member)
+        expect(ad).to be_anon_proxy_vendor_account_requires_attention(member, now: Time.now)
 
         Suma::AnonProxy::AuthToVendor::Fake.needs_attention = false
         Suma::Mobility::VendorAdapter::Fake.find_anon_proxy_vendor_account_results << va
-        expect(ad).to_not be_anon_proxy_vendor_account_requires_attention(member)
+        expect(ad).to_not be_anon_proxy_vendor_account_requires_attention(member, now: Time.now)
       end
     end
   end

--- a/spec/suma_spec.rb
+++ b/spec/suma_spec.rb
@@ -200,5 +200,13 @@ RSpec.describe Suma do
       described_class.cached_get("z", &@cb)
       expect(@cnt).to eq(3)
     end
+
+    it "can set/delete a key" do
+      described_class.use_globals_cache = true
+      described_class.cached_set(key, "x")
+      expect(described_class.cached_get(key) { nil }).to eq("x")
+      described_class.cached_set(key, nil, delete: true)
+      expect(described_class.cached_get(key) { nil }).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Fixes #771 and #770 

---

Lyft: Create vehicles from stations

Lime has bikes in their free_bike_status,
but since Lyft uses docks, they have station info.

---

Lyft Pass programs use Suma programs

We need different Suma programs to target different Lyft programs,
since different users may use different Lyft programs.

Make sure users are registered for Lyft in all programs
they are enrolled in.
