### PR TITLE
Front/signalwire optout fix; verification helpers

### DIFF
--- a/adminapp/src/modules/formatDate.js
+++ b/adminapp/src/modules/formatDate.js
@@ -1,0 +1,26 @@
+import dayjs from "dayjs";
+
+/**
+ * Run dayjs(value).format('lll').
+ *
+ * @param value The date string.
+ * @param opts
+ * @param opts.default The empty date value, defaults to '-'.
+ * @param opts.template The template string, defaults to 'lll'.
+ * @returns {string}
+ */
+export default function formatDate(value, opts = {}) {
+  let d = opts.default;
+  if (d === undefined) {
+    d = "-";
+  }
+  const t = dayjs(value);
+  if (!t.isValid()) {
+    return d;
+  }
+  let tmpl = opts.template;
+  if (tmpl === undefined) {
+    tmpl = "lll";
+  }
+  return t.format(tmpl);
+}

--- a/adminapp/src/pages/BookTransactionDetailPage.jsx
+++ b/adminapp/src/pages/BookTransactionDetailPage.jsx
@@ -3,6 +3,7 @@ import AdminLink from "../components/AdminLink";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -60,7 +61,7 @@ export default function BookTransactionDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               row.status,
               <Money key="amt">{row.amount}</Money>,
             ]}
@@ -71,7 +72,7 @@ export default function BookTransactionDetailPage() {
             rows={model.charges}
             toCells={(row) => [
               <AdminLink model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               <Money key={3}>{row.undiscountedSubtotal}</Money>,
               row.opaqueId,
             ]}

--- a/adminapp/src/pages/BookTransactionListPage.jsx
+++ b/adminapp/src/pages/BookTransactionListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -25,7 +25,7 @@ export default function BookTransactionListPage() {
           label: "Apply At",
           align: "center",
           sortable: true,
-          render: (c) => dayjs(c.applyAt).format("lll"),
+          render: (c) => formatDate(c.applyAt),
         },
         {
           id: "amount",

--- a/adminapp/src/pages/ChargeDetailPage.jsx
+++ b/adminapp/src/pages/ChargeDetailPage.jsx
@@ -4,6 +4,7 @@ import DetailGrid from "../components/DetailGrid";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -42,7 +43,7 @@ export default function ChargeDetailPage() {
                 { label: "ID", value: <AdminLink model={model.mobilityTrip} /> },
                 {
                   label: "Created At",
-                  value: dayjs(model.mobilityTrip.createdAt).format("lll"),
+                  value: formatDate(model.mobilityTrip.createdAt),
                 },
                 { label: "Vehicle ID", value: model.mobilityTrip.vehicleId },
                 {
@@ -55,11 +56,11 @@ export default function ChargeDetailPage() {
                 },
                 {
                   label: "Started",
-                  value: dayjs(model.mobilityTrip.createdAt).format("ll LTS"),
+                  value: formatDate(model.mobilityTrip.createdAt, { template: "ll LTS" }),
                 },
                 {
                   label: "Ended",
-                  value: dayjs(model.mobilityTrip.createdAt).format("ll LTS"),
+                  value: formatDate(model.mobilityTrip.createdAt, { template: "ll LTS" }),
                 },
               ]}
             />
@@ -71,7 +72,7 @@ export default function ChargeDetailPage() {
                 { label: "ID", value: <AdminLink model={model.commerceOrder} /> },
                 {
                   label: "Created At",
-                  value: dayjs(model.commerceOrder.createdAt).format("lll"),
+                  value: formatDate(model.commerceOrder.createdAt),
                 },
                 { label: "Status", value: model.commerceOrder.statusLabel },
               ]}
@@ -107,7 +108,7 @@ export default function ChargeDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               row.status,
               <Money key="amt">{row.amount}</Money>,
               <AdminLink model={row.originatingPaymentAccount}>

--- a/adminapp/src/pages/ChargeListPage.jsx
+++ b/adminapp/src/pages/ChargeListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -29,7 +29,7 @@ export default function ChargeListPage() {
           id: "created_at",
           label: "Created",
           align: "left",
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
         {
           id: "discounted_subtotal",

--- a/adminapp/src/pages/FundingTransactionListPage.jsx
+++ b/adminapp/src/pages/FundingTransactionListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -25,7 +25,7 @@ export default function FundingTransactionListPage() {
           label: "Created",
           align: "center",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
         {
           id: "amount",

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -12,6 +12,7 @@ import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import useRoleAccess from "../hooks/useRoleAccess";
 import { useUser } from "../hooks/user";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import Money from "../shared/react/Money";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
@@ -68,11 +69,7 @@ export default function MemberDetailPage() {
             children: (
               <InlineEditField
                 resource="member"
-                renderDisplay={
-                  model.onboardingVerifiedAt
-                    ? dayjs(model.onboardingVerifiedAt).format("lll")
-                    : "-"
-                }
+                renderDisplay={formatDate(model.onboardingVerifiedAt)}
                 initialEditingState={{ id: model.id }}
                 renderEdit={(st, set) => {
                   const mem = { ...model, ...st };
@@ -193,7 +190,7 @@ function OrganizationMemberships({ memberships, model }) {
       keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
-        dayjs(row.createdAt).format("lll"),
+        formatDate(row.createdAt),
         row.verifiedOrganization ? (
           <AdminLink key="org" model={row.verifiedOrganization}>
             {row.verifiedOrganization.name}
@@ -214,7 +211,7 @@ function Activities({ activities }) {
       rows={activities}
       keyRowAttr="id"
       toCells={(row) => [
-        dayjs(row.createdAt).format("lll"),
+        formatDate(row.createdAt),
         row.summary,
         <span key="msg">
           {row.messageName} / <code>{JSON.stringify(row.messageVars)}</code>
@@ -232,8 +229,8 @@ function ResetCodes({ resetCodes }) {
       rows={resetCodes}
       keyRowAttr="id"
       toCells={(row) => [
-        dayjs(row.createdAt).format("lll"),
-        dayjs(row.expireAt).format("lll"),
+        formatDate(row.createdAt),
+        formatDate(row.expireAt),
         row.token,
         <BoolCheckmark key="used">{row.used}</BoolCheckmark>,
       ]}
@@ -249,7 +246,7 @@ function Sessions({ sessions }) {
       keyRowAttr="id"
       rows={sessions}
       toCells={(row) => [
-        dayjs(row.createdAt).format("lll"),
+        formatDate(row.createdAt),
         <SafeExternalLink key="ip" href={row.ipLookupLink}>
           {row.peerIp}
         </SafeExternalLink>,
@@ -268,7 +265,7 @@ function Orders({ orders }) {
       keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
-        dayjs(row.createdAt).format("lll"),
+        formatDate(row.createdAt),
         row.totalItemCount,
         <AdminLink key="off" model={row.offering}>
           {row.offering.description.en}
@@ -288,7 +285,7 @@ function Charges({ charges }) {
       rows={charges}
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
-        dayjs(row.createdAt).format("lll"),
+        formatDate(row.createdAt),
         <Money key="disc">{row.discountedSubtotal}</Money>,
         <Money key="undisc">{row.undiscountedSubtotal}</Money>,
         row.opaqueId,
@@ -307,8 +304,8 @@ function BankAccounts({ bankAccounts }) {
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         row.adminLabel,
-        dayjs(row.createdAt).format("lll"),
-        row.softDeletedAt ? dayjs(row.softDeletedAt).format("lll") : "",
+        formatDate(row.createdAt),
+        formatDate(row.softDeletedAt),
       ]}
     />
   );
@@ -352,8 +349,8 @@ function MessageDeliveries({ messageDeliveries }) {
       keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
-        dayjs(row.createdAt).format("lll"),
-        row.sentAt ? dayjs(row.sentAt).format("lll") : "<unsent>",
+        formatDate(row.createdAt),
+        formatDate(row.sentAt, { default: "<unsent>" }),
         row.template,
         row.to,
       ]}
@@ -376,7 +373,7 @@ function VendorAccounts({ vendorAccounts }) {
       keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
-        dayjs(row.createdAt).format("lll"),
+        formatDate(row.createdAt),
         <AdminLink key="vendor" model={row.vendor}>
           {row.vendor.name}
         </AdminLink>,
@@ -467,7 +464,7 @@ function InlineSoftDelete({ id, name, phone, softDeletedAt, onSoftDelete }) {
   }
   return (
     <>
-      {softDeletedAt ? dayjs(softDeletedAt).format("lll") : display}
+      {formatDate(softDeletedAt, { default: display })}
       <Dialog open={showModal.isOn} onClose={showModal.turnOff}>
         <DialogTitle>Confirm Soft Deletion</DialogTitle>
         <DialogContent>

--- a/adminapp/src/pages/MemberListPage.jsx
+++ b/adminapp/src/pages/MemberListPage.jsx
@@ -2,7 +2,6 @@ import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
 import Unavailable from "../components/Unavailable";
-import { dayjs } from "../modules/dayConfig";
 import formatDate from "../modules/formatDate";
 import React from "react";
 import { formatPhoneNumber } from "react-phone-number-input";

--- a/adminapp/src/pages/MemberListPage.jsx
+++ b/adminapp/src/pages/MemberListPage.jsx
@@ -3,6 +3,7 @@ import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
 import Unavailable from "../components/Unavailable";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 import { formatPhoneNumber } from "react-phone-number-input";
 
@@ -39,7 +40,14 @@ export default function MemberListPage() {
           label: "Registered",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
+        },
+        {
+          id: "onboarding_verified_at",
+          label: "Verified",
+          align: "left",
+          sortable: true,
+          render: (c) => formatDate(c.onboardingVerifiedAt),
         },
       ]}
     />

--- a/adminapp/src/pages/MessageDetailPage.jsx
+++ b/adminapp/src/pages/MessageDetailPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceDetail from "../components/ResourceDetail";
-import dateFormat from "../shared/dateFormat";
+import formatDate from "../modules/formatDate";
 import { Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import React from "react";
@@ -20,9 +20,9 @@ export default function MessageDetailPage() {
         },
         { label: "MessageId", value: model.transportMessageId },
         { label: "Template", value: model.template },
-        { label: "CreatedAt", value: dateFormat(model.createdAt, "lll") },
-        { label: "SentAt", value: dateFormat(model.sentAt, "lll") },
-        { label: "AbortedAt", value: dateFormat(model.abortedAt, "lll") },
+        { label: "CreatedAt", value: formatDate(model.createdAt) },
+        { label: "SentAt", value: formatDate(model.sentAt) },
+        { label: "AbortedAt", value: formatDate(model.abortedAt) },
         model.recipient && {
           label: "Recipient",
           value: (

--- a/adminapp/src/pages/MessageListPage.jsx
+++ b/adminapp/src/pages/MessageListPage.jsx
@@ -1,8 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
-import dateFormat from "../shared/dateFormat";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function MessageListPage() {
@@ -24,14 +23,14 @@ export default function MessageListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
         {
           id: "sent_at",
           label: "Sent",
           align: "left",
           sortable: true,
-          render: (c) => dateFormat(c.sentAt, "lll"),
+          render: (c) => formatDate(c.sentAt),
         },
         {
           id: "to",

--- a/adminapp/src/pages/MobilityTripDetailPage.jsx
+++ b/adminapp/src/pages/MobilityTripDetailPage.jsx
@@ -3,6 +3,7 @@ import AdminLink from "../components/AdminLink";
 import DetailGrid from "../components/DetailGrid";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -36,10 +37,10 @@ export default function MobilityTripDetailPage() {
         { label: "Vehicle ID", value: model.vehicleId },
         { label: "Opaque ID", value: model.opaqueId },
         { label: "External Trip ID", value: model.externalTripId },
-        { label: "Started At", value: dayjs(model.beganAt).format("ll LTS") },
+        { label: "Started At", value: formatDate(model.beganAt, { template: "ll LTS" }) },
         {
           label: "Ended At",
-          value: model.endedAt ? dayjs(model.endedAt).format("ll LTS") : "Ongoing",
+          value: formatDate(model.endedAt, { template: "ll LTS", default: "Ongoing" }),
         },
         { label: "Start Lat", value: model.beginLat },
         { label: "Start Lng", value: model.beginLng },
@@ -58,7 +59,7 @@ export default function MobilityTripDetailPage() {
                 { label: "ID", value: <AdminLink model={model.charge} /> },
                 {
                   label: "Created At",
-                  value: dayjs(model.charge.createdAt).format("lll"),
+                  value: formatDate(model.charge.createdAt),
                 },
                 { label: "Opaque ID", value: model.charge.opaqueId },
                 {
@@ -77,7 +78,7 @@ export default function MobilityTripDetailPage() {
             properties={[
               { label: "Id", value: model.rate.id },
               { label: "Name", value: model.rate.name },
-              { label: "Created", value: dayjs(model.rate.createdAt).format("lll") },
+              { label: "Created", value: formatDate(model.rate.createdAt) },
               { label: "Unit Amount", value: <Money>{model.rate.unitAmount}</Money> },
               { label: "Surcharge", value: <Money>{model.rate.surcharge}</Money> },
               { label: "Unit Offset", value: model.rate.unitOffset },

--- a/adminapp/src/pages/MobilityTripListPage.jsx
+++ b/adminapp/src/pages/MobilityTripListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -53,13 +53,14 @@ export default function MobilityTripListPage() {
           id: "began_at",
           label: "Began",
           align: "center",
-          render: (c) => dayjs(c.beganAt).format("ll LTS"),
+          render: (c) => formatDate(c.beganAt, { template: "ll LTS" }),
         },
         {
           id: "ended_at",
           label: "Ended",
           align: "center",
-          render: (c) => (c.endedAt ? dayjs(c.endedAt).format("ll LTS") : "Ongoing"),
+          render: (c) =>
+            formatDate(c.endedAt, { template: "ll LTS", default: "Ongoing" }),
         },
         {
           id: "total_cost",

--- a/adminapp/src/pages/OfferingDetailPage.jsx
+++ b/adminapp/src/pages/OfferingDetailPage.jsx
@@ -6,6 +6,7 @@ import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import SumaImage from "../components/SumaImage";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import oneLineAddress from "../modules/oneLineAddress";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import Money from "../shared/react/Money";
@@ -133,7 +134,7 @@ export default function OfferingDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               <AdminLink key="mem" model={row.member}>
                 {row.member.name}
               </AdminLink>,

--- a/adminapp/src/pages/OfferingListPage.jsx
+++ b/adminapp/src/pages/OfferingListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function OfferingListPage() {
@@ -41,13 +41,13 @@ export default function OfferingListPage() {
           id: "period_begin",
           label: "Opens",
           align: "center",
-          render: (c) => dayjs(c.periodBegin).format("l"),
+          render: (c) => formatDate(c.periodBegin, { template: "l" }),
         },
         {
           id: "period_end",
           label: "Closes",
           align: "center",
-          render: (c) => dayjs(c.periodEnd).format("l"),
+          render: (c) => formatDate(c.periodEnd, { template: "l" }),
         },
       ]}
     />

--- a/adminapp/src/pages/OfferingProductDetailPage.jsx
+++ b/adminapp/src/pages/OfferingProductDetailPage.jsx
@@ -3,6 +3,7 @@ import AdminLink from "../components/AdminLink";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -49,7 +50,7 @@ export default function OfferingProductDetailPage() {
           keyRowAttr="id"
           toCells={(row) => [
             <AdminLink key="id" model={row} />,
-            dayjs(row.createdAt).format("lll"),
+            formatDate(row.createdAt),
             <AdminLink key="mem" model={row.member}>
               {row.member.name}
             </AdminLink>,

--- a/adminapp/src/pages/OrderListPage.jsx
+++ b/adminapp/src/pages/OrderListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function OrderListPage() {
@@ -23,7 +23,7 @@ export default function OrderListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
         {
           id: "member",

--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -4,6 +4,7 @@ import ProgramEnrollmentRelatedList from "../components/ProgramEnrollmentRelated
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import React from "react";
 
@@ -43,7 +44,7 @@ export default function OrganizationDetailPage() {
               <AdminLink key="member" model={row.member}>
                 {row.member.name}
               </AdminLink>,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
             ]}
           />
         </>

--- a/adminapp/src/pages/OrganizationListPage.jsx
+++ b/adminapp/src/pages/OrganizationListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function OrganizationListPage() {
@@ -30,7 +30,7 @@ export default function OrganizationListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
       ]}
     />

--- a/adminapp/src/pages/OrganizationMembershipListPage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function OrganizationMembershipListPage() {
@@ -43,7 +43,7 @@ export default function OrganizationMembershipListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
       ]}
     />

--- a/adminapp/src/pages/PaymentTriggerDetailPage.jsx
+++ b/adminapp/src/pages/PaymentTriggerDetailPage.jsx
@@ -4,6 +4,7 @@ import Programs from "../components/Programs";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import { formatMoney, intToMoney } from "../shared/money";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import React from "react";
@@ -65,7 +66,7 @@ export default function PaymentTriggerDetailPage() {
               <AdminLink key="bookx" model={row}>
                 {row.bookTransactionId}
               </AdminLink>,
-              dayjs(row.at).format("lll"),
+              formatDate(row.at),
               <AdminLink key="recledger" model={row}>
                 {row.receivingLedger.adminLabel}
               </AdminLink>,
@@ -86,7 +87,7 @@ export default function PaymentTriggerDetailPage() {
             ]}
             toCells={(row) => [
               row.id,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               <AdminLink key={row.vendor.name} model={row.vendor}>
                 {row.vendor.name}
               </AdminLink>,

--- a/adminapp/src/pages/PayoutTransactionListPage.jsx
+++ b/adminapp/src/pages/PayoutTransactionListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -24,7 +24,7 @@ export default function PayoutTransactionListPage() {
           label: "Created",
           align: "center",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
         {
           id: "amount",

--- a/adminapp/src/pages/ProductDetailPage.jsx
+++ b/adminapp/src/pages/ProductDetailPage.jsx
@@ -4,6 +4,7 @@ import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import SumaImage from "../components/SumaImage";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import Money from "../shared/react/Money";
 import React from "react";
@@ -84,7 +85,7 @@ export default function ProductDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               row.orderStatus,
               <AdminLink key="member" model={row.member}>
                 {row.member.name}

--- a/adminapp/src/pages/ProductListPage.jsx
+++ b/adminapp/src/pages/ProductListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function ProductListPage() {
@@ -24,7 +24,7 @@ export default function ProductListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
         {
           id: "name",

--- a/adminapp/src/pages/ProgramDetailPage.jsx
+++ b/adminapp/src/pages/ProgramDetailPage.jsx
@@ -4,6 +4,7 @@ import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import SumaImage from "../components/SumaImage";
 import { dayjs, dayjsOrNull } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import createRelativeUrl from "../shared/createRelativeUrl";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import React from "react";
@@ -51,8 +52,8 @@ export default function ProgramDetailPage() {
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
               <AdminLink model={row}>{row.description.en}</AdminLink>,
-              dayjs(row.periodBegin).format("lll"),
-              dayjs(row.periodEnd).format("lll"),
+              formatDate(row.periodBegin),
+              formatDate(row.periodEnd),
             ]}
           />
           <RelatedList
@@ -68,8 +69,8 @@ export default function ProgramDetailPage() {
               <AdminLink key="vendor_name" model={row.vendor}>
                 {row.vendor.name}
               </AdminLink>,
-              dayjs(row.periodBegin).format("lll"),
-              dayjs(row.periodEnd).format("lll"),
+              formatDate(row.periodBegin),
+              formatDate(row.periodEnd),
             ]}
           />
           <RelatedList
@@ -80,8 +81,8 @@ export default function ProgramDetailPage() {
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
               <AdminLink model={row}>{row.label}</AdminLink>,
-              dayjs(row.activeDuringBegin).format("lll"),
-              dayjs(row.activeDuringEnd).format("lll"),
+              formatDate(row.activeDuringBegin),
+              formatDate(row.activeDuringEnd),
             ]}
           />
           <RelatedList
@@ -99,7 +100,7 @@ export default function ProgramDetailPage() {
             ]}
             toCells={(row) => [
               <AdminLink model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               <AdminLink key={row.vendor.name} model={row.vendor}>
                 {row.vendor.name}
               </AdminLink>,

--- a/adminapp/src/pages/ProgramEnrollmentDetailPage.jsx
+++ b/adminapp/src/pages/ProgramEnrollmentDetailPage.jsx
@@ -5,6 +5,7 @@ import ResourceDetail from "../components/ResourceDetail";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import { useUser } from "../hooks/user";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import { Switch } from "@mui/material";
 import React from "react";
 
@@ -41,9 +42,7 @@ export default function ProgramEnrollmentDetailPage() {
           children: (
             <InlineEditField
               resource="program_enrollment"
-              renderDisplay={
-                model.approvedAt ? dayjs(model.approvedAt).format("lll") : "-"
-              }
+              renderDisplay={formatDate(model.approvedAt)}
               initialEditingState={{ id: model.id }}
               renderEdit={(st, set) => {
                 const enrollment = { ...model, ...st };
@@ -75,9 +74,7 @@ export default function ProgramEnrollmentDetailPage() {
           children: (
             <InlineEditField
               resource="program_enrollment"
-              renderDisplay={
-                model.unenrolledAt ? dayjs(model.unenrolledAt).format("lll") : "-"
-              }
+              renderDisplay={formatDate(model.unenrolledAt)}
               initialEditingState={{ id: model.id }}
               renderEdit={(st, set) => {
                 const enrollment = { ...model, ...st };

--- a/adminapp/src/pages/ProgramListPage.jsx
+++ b/adminapp/src/pages/ProgramListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function ProgramListPage() {
@@ -36,13 +36,13 @@ export default function ProgramListPage() {
           id: "period_begin",
           label: "Opens",
           align: "center",
-          render: (c) => dayjs(c.periodBegin).format("l"),
+          render: (c) => formatDate(c.periodBegin, { template: "l" }),
         },
         {
           id: "period_end",
           label: "Closes",
           align: "center",
-          render: (c) => dayjs(c.periodEnd).format("l"),
+          render: (c) => formatDate(c.periodEnd, { template: "l" }),
         },
       ]}
     />

--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -5,6 +5,7 @@ import DetailGrid from "../components/DetailGrid";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import SafeExternalLink from "../shared/react/SafeExternalLink";
 import React from "react";
 
@@ -31,13 +32,11 @@ export default function VendorAccountDetailPage() {
         { label: "Latest Access Code", value: model.latestAccessCode },
         {
           label: "Latest Access Code Requested At",
-          value: model.latestAccessCodeRequestedAt
-            ? dayjs(model.latestAccessCodeRequestedAt)
-            : "",
+          value: formatDate(model.latestAccessCodeRequestedAt),
         },
         {
           label: "Latest Access Code Set At",
-          value: model.latestAccessCodeSetAt ? dayjs(model.latestAccessCodeSetAt) : "",
+          value: formatDate(model.latestAccessCodeSetAt),
         },
         {
           label: "Registered with Vendor",
@@ -96,13 +95,13 @@ export default function VendorAccountDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               row.id,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               row.messageContent,
               row.messageFrom,
               row.messageTo,
               row.messageHandlerKey,
               row.relayKey,
-              dayjs(row.messageTimestamp).format("lll"),
+              formatDate(row.messageTimestamp),
             ]}
           />
         </>

--- a/adminapp/src/pages/VendorAccountListPage.jsx
+++ b/adminapp/src/pages/VendorAccountListPage.jsx
@@ -2,7 +2,7 @@ import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
 import Unavailable from "../components/Unavailable";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function VendorAccountListPage() {
@@ -40,7 +40,7 @@ export default function VendorAccountListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
       ]}
     />

--- a/adminapp/src/pages/VendorConfigurationListPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationListPage.jsx
@@ -2,7 +2,7 @@ import api from "../api";
 import AdminLink from "../components/AdminLink";
 import BoolCheckmark from "../components/BoolCheckmark";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function VendorConfigurationListPage() {
@@ -42,7 +42,7 @@ export default function VendorConfigurationListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
       ]}
     />

--- a/adminapp/src/pages/VendorDetailPage.jsx
+++ b/adminapp/src/pages/VendorDetailPage.jsx
@@ -5,6 +5,7 @@ import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import SumaImage from "../components/SumaImage";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function VendorDetailPage() {
@@ -63,7 +64,7 @@ export default function VendorDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               row.name.en,
             ]}
           />

--- a/adminapp/src/pages/VendorListPage.jsx
+++ b/adminapp/src/pages/VendorListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function VendorListPage() {
@@ -24,7 +24,7 @@ export default function VendorListPage() {
           label: "Created",
           align: "left",
           sortable: true,
-          render: (c) => dayjs(c.createdAt).format("lll"),
+          render: (c) => formatDate(c.createdAt),
         },
         {
           id: "name",

--- a/adminapp/src/pages/VendorServiceDetailPage.jsx
+++ b/adminapp/src/pages/VendorServiceDetailPage.jsx
@@ -5,6 +5,7 @@ import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import SumaImage from "../components/SumaImage";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -73,7 +74,7 @@ export default function VendorServiceDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               row.id,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               row.name,
               <Money key="unit_amount">{row.unitAmount}</Money>,
               <Money key="surcharge">{row.surcharge}</Money>,
@@ -102,12 +103,12 @@ export default function VendorServiceDetailPage() {
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink key="id" model={row} />,
-              dayjs(row.createdAt).format("lll"),
+              formatDate(row.createdAt),
               row.vehicleId,
               row.rate.name,
               // This formatting shows date and time with seconds
-              dayjs(row.beganAt).format("ll LTS"),
-              row.endedAt ? dayjs(row.endedAt).format("ll LTS") : "Ongoing",
+              formatDate(row.beganAt, { template: "ll LTS" }),
+              formatDate(row.endedAt, { template: "ll LTS", default: "Ongoing" }),
               row.beginLat,
               row.beginLng,
               row.endLat,

--- a/adminapp/src/pages/VendorServiceListPage.jsx
+++ b/adminapp/src/pages/VendorServiceListPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceList from "../components/ResourceList";
-import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function VendorServiceListPage() {
@@ -34,13 +34,13 @@ export default function VendorServiceListPage() {
           id: "period_begin",
           label: "Opens",
           align: "center",
-          render: (c) => dayjs(c.periodBegin).format("l"),
+          render: (c) => formatDate(c.periodBegin, { template: "l" }),
         },
         {
           id: "period_end",
           label: "Closes",
           align: "center",
-          render: (c) => dayjs(c.periodEnd).format("l"),
+          render: (c) => formatDate(c.periodEnd, { template: "l" }),
         },
       ]}
     />

--- a/db/migrations/063_analytics_member_columns.rb
+++ b/db/migrations/063_analytics_member_columns.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(Sequel[:analytics][:members]) do
+      add_column :onboarding_verified, :boolean
+      add_column :preferred_language, :text
+      add_column :account_updates_sms_optout, :boolean
+      add_column :marketing_sms_optout, :boolean
+    end
+  end
+end

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -97,6 +97,7 @@ module Suma::AdminAPI::Entities
     expose :name
     expose :phone
     expose :timezone
+    expose :onboarding_verified_at
   end
 
   class MessageDeliveryEntity < BaseEntity

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -68,7 +68,6 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
     expose :note
     expose :roles, with: RoleEntity
     expose :onboarding_verified?, as: :onboarding_verified
-    expose :onboarding_verified_at
 
     expose :legal_entity, with: LegalEntityEntity
     expose :payment_account, with: DetailedPaymentAccountEntity

--- a/lib/suma/analytics/member.rb
+++ b/lib/suma/analytics/member.rb
@@ -11,9 +11,10 @@ class Suma::Analytics::Member < Suma::Analytics::Model(Sequel[:analytics][:membe
     :created_at,
     :soft_deleted_at,
     :phone,
-    [:email, :email],
+    :email,
     :name,
     :timezone,
+    [:onboarding_verified, ->(m) { m.onboarding_verified_at ? true : false }],
   ]
 
   denormalize Suma::Commerce::Order, with: :denormalize_order
@@ -22,6 +23,13 @@ class Suma::Analytics::Member < Suma::Analytics::Model(Sequel[:analytics][:membe
     member = order.checkout.cart.member
     return {member_id: member.id, order_count: member.orders_dataset.count}
   end
+
+  denormalize Suma::Message::Preferences, with: [
+    :member_id,
+    :preferred_language,
+    :account_updates_sms_optout,
+    :marketing_sms_optout,
+  ]
 end
 
 # Table: analytics.members

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -32,6 +32,7 @@ module Suma::Async
     "suma/async/funding_transaction_processor",
     "suma/async/lyft_pass_trip_sync",
     "suma/async/member_onboarding_verified_dispatch",
+    "suma/async/membership_verified_verify_onboarding",
     "suma/async/message_dispatched",
     "suma/async/offering_schedule_fulfillment",
     "suma/async/order_confirmation",

--- a/lib/suma/async/membership_verified_verify_onboarding.rb
+++ b/lib/suma/async/membership_verified_verify_onboarding.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "amigo/job"
+
+# When a member's membership is verified,
+# make sure they are marked onboarding verified,
+# so we don't have to update things in two places.
+class Suma::Async::MembershipVerifiedVerifyOnboarding
+  extend Amigo::Job
+
+  on "suma.organization.membership.updated"
+
+  def _perform(event)
+    membership = self.lookup_model(Suma::Organization::Membership, event)
+    case event.payload[1]
+      when changed(:verified_organization_id, from: nil)
+        membership.member.onboarding_verified = true
+        membership.member.save_changes
+    end
+  end
+end

--- a/lib/suma/message/signalwire_webhookdb_optout_processor.rb
+++ b/lib/suma/message/signalwire_webhookdb_optout_processor.rb
@@ -36,12 +36,14 @@ class Suma::Message::SignalwireWebhookdbOptoutProcessor
   end
 
   def fetch_rows
+    raise Suma::InvalidPrecondition, "Suma::Signalwire.marketing_number cannot have a + prefix" if
+      Suma::Signalwire.marketing_number.starts_with?("+")
     cutoff = @now - 1.week
     ds = Suma::Webhookdb.signalwire_messages_dataset
     ds = ds.where { date_created > cutoff }
     ds = ds.where(
       direction: "inbound",
-      to: Suma::Signalwire.marketing_number,
+      to: "+" + Suma::Signalwire.marketing_number,
     )
     keywords = Suma::Signalwire.message_marketing_sms_unsubscribe_keywords +
       Suma::Signalwire.message_marketing_sms_resubscribe_keywords +

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -161,8 +161,17 @@ module Suma::Service::Helpers
     return dataset.paginate(params[:page], params[:per_page])
   end
 
+  # Order the database. By default, use descending nulls last.
+  # If order_direction is :asc, use ascending nulls first.
   def order(dataset, params, disambiguator: :id)
-    expr = params[:order_direction] == :asc ? Sequel.asc(params[:order_by]) : Sequel.desc(params[:order_by])
+    if params[:order_direction] == :asc
+      m = :asc
+      nulls = :first
+    else
+      nulls = :last
+      m = :desc
+    end
+    expr = Sequel.send(m, params[:order_by], nulls:)
     return dataset.order(expr, Sequel.desc(disambiguator))
   end
 

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -200,6 +200,28 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
     end
   end
 
+  describe "MembershipVerifiedOnboardingVerify" do
+    let(:membership) { Suma::Fixtures.organization_membership.unverified.create }
+    let(:org) { Suma::Fixtures.organization.create }
+
+    it "sets the member verified when a membership is verified" do
+      expect do
+        membership.update(verified_organization: org)
+      end.to perform_async_job(Suma::Async::MembershipVerifiedVerifyOnboarding)
+
+      expect(membership.refresh.member).to be_onboarding_verified
+    end
+
+    it "noops if the membership is not verified" do
+      membership.update(verified_organization: org)
+      expect do
+        membership.update(verified_organization_id: nil, unverified_organization_name: "hi")
+      end.to perform_async_job(Suma::Async::MembershipVerifiedVerifyOnboarding)
+
+      expect(membership.refresh.member).to_not be_onboarding_verified
+    end
+  end
+
   describe "MessageDispatched", messaging: true do
     it "sends the delivery on create" do
       email = "wibble@lithic.tech"

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
 
   describe "SignalwireProcessOptouts", reset_configuration: Suma::Signalwire do
     it "syncs refunds" do
-      Suma::Signalwire.marketing_number = "+12225550000"
+      Suma::Signalwire.marketing_number = "12225550000"
       member = Suma::Fixtures.member.create
       Suma::Webhookdb.signalwire_messages_dataset.insert(
         signalwire_id: "msg1",

--- a/spec/suma/frontapp/list_sync_spec.rb
+++ b/spec/suma/frontapp/list_sync_spec.rb
@@ -186,8 +186,8 @@ RSpec.describe Suma::Frontapp::ListSync, :db, reset_configuration: Suma::Frontap
       Suma::Message::Preferences.create(member: old)
 
       specs = described_class.new(now:).gather_list_specs
-      en = specs.find { |s| s.full_name == "Unverified - SMS - English" }
-      es = specs.find { |s| s.full_name == "Unverified - SMS - Spanish" }
+      en = specs.find { |s| s.full_name == "Unverified, last 30 days - SMS - English" }
+      es = specs.find { |s| s.full_name == "Unverified, last 30 days - SMS - Spanish" }
       expect(en.dataset.all).to have_same_ids_as(en_member)
       expect(es.dataset.all).to have_same_ids_as(es_member)
     end

--- a/spec/suma/message/signalwire_webhookdb_optout_processor_spec.rb
+++ b/spec/suma/message/signalwire_webhookdb_optout_processor_spec.rb
@@ -4,7 +4,7 @@ require "suma/message/signalwire_webhookdb_optout_processor"
 
 RSpec.describe Suma::Message::SignalwireWebhookdbOptoutProcessor, :db, reset_configuration: Suma::Signalwire do
   before(:each) do
-    Suma::Signalwire.marketing_number = "+12225550000"
+    Suma::Signalwire.marketing_number = "12225550000"
   end
 
   let(:member_phone) { "14445556666" }
@@ -15,11 +15,18 @@ RSpec.describe Suma::Message::SignalwireWebhookdbOptoutProcessor, :db, reset_con
       date_created: 4.days.ago,
       direction: "inbound",
       from: "+12225551234",
-      to: Suma::Signalwire.marketing_number,
+      to: "+" + Suma::Signalwire.marketing_number,
       data: {body:}.to_json,
     }
     r.merge!(**kw)
     return r
+  end
+
+  it "errors if the signalwire marketing number starts with a +" do
+    Suma::Signalwire.marketing_number = "+12225550000"
+    expect do
+      described_class.new(now: Time.now).fetch_rows
+    end.to raise_error(Suma::InvalidPrecondition, /cannot have a/)
   end
 
   it "finds potential unsubscribe rows from the last week" do


### PR DESCRIPTION
Use formatDate helper in admin

---

Add verified timestamp to member list

Sort nulls last when desc, first when asc.

Also add a date format helper.

---

Add Front list for 'all time unverified'

Make clear existing one is just last 30 days.

---

Add onboarding and message prefs to analytics

---

Better automatic verification

When a user's organization membership is marked verified,
ensure the member is marked onboarding verified.

---

Signalwire marketing number cannot have + prefix

Error if it's set, remove ambiguity.
