### PR TITLE
Optout processor send on marketing channel

### DIFF
--- a/lib/suma/message.rb
+++ b/lib/suma/message.rb
@@ -37,7 +37,7 @@ module Suma::Message
 
   # Create a Suma::Message::Delivery ready to deliver (rendered, all bodies set up)
   # using the given transport_type to the given user.
-  def self.dispatch(template, to, transport_type)
+  def self.dispatch(template, to, transport_type, extra_fields: {})
     (transport = Suma::Message::Transport.for(transport_type)) or
       raise InvalidTransportError, "Invalid transport #{transport_type}"
     recipient = transport.recipient(to)
@@ -52,7 +52,7 @@ module Suma::Message
         transport_service: transport.service,
         to: recipient.to,
         recipient: recipient.member,
-        extra_fields: template.extra_fields,
+        extra_fields: template.extra_fields.merge(extra_fields),
       )
       transport.add_bodies(delivery, contents)
       delivery.publish_deferred("dispatched", delivery.id)

--- a/lib/suma/message/sms_transport.rb
+++ b/lib/suma/message/sms_transport.rb
@@ -91,7 +91,8 @@ class Suma::Message::SmsTransport < Suma::Message::Transport
     raise Suma::Message::Transport::Error, "Could not format phone number" if
       to_phone.nil?
 
-    (from_phone = Suma::PhoneNumber.format_e164(self.class.from)) or
+    from_phone = delivery.extra_fields.fetch("from", self.class.from)
+    (from_phone = Suma::PhoneNumber.format_e164(from_phone)) or
       raise Suma::InvalidPrecondition, "SMS_TRANSPORT_FROM is invalid"
 
     raise Suma::Message::Transport::UndeliverableRecipient, "Number '#{to_phone}' not allowlisted" unless

--- a/spec/suma/message/signalwire_webhookdb_optout_processor_spec.rb
+++ b/spec/suma/message/signalwire_webhookdb_optout_processor_spec.rb
@@ -106,6 +106,10 @@ RSpec.describe Suma::Message::SignalwireWebhookdbOptoutProcessor, :db, reset_con
       have_attributes(recipient: be === member, template: "sms_compliance/optin"),
       have_attributes(recipient: be === member, template: "sms_compliance/help"),
     )
+    expect(Suma::Message::Delivery.first).to have_attributes(
+      transport_service: "signalwire",
+      extra_fields: hash_including("from" => Suma::Signalwire.marketing_number),
+    )
   end
 
   describe "msgtype" do

--- a/spec/suma/message/sms_transport_spec.rb
+++ b/spec/suma/message/sms_transport_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Suma::Message::SmsTransport, :db, reset_configuration: Suma::Mess
       expect(req).to have_been_made
     end
 
+    it "can override the from number using an extra field" do
+      req = stub_signalwire_sms(sid: "SMXYZ").
+        with(body: {"Body" => "hello", "From" => "+19998887777", "To" => "+15554443210"})
+      delivery = Suma::Fixtures.message_delivery.sms("+15554443210", "hello").
+        create(extra_fields: {"from" => "19998887777"})
+      result = described_class.new.send!(delivery)
+      expect(result).to eq("SMXYZ")
+      expect(req).to have_been_made
+    end
+
     it "formats the provided phone number" do
       req = stub_signalwire_sms.
         with(body: {"Body" => "hello", "From" => "+15554443333", "To" => "+15554443210"})


### PR DESCRIPTION
Fixes https://github.com/lithictech/suma/issues/776

The optout processor would send its messages
on the transactional app channel.
This meant users would likely to STOP or START
on the transactional channel, which would not do anything (except make a Front message).

This changes the sms transport to recognize a 'from' key in the 'extra_fields' column,
and use that to override the default 'from' configured for the entire transport.

The optout processor passess the 'from' number into the message.