### PR TITLE
Admin: Lyft pass program; Admin: search with explicit ordering; Fix pgvector issue with db restore and extension schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ download-production-dump:
 
 restore-db-from-dump:
 	@mkdir -p temp
-	@PGPASSWORD=suma psql postgres://suma:suma@localhost:22005/suma -c "CREATE SCHEMA IF NOT EXISTS heroku_ext"
+	@PGPASSWORD=suma psql postgres://suma:suma@localhost:22005/suma -c "CREATE SCHEMA IF NOT EXISTS heroku_ext; ALTER DATABASE suma SET search_path TO public,heroku_ext;"
 	PGPASSWORD=suma pg_restore --clean --no-acl --no-owner -h 127.0.0.1 -p 22005 -U suma -d suma temp/latest.dump || true
 	@PGPASSWORD=suma psql postgres://suma:suma@localhost:22005/suma -c "ALTER EXTENSION citext SET SCHEMA public"
 	@bundle exec rake release:prepare_prod_db_for_testing

--- a/adminapp/src/pages/ProgramDetailPage.jsx
+++ b/adminapp/src/pages/ProgramDetailPage.jsx
@@ -40,6 +40,7 @@ export default function ProgramDetailPage() {
         { label: "App Link Text EN", value: model.appLinkText.en },
         { label: "App Link Text ES", value: model.appLinkText.es },
         { label: "Ordinal", value: model.ordinal },
+        { label: "Lyft Pass Program", value: model.lyftPassProgramId },
       ]}
     >
       {(model) => (

--- a/adminapp/src/pages/ProgramForm.jsx
+++ b/adminapp/src/pages/ProgramForm.jsx
@@ -107,7 +107,17 @@ export default function ProgramForm({
           type="number"
           label="Ordinal"
           helperText="Programs are listed from lower to higher ordinal values in the dashboard."
-          sx={{ width: { xs: "100%", sm: "50%" } }}
+          fullWidth
+          onChange={setFieldFromInput}
+        />
+        <FormLabel>Other</FormLabel>
+        <TextField
+          {...register("lyftPassProgramId")}
+          label="Lyft Pass Program"
+          name="lyftPassProgramId"
+          value={resource.lyftPassProgramId}
+          helperText="Set this for programs that are for Lyft Pass enrollment."
+          fullWidth
           onChange={setFieldFromInput}
         />
         <ModelItems

--- a/lib/suma/admin_api/payment_ledgers.rb
+++ b/lib/suma/admin_api/payment_ledgers.rb
@@ -29,10 +29,9 @@ class Suma::AdminAPI::PaymentLedgers < Suma::AdminAPI::V1
       self,
       Suma::Payment::Ledger,
       LedgerEntity,
-      ordering_kw: {default: nil},
       ordering: lambda do |ds, params|
-        if params[:order_by]
-          ds = Suma::Service::Helpers.order(ds, params)
+        if param_passed?(:order_by)
+          ds = order(ds, params)
         else
           # Default ordering is to put platform accounts first, then order by created at,
           # since we likely only have a few platform accounts.
@@ -40,7 +39,7 @@ class Suma::AdminAPI::PaymentLedgers < Suma::AdminAPI::V1
           # then unselect the addition columns via select_all when reselecting the model.
           params[:order_by] = [:is_platform_account, Sequel[:payment_ledgers][:created_at]]
           ds = ds.join(:payment_accounts, {id: :account_id})
-          ds = Suma::Service::Helpers.order(ds, params, disambiguator: Sequel[:payment_ledgers][:id])
+          ds = order(ds, params, disambiguator: Sequel[:payment_ledgers][:id])
           ds = ds.select_all(:payment_ledgers)
         end
         ds

--- a/lib/suma/admin_api/programs.rb
+++ b/lib/suma/admin_api/programs.rb
@@ -40,6 +40,7 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
         requires :period_begin, type: Time
         requires :period_end, type: Time
         optional :ordinal, type: Integer
+        optional :lyft_pass_program_id, type: String
         optional :commerce_offerings, type: Array, coerce_with: proc(&:values) do
           use :model_with_id
         end
@@ -82,6 +83,7 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
         optional :period_begin, type: Time
         optional :period_end, type: Time
         optional :ordinal, type: Integer
+        optional :lyft_pass_program_id, type: String
         optional :commerce_offerings, type: Array, coerce_with: proc(&:values) do
           use :model_with_id
         end

--- a/lib/suma/postgres/model.rb
+++ b/lib/suma/postgres/model.rb
@@ -79,6 +79,7 @@ class Suma::Postgres::Model
       "pgcrypto",
       "btree_gist",
       "pg_trgm",
+      "vector",
     ]
   end
 

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -147,7 +147,7 @@ module Suma::Service::Helpers
 
   # Order the database. By default, use descending nulls last.
   # If order_direction is :asc, use ascending nulls first.
-  def self.order(dataset, params, disambiguator: :id)
+  def order(dataset, params, disambiguator: Sequel[dataset.model.table_name][dataset.model.primary_key])
     if params[:order_direction] == :asc
       m = :asc
       nulls = :first
@@ -159,9 +159,15 @@ module Suma::Service::Helpers
     return dataset.order(expr, Sequel.desc(disambiguator))
   end
 
-  # Order the database. By default, use descending nulls last.
-  # If order_direction is :asc, use ascending nulls first.
-  def order(*) = Suma::Service::Helpers.order(*)
+  # Return true if the key was passed in the GET query params
+  # or POST body. false if not passed.
+  # This is the only way to know if a param was passed,
+  # rather than set by a default value in a Grape parameter block.
+  # `params` and `declared` include default parameterw.
+  def param_passed?(key)
+    key = key.to_s
+    return request.GET.key?(key) || request.POST.key?(key)
+  end
 
   def hybrid_search(dataset, params)
     return dataset.hybrid_search(params.fetch(:search))


### PR DESCRIPTION
Hybrid search supports explicit ordering

Fixes https://github.com/lithictech/suma/issues/779

Override a the hybrid search ordering if order_by is passed.
Required detecting if the param was passed explicitly,
which was a bit of a rigamarole.

---

Fix extension schema with DB restore

There was a latent issue when restoring the production database;
extensions could be in the heroku_ext schema,
but it wasn't on the search path.
So `[]::vector` wouldn't work, but `[]::heroku_ext.vector` would.

Now, set the suma DB search path to include heroku_ext by default,
just like Heroku does.

---

Admin: Edit lyft pass program id
