### PR TITLE
Admin: Org removal, view/edit member contacts, destroy vendor accounts

### DIFF
--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -1,6 +1,9 @@
 import { redirectIfAuthed, redirectIfUnauthed } from "./hocs/authRedirects";
 import { GlobalApiStateProvider } from "./hooks/globalApiState";
 import { UserProvider } from "./hooks/user";
+import AnonMemberContactDetailPage from "./pages/AnonMemberContactDetailPage";
+import AnonMemberContactEditPage from "./pages/AnonMemberContactEditPage";
+import AnonMemberContactListPage from "./pages/AnonMemberContactListPage";
 import BankAccountDetailPage from "./pages/BankAccountDetailPage";
 import BookTransactionCreatePage from "./pages/BookTransactionCreatePage";
 import BookTransactionDetailPage from "./pages/BookTransactionDetailPage";
@@ -131,6 +134,33 @@ function PageSwitch() {
         exact
         path="/dashboard"
         element={renderWithHocs(redirectIfUnauthed, withLayout(), DashboardPage)}
+      />
+      <Route
+        exact
+        path="/anon-member-contacts"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          AnonMemberContactListPage
+        )}
+      />
+      <Route
+        exact
+        path="/anon-member-contact/:id"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          AnonMemberContactDetailPage
+        )}
+      />
+      <Route
+        exact
+        path="/anon-member-contact/:id/edit"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          AnonMemberContactEditPage
+        )}
       />
       <Route
         exact

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -176,6 +176,8 @@ export default {
   getVendorAccounts: (data) => get("/adminapi/v1/anon_proxy/vendor_accounts", data),
   getVendorAccount: ({ id, data }) =>
     get(`/adminapi/v1/anon_proxy/vendor_accounts/${id}`, data),
+  destroyVendorAccount: ({ id, data }) =>
+    post(`/adminapi/v1/anon_proxy/vendor_accounts/${id}/destroy`, data),
 
   getVendorConfigurations: (data) =>
     get("/adminapi/v1/anon_proxy/vendor_configurations", data),
@@ -183,6 +185,14 @@ export default {
     get(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data),
   updateVendorConfigurationPrograms: ({ id, ...data }) =>
     post(`/adminapi/v1/anon_proxy/vendor_configurations/${id}/programs`, data),
+
+  getAnonMemberContacts: (data) => get(`/adminapi/v1/anon_proxy/member_contacts`, data),
+  createAnonMemberContact: (data) =>
+    postForm("/adminapi/v1/anon_proxy/member_contacts/create", data),
+  getAnonMemberContact: ({ id, ...data }) =>
+    get(`/adminapi/v1/anon_proxy/member_contacts/${id}`, data),
+  updateAnonMemberContact: ({ id, ...data }) =>
+    postForm(`/adminapi/v1/anon_proxy/member_contacts/${id}`, data),
 
   getCommerceOrders: (data) => get(`/adminapi/v1/commerce_orders`, data),
   getCommerceOrder: ({ id, ...data }) => get(`/adminapi/v1/commerce_orders/${id}`, data),

--- a/adminapp/src/components/ResourceDetail.jsx
+++ b/adminapp/src/components/ResourceDetail.jsx
@@ -1,20 +1,31 @@
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import useRoleAccess from "../hooks/useRoleAccess";
-import { resourceEditRoute } from "../modules/resourceRoutes";
+import { resourceEditRoute, resourceListRoute } from "../modules/resourceRoutes";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
+import useToggle from "../shared/react/useToggle";
 import DetailGrid from "./DetailGrid";
 import Link from "./Link";
+import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
-import { CircularProgress } from "@mui/material";
+import {
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import isEmpty from "lodash/isEmpty";
 import isFunction from "lodash/isFunction";
 import startCase from "lodash/startCase";
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 export default function ResourceDetail({
   resource,
+  apiDelete,
   apiGet,
   title,
   properties,
@@ -23,6 +34,7 @@ export default function ResourceDetail({
 }) {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
   const { canWriteResource } = useRoleAccess();
+  const navigate = useNavigate();
   let { id } = useParams();
   id = Number(id);
   const getResource = React.useCallback(() => {
@@ -45,6 +57,11 @@ export default function ResourceDetail({
           <DetailGrid
             title={
               <Title
+                onDelete={
+                  apiDelete &&
+                  (() =>
+                    apiDelete({ id }).then(() => navigate(resourceListRoute(resource))))
+                }
                 toEdit={
                   canEdit &&
                   canWriteResource(resource) &&
@@ -63,16 +80,54 @@ export default function ResourceDetail({
   );
 }
 
-function Title({ toEdit, children }) {
-  if (!toEdit) {
-    return children;
-  }
+function Title({ toEdit, onDelete, children }) {
+  const { enqueueErrorSnackbar } = useErrorSnackbar();
+  const deleteDialogToggle = useToggle();
+  const [deleting, setDeleting] = React.useState(false);
+  const handleDelete = React.useCallback(
+    (e) => {
+      e.preventDefault();
+      setDeleting(true);
+      onDelete().catch((e) => {
+        enqueueErrorSnackbar(e);
+        setDeleting(false);
+        deleteDialogToggle.turnOff();
+      });
+    },
+    [deleteDialogToggle, enqueueErrorSnackbar, onDelete]
+  );
+
   return (
     <>
       {children}
-      <IconButton href={toEdit} component={Link}>
-        <EditIcon color="info" />
-      </IconButton>
+      {toEdit && (
+        <IconButton href={toEdit} component={Link}>
+          <EditIcon color="info" />
+        </IconButton>
+      )}
+      {onDelete && deleting && <CircularProgress />}
+      {onDelete && !deleting && (
+        <>
+          <IconButton onClick={deleteDialogToggle.turnOn}>
+            <DeleteIcon color="error" />
+          </IconButton>
+          <Dialog open={deleteDialogToggle.isOn} onClose={deleteDialogToggle.turnOff}>
+            <DialogTitle>Destroy this resource?</DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                Do you want to destroy this resource in the database? This operation
+                cannot be undone.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={deleteDialogToggle.turnOff}>Cancel</Button>
+              <Button variant="contained" color="error" onClick={handleDelete}>
+                Delete
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </>
+      )}
     </>
   );
 }

--- a/adminapp/src/components/ResourceForm.jsx
+++ b/adminapp/src/components/ResourceForm.jsx
@@ -48,6 +48,15 @@ export default function ResourceForm({ InnerForm, baseResource, isCreate, applyC
     [setField]
   );
 
+  const clearField = React.useCallback(
+    (f) => {
+      const newChanges = assign({}, changes);
+      delete newChanges[f];
+      setChanges(newChanges);
+    },
+    [changes]
+  );
+
   const resource = mergeWith({}, baseResource, changes, (obj, src) => {
     // Since `_.merge()` only merges array indexes and does not replace arrays,
     // we need to check for empty arrays and return them, also return src when
@@ -67,6 +76,7 @@ export default function ResourceForm({ InnerForm, baseResource, isCreate, applyC
       setFields={setChanges}
       setField={setField}
       setFieldFromInput={setFieldFromInput}
+      clearField={clearField}
       register={register}
       isBusy={isBusy}
       onSubmit={handleSubmit(submitter)}

--- a/adminapp/src/hooks/useNavLinks.jsx
+++ b/adminapp/src/hooks/useNavLinks.jsx
@@ -5,6 +5,7 @@ import AddBusinessIcon from "@mui/icons-material/AddBusiness";
 import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
 import AutoModeIcon from "@mui/icons-material/AutoMode";
 import BikeScooterIcon from "@mui/icons-material/BikeScooter";
+import ContactlessIcon from "@mui/icons-material/Contactless";
 import CorporateFareIcon from "@mui/icons-material/CorporateFare";
 import EventAvailableIcon from "@mui/icons-material/EventAvailable";
 import HomeIcon from "@mui/icons-material/Home";
@@ -139,6 +140,11 @@ export default function useNavLinks() {
             label: "External Account Configs",
             href: "/vendor-configurations",
             icon: <ManageAccountsIcon />,
+          },
+          commerce && {
+            label: "Anon Member Contacts",
+            href: "/anon-member-contacts",
+            icon: <ContactlessIcon />,
           },
           commerce && {
             label: "Vendor Services",

--- a/adminapp/src/modules/resourceRoutes.js
+++ b/adminapp/src/modules/resourceRoutes.js
@@ -5,16 +5,17 @@ const mapping = {
   organizationMembership: "membership",
 };
 
-export function resourceRoute(resource) {
+export function resourceRoute(resource, { plural } = {}) {
   resource = camelCase(resource);
-  if (mapping[resource]) {
-    return mapping[resource];
+  let p = mapping[resource] || kebabCase(resource);
+  if (plural) {
+    p = pluralize(p);
   }
-  return kebabCase(resource);
+  return p;
 }
 
 export function resourceListRoute(resource) {
-  return `/${resourceRoute(resource)}`;
+  return `/${resourceRoute(resource, { plural: true })}`;
 }
 
 export function resourceCreateRoute(resource) {
@@ -27,4 +28,9 @@ export function resourceViewRoute(resource, model) {
 
 export function resourceEditRoute(resource, model) {
   return `/${resourceRoute(resource)}/${model.id}/edit?edit=true`;
+}
+
+function pluralize(str) {
+  // Improve or special case this as needed.
+  return str + "s";
 }

--- a/adminapp/src/pages/AnonMemberContactDetailPage.jsx
+++ b/adminapp/src/pages/AnonMemberContactDetailPage.jsx
@@ -1,0 +1,45 @@
+import api from "../api";
+import AdminLink from "../components/AdminLink";
+import RelatedList from "../components/RelatedList";
+import ResourceDetail from "../components/ResourceDetail";
+import { dayjs } from "../modules/dayConfig";
+import React from "react";
+
+export default function AnonMemberContactDetailPage() {
+  return (
+    <ResourceDetail
+      resource="anon_member_contact"
+      apiGet={api.getAnonMemberContact}
+      canEdit
+      properties={(model) => [
+        { label: "ID", value: model.id },
+        { label: "Created At", value: dayjs(model.createdAt) },
+        { label: "Phone", value: model.phone },
+        { label: "Email", value: model.email },
+        { label: "Relay", value: model.relayKey },
+        {
+          label: "Member",
+          value: <AdminLink model={model.member}>{model.member.name}</AdminLink>,
+        },
+      ]}
+    >
+      {(model) => (
+        <>
+          <RelatedList
+            title="Extenal Accounts"
+            rows={model.vendorAccounts}
+            showMore
+            headers={["Id", "Vendor"]}
+            keyRowAttr="id"
+            toCells={(row) => [
+              <AdminLink model={row} />,
+              <AdminLink model={row.configuration.vendor?.name}>
+                {row.configuration.vendor?.name}
+              </AdminLink>,
+            ]}
+          />
+        </>
+      )}
+    </ResourceDetail>
+  );
+}

--- a/adminapp/src/pages/AnonMemberContactEditPage.jsx
+++ b/adminapp/src/pages/AnonMemberContactEditPage.jsx
@@ -1,0 +1,14 @@
+import api from "../api";
+import ResourceEdit from "../components/ResourceEdit";
+import AnonMemberContactForm from "./AnonMemberContactForm";
+import React from "react";
+
+export default function AnonMemberContactEditPage() {
+  return (
+    <ResourceEdit
+      apiGet={api.getAnonMemberContact}
+      apiUpdate={api.updateAnonMemberContact}
+      Form={AnonMemberContactForm}
+    />
+  );
+}

--- a/adminapp/src/pages/AnonMemberContactForm.jsx
+++ b/adminapp/src/pages/AnonMemberContactForm.jsx
@@ -1,0 +1,37 @@
+import FormLayout from "../components/FormLayout";
+import { Stack, TextField } from "@mui/material";
+import React from "react";
+
+export default function AnonMemberContactForm({
+  isCreate,
+  resource,
+  setFieldFromInput,
+  register,
+  isBusy,
+  onSubmit,
+}) {
+  return (
+    <FormLayout
+      title={
+        isCreate
+          ? "Create an Anonymous Member Contact"
+          : "Update an Anonymous Member Contact"
+      }
+      subtitle="Anonymous member contacts are automatically created by the Private/External Account system.
+      You can modify the phone or email of a member's Anonymous Member Contact and delete their Vendor Account
+      to reset their account and create a new External Account for the vendor."
+      onSubmit={onSubmit}
+      isBusy={isBusy}
+    >
+      <Stack spacing={2}>
+        <TextField
+          {...register("email")}
+          fullWidth
+          value={resource.email}
+          label="Email"
+          onChange={setFieldFromInput}
+        />
+      </Stack>
+    </FormLayout>
+  );
+}

--- a/adminapp/src/pages/AnonMemberContactListPage.jsx
+++ b/adminapp/src/pages/AnonMemberContactListPage.jsx
@@ -1,0 +1,43 @@
+import api from "../api";
+import AdminLink from "../components/AdminLink";
+import ResourceList from "../components/ResourceList";
+import React from "react";
+
+export default function AnonMemberContactListPage() {
+  return (
+    <ResourceList
+      resource="anon_member_contact"
+      apiList={api.getAnonMemberContacts}
+      canSearch
+      columns={[
+        {
+          id: "id",
+          label: "ID",
+          align: "center",
+          sortable: true,
+          render: (c) => <AdminLink model={c} />,
+        },
+        {
+          id: "member",
+          label: "Member",
+          align: "left",
+          render: (c) => <AdminLink model={c.member}>{c.member.name}</AdminLink>,
+        },
+        {
+          id: "email",
+          label: "Email",
+          align: "left",
+          sortable: true,
+          render: (c) => c.email,
+        },
+        {
+          id: "phone",
+          label: "Phone",
+          align: "left",
+          sortable: true,
+          render: (c) => c.phone,
+        },
+      ]}
+    />
+  );
+}

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -193,16 +193,31 @@ function OrganizationMemberships({ memberships, model }) {
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         formatDate(row.createdAt),
-        row.verifiedOrganization ? (
-          <AdminLink key="org" model={row.verifiedOrganization}>
-            {row.verifiedOrganization.name}
-          </AdminLink>
-        ) : (
-          row.unverifiedOrganizationName
-        ),
+        membershipOrgCell(row),
       ]}
     />
   );
+}
+
+function membershipOrgCell(row) {
+  if (row.verifiedOrganization) {
+    return (
+      <AdminLink key="org" model={row.verifiedOrganization}>
+        {row.verifiedOrganization.name}
+      </AdminLink>
+    );
+  }
+  if (row.formerOrganization) {
+    return (
+      <AdminLink key="org" model={row.formerOrganization}>
+        {row.formerOrganization?.name} (removed{" "}
+        {formatDate(row.formerlyInOrganizationAt, { template: "l" })})
+      </AdminLink>
+    );
+  }
+  if (row.unverifiedOrganizationName) {
+    return row.unverifiedOrganizationName;
+  }
 }
 
 function Activities({ activities }) {

--- a/adminapp/src/pages/OrganizationMembershipCreatePage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipCreatePage.jsx
@@ -4,7 +4,7 @@ import OrganizationMembershipForm from "./OrganizationMembershipForm";
 import React from "react";
 
 export default function OrganizationMembershipCreatePage() {
-  const empty = { name: "" };
+  const empty = { unverifiedOrganizationName: "", membershipType: "unverified" };
 
   return (
     <ResourceCreate

--- a/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
@@ -2,6 +2,7 @@ import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function OrganizationMembershipDetailPage() {
@@ -9,7 +10,7 @@ export default function OrganizationMembershipDetailPage() {
     <ResourceDetail
       resource="organization_membership"
       apiGet={api.getOrganizationMembership}
-      canEdit
+      canEdit={(model) => !model.formerOrganization}
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
@@ -22,7 +23,7 @@ export default function OrganizationMembershipDetailPage() {
             </AdminLink>
           ),
         },
-        {
+        model.verifiedOrganization && {
           label: "Verified Organization",
           value: (
             <AdminLink key="org" model={model.verifiedOrganization}>
@@ -30,9 +31,18 @@ export default function OrganizationMembershipDetailPage() {
             </AdminLink>
           ),
         },
-        {
+        model.unverifiedOrganizationName && {
           label: "Unverified Organization",
           value: model.unverifiedOrganizationName,
+        },
+        model.formerOrganization && {
+          label: "Former Organization",
+          value: (
+            <AdminLink key="org" model={model.formerOrganization}>
+              {model.formerOrganization?.name} (removed{" "}
+              {formatDate(model.formerlyInOrganizationAt)})
+            </AdminLink>
+          ),
         },
       ]}
     />

--- a/adminapp/src/pages/OrganizationMembershipForm.jsx
+++ b/adminapp/src/pages/OrganizationMembershipForm.jsx
@@ -1,8 +1,17 @@
 import api from "../api";
 import AutocompleteSearch from "../components/AutocompleteSearch";
 import FormLayout from "../components/FormLayout";
-import ResponsiveStack from "../components/ResponsiveStack";
 import useMountEffect from "../shared/react/useMountEffect";
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import React from "react";
 import { useSearchParams } from "react-router-dom";
 
@@ -10,11 +19,31 @@ export default function OrganizationMembershipForm({
   isCreate,
   resource,
   setField,
+  setFieldFromInput,
+  clearField,
   register,
   isBusy,
   onSubmit,
 }) {
   const [searchParams] = useSearchParams();
+  const origMembershipType = resource.membershipType;
+  const [membershipType, setMembershipType] = React.useState(origMembershipType);
+
+  const membershipTypes = [];
+  if (isCreate || resource.unverifiedOrganizationName) {
+    // We can create an unverified or verified membership,
+    // or modify an unverified into a verified.
+    membershipTypes.push({ label: "Unverified", value: "unverified" });
+    membershipTypes.push({ label: "Verified", value: "verified" });
+  } else if (resource.verifiedOrganization) {
+    // We can remove a verified membership.
+    membershipTypes.push({ label: "Verified", value: "verified" });
+    membershipTypes.push({ label: "Removed", value: "removed" });
+  } else {
+    // We cannot edit a removed membership.
+    membershipTypes.push({ label: "Removed", value: "removed" });
+  }
+
   useMountEffect(() => {
     if (searchParams.get("edit")) {
       return;
@@ -34,10 +63,30 @@ export default function OrganizationMembershipForm({
       });
     }
   }, [searchParams]);
-  let orgText = "The organization the member is a part of.";
-  if (resource.unverifiedOrganizationName) {
-    orgText += ` The member has identified themselves with '${resource.unverifiedOrganizationName}.'`;
-  }
+
+  const handleTypeChange = React.useCallback(
+    (e) => {
+      const mt = e.target.value;
+      setMembershipType(mt);
+      if (mt === "unverified") {
+        // If we're choosing unverified, it can only be because we are currently unverified,
+        // and may have chosen a verified org. If we did, remove the verified org.
+        clearField("verifiedOrganization");
+      } else if (mt === "verified") {
+        // If we're choosing verified, it could be because we're unverified->verified
+        // (so clear out any name change), or toggling back from 'removed'
+        // (so clear out the flag).
+        clearField("unverifiedOrganizationName");
+        clearField("removeFromOrganization");
+      } else if (mt === "removed") {
+        // If we're choosing removed, it can only be because we toggled to it from verified.
+        // The org is already immutable; so just set the flag to remove the member.
+        setField("removeFromOrganization", true);
+      }
+    },
+    [setField, clearField]
+  );
+
   return (
     <FormLayout
       title={
@@ -47,11 +96,11 @@ export default function OrganizationMembershipForm({
       onSubmit={onSubmit}
       isBusy={isBusy}
     >
-      <ResponsiveStack>
+      <Stack spacing={2}>
+        <Typography>The member who is in an organization:</Typography>
         <AutocompleteSearch
           {...register("member")}
           label="Member"
-          helperText="The member who is in an organization."
           value={resource.member?.name}
           disabled={!isCreate}
           required={isCreate}
@@ -60,18 +109,67 @@ export default function OrganizationMembershipForm({
           style={{ flex: 1 }}
           onValueSelect={(m) => setField("member", m)}
         />
-        <AutocompleteSearch
-          {...register("organization")}
-          label="Organization"
-          helperText={orgText}
-          value={resource.verifiedOrganization?.name}
-          fullWidth
-          required
-          search={api.searchOrganizations}
-          style={{ flex: 1 }}
-          onValueSelect={(org) => setField("verifiedOrganization", org)}
-        />
-      </ResponsiveStack>
+        {membershipTypes.length > 0 && (
+          <FormControl disabled={membershipTypes.length === 1}>
+            <FormLabel>Membership Type</FormLabel>
+            <RadioGroup value={membershipType} row onChange={handleTypeChange}>
+              {membershipTypes.map(({ label, value }) => (
+                <FormControlLabel
+                  key={value}
+                  value={value}
+                  control={<Radio />}
+                  label={label}
+                />
+              ))}
+            </RadioGroup>
+          </FormControl>
+        )}
+        {membershipType === "unverified" && (
+          <TextField
+            {...register("unverifiedOrganizationName")}
+            label="Organization Name"
+            name="unverifiedOrganizationName"
+            value={resource.unverifiedOrganizationName}
+            fullWidth
+            onChange={setFieldFromInput}
+          />
+        )}
+        {membershipType === "verified" && (
+          <>
+            <Typography>
+              The organization the member is a part of.
+              {resource.unverifiedOrganizationName && (
+                <span>
+                  {" "}
+                  The member has identified themselves with:
+                  <br />
+                  <strong>{resource.unverifiedOrganizationName}</strong>.
+                </span>
+              )}
+            </Typography>
+            <AutocompleteSearch
+              {...register("verifiedOrganization")}
+              label="Organization"
+              value={resource.verifiedOrganization?.name}
+              fullWidth
+              required
+              disabled={origMembershipType === "verified"}
+              search={api.searchOrganizations}
+              style={{ flex: 1 }}
+              onValueSelect={(org) => setField("verifiedOrganization", org)}
+            />
+          </>
+        )}
+        {origMembershipType === "removed" && (
+          <>
+            <Typography>
+              This member has already been removed from the following organization. Create
+              a new membership to re-add them.
+            </Typography>
+            <TextField disabled value={resource.formerOrganization.name} />
+          </>
+        )}
+      </Stack>
     </FormLayout>
   );
 }

--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -14,6 +14,7 @@ export default function VendorAccountDetailPage() {
     <ResourceDetail
       resource="vendor_account"
       apiGet={api.getVendorAccount}
+      apiDelete={api.destroyVendorAccount}
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
@@ -72,7 +73,7 @@ export default function VendorAccountDetailPage() {
             <DetailGrid
               title="Member Contact"
               properties={[
-                { label: "ID", value: model.contact.id },
+                { label: "ID", value: <AdminLink model={model.contact} /> },
                 { label: "Email", value: model.contact.email },
                 { label: "Phone", value: model.contact.phone },
                 { label: "Relay Key", value: model.contact.relayKey },
@@ -82,6 +83,7 @@ export default function VendorAccountDetailPage() {
           <RelatedList
             title="Messages"
             rows={model.messages}
+            showMore
             headers={[
               "Id",
               "Created",

--- a/db/migrations/068_remove_org_membership.rb
+++ b/db/migrations/068_remove_org_membership.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "sequel/all_or_none_constraint"
+require "sequel/unambiguous_constraint"
+
+Sequel.migration do
+  up do
+    alter_table(:organization_memberships) do
+      add_foreign_key :former_organization_id, :organizations, index: true
+      add_column :formerly_in_organization_at, :timestamptz
+      drop_constraint(:unambiguous_verification_status)
+      add_constraint(
+        :unambiguous_verification_status,
+        Sequel.unambiguous_constraint([:verified_organization_id, :former_organization_id,
+                                       :unverified_organization_name,]),
+      )
+      add_constraint(
+        :unambiguous_former_organization,
+        Sequel.all_or_none_constraint([:former_organization_id, :formerly_in_organization_at]),
+      )
+    end
+  end
+  down do
+    alter_table(:organization_memberships) do
+      drop_column :former_organization_id
+      drop_column :formerly_in_organization_at
+      add_constraint(
+        :unambiguous_verification_status,
+        Sequel.unambiguous_constraint([:verified_organization_id, :unverified_organization_name]),
+      )
+    end
+  end
+end

--- a/db/migrations/068_remove_org_membership.rb
+++ b/db/migrations/068_remove_org_membership.rb
@@ -19,8 +19,17 @@ Sequel.migration do
         Sequel.all_or_none_constraint([:former_organization_id, :formerly_in_organization_at]),
       )
     end
+    alter_table(:anon_proxy_member_contacts) do
+      add_column :search_content, :text
+      add_column :search_embedding, "vector(384)"
+      add_column :search_hash, :text
+      add_index Sequel.function(:to_tsvector, "english", :search_content),
+                name: :anon_proxy_member_contacts_search_content_tsvector_index,
+                type: :gin
+    end
   end
   down do
+    from(:organization_memberships).where(unverified_organization_name: nil, verified_organization_id: nil).delete
     alter_table(:organization_memberships) do
       drop_column :former_organization_id
       drop_column :formerly_in_organization_at
@@ -28,6 +37,11 @@ Sequel.migration do
         :unambiguous_verification_status,
         Sequel.unambiguous_constraint([:verified_organization_id, :unverified_organization_name]),
       )
+    end
+    alter_table(:anon_proxy_member_contacts) do
+      drop_column :search_content
+      drop_column :search_embedding
+      drop_column :search_hash
     end
   end
 end

--- a/lib/suma/admin_api/access.rb
+++ b/lib/suma/admin_api/access.rb
@@ -8,6 +8,7 @@ class Suma::AdminAPI::Access
   MANAGEMENT = Suma::Member::RoleAccess::ADMIN_MANAGEMENT
 
   MAPPING = {
+    Suma::AnonProxy::MemberContact => [:anon_member_contact, COMMERCE, MANAGEMENT],
     Suma::AnonProxy::VendorAccount => [:vendor_account, COMMERCE, COMMERCE],
     Suma::AnonProxy::VendorConfiguration => [:vendor_configuration, COMMERCE, COMMERCE],
     Suma::Payment::BankAccount => [:bank_account, MEMBERS, MEMBERS],

--- a/lib/suma/admin_api/common_endpoints.rb
+++ b/lib/suma/admin_api/common_endpoints.rb
@@ -271,6 +271,21 @@ module Suma::AdminAPI::CommonEndpoints
     end
   end
 
+  def self.destroy(route_def, model_type, entity)
+    route_def.instance_exec do
+      route_param :id, type: Integer do
+        post :destroy do
+          access = Suma::AdminAPI::Access.write_key(model_type)
+          check_role_access!(admin_member, :write, access)
+          (m = model_type[params[:id]]) or forbidden!
+          m.destroy
+          status 200
+          present m, with: entity
+        end
+      end
+    end
+  end
+
   def self.programs_update(route_def, model_type, entity)
     route_def.instance_exec do
       route_param :id, type: Integer do

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -337,6 +337,9 @@ module Suma::AdminAPI::Entities
     expose :member, with: MemberEntity
     expose :verified_organization, with: OrganizationEntity
     expose :unverified_organization_name
+    expose :former_organization, with: OrganizationEntity
+    expose :formerly_in_organization_at
+    expose :membership_type
   end
 
   class ChargeLineItemEntity < BaseEntity

--- a/lib/suma/admin_api/organization_memberships.rb
+++ b/lib/suma/admin_api/organization_memberships.rb
@@ -6,23 +6,28 @@ require "suma/admin_api"
 class Suma::AdminAPI::OrganizationMemberships < Suma::AdminAPI::V1
   include Suma::AdminAPI::Entities
 
-  resource :organization_memberships do
-    Suma::AdminAPI::CommonEndpoints.get_one(
-      self,
-      Suma::Organization::Membership,
-      OrganizationMembershipEntity,
-    )
+  class DetailedOrganizationMembershipEntity < OrganizationMembershipEntity
+    include Suma::AdminAPI::Entities
+    include AutoExposeDetail
+  end
 
+  resource :organization_memberships do
     Suma::AdminAPI::CommonEndpoints.list(
       self,
       Suma::Organization::Membership,
       OrganizationMembershipEntity,
     )
 
+    Suma::AdminAPI::CommonEndpoints.get_one(
+      self,
+      Suma::Organization::Membership,
+      DetailedOrganizationMembershipEntity,
+    )
+
     Suma::AdminAPI::CommonEndpoints.create(
       self,
       Suma::Organization::Membership,
-      OrganizationMembershipEntity,
+      DetailedOrganizationMembershipEntity,
     ) do
       params do
         requires(:member, type: JSON) { use :model_with_id }
@@ -34,11 +39,42 @@ class Suma::AdminAPI::OrganizationMemberships < Suma::AdminAPI::V1
     Suma::AdminAPI::CommonEndpoints.update(
       self,
       Suma::Organization::Membership,
-      OrganizationMembershipEntity,
+      DetailedOrganizationMembershipEntity,
+      around: lambda do |rt, m, &block|
+        remove_from_org = rt.params.delete(:remove_from_organization)
+        # Removal modifies the membership so must come before block.call so it's saved
+        m.remove_from_organization if remove_from_org
+        block.call
+        # Audits do not modify the row itself so should come after
+        if remove_from_org
+          m.former_organization.audit_activity(
+            "removemember",
+            member: rt.admin_member,
+            action: "Suma::Member[#{m.member.id}] #{m.member.name}",
+          )
+          m.member.audit_activity(
+            "endmembership",
+            member: rt.admin_member,
+            action: "Suma::Organization[#{m.former_organization.id}] #{m.former_organization.name}",
+          )
+        elsif rt.params[:verified_organization]
+          m.verified_organization.audit_activity(
+            "addmember",
+            member: rt.admin_member,
+            action: "Suma::Member[#{m.member.id}] #{m.member.name}",
+          )
+          m.member.audit_activity(
+            "beginmembership",
+            member: rt.admin_member,
+            action: "Suma::Organization[#{m.verified_organization.id}] #{m.verified_organization.name}",
+          )
+        end
+      end,
     ) do
       params do
         optional(:verified_organization, type: JSON) { use :model_with_id }
         optional :unverified_organization_name, type: String
+        optional :remove_from_organization, type: Boolean
       end
     end
   end

--- a/lib/suma/admin_api/vendors.rb
+++ b/lib/suma/admin_api/vendors.rb
@@ -50,5 +50,11 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
         optional :name, type: String, allow_blank: false
       end
     end
+
+    Suma::AdminAPI::CommonEndpoints.destroy(
+      self,
+      Suma::Vendor,
+      DetailedVendorEntity,
+    )
   end
 end

--- a/lib/suma/anon_proxy/member_contact.rb
+++ b/lib/suma/anon_proxy/member_contact.rb
@@ -1,16 +1,27 @@
 # frozen_string_literal: true
 
+require "suma/admin_linked"
 require "suma/postgres"
 require "suma/anon_proxy"
 
 class Suma::AnonProxy::MemberContact < Suma::Postgres::Model(:anon_proxy_member_contacts)
+  include Suma::AdminLinked
+  include Suma::Postgres::HybridSearch
+
+  plugin :hybrid_search
   plugin :timestamps
 
   many_to_one :member, class: "Suma::Member"
-  one_to_many :vendor_accounts, class: "Suma::AnonProxy::VendorAccount"
+  one_to_many :vendor_accounts, class: "Suma::AnonProxy::VendorAccount", key: :contact_id
 
   def phone? = !!self.phone
   def email? = !!self.email
+
+  def rel_admin_link = "/anon-member-contact/#{self.id}"
+
+  def hybrid_search_fields
+    return [:member, :phone, :email]
+  end
 end
 
 # Table: anon_proxy_member_contacts

--- a/lib/suma/fixtures.rb
+++ b/lib/suma/fixtures.rb
@@ -14,9 +14,30 @@ module Suma::Fixtures
   ::Faker::Config.locale = :en
 
   class << self
+    def extended(mod)
+      mod.define_singleton_method :fixtured_class do |cls=nil|
+        # Must be defined like this to work with the DSL mixin, it's a weird implementation.
+        (Suma::Fixtures.fixtured_class_to_fixture_module[cls] = self) if cls
+        super(cls)
+      end
+      super
+    end
+
+    def fixtured_class_to_fixture_module = @fixtured_class_to_fixture_module ||= {}
+    def fixtured_classes = self.fixtured_class_to_fixture_module.keys
+    def fixture_modules = self.fixtured_class_to_fixture_module.values
+    def fixture_module_for(cls) = self.fixtured_class_to_fixture_module.fetch(cls)
+
     def nilor(x, val)
       return val if x.nil?
       return x
     end
   end
+
+  # Return the base factory, like Suma::Fixtures.member.
+  def base_factory = Suma::Fixtures.send(self.base_fixture)
+
+  # Implement/override this when the #base_factory cannot be created directly,
+  # and other decorators are required to fixture the instance.
+  def ensure_fixturable(factory) = factory
 end

--- a/lib/suma/fixtures/funding_transactions.rb
+++ b/lib/suma/fixtures/funding_transactions.rb
@@ -8,6 +8,10 @@ module Suma::Fixtures::FundingTransactions
 
   fixtured_class Suma::Payment::FundingTransaction
 
+  class << self
+    def ensure_fixturable(factory) = super.with_fake_strategy
+  end
+
   base :funding_transaction do
     self.amount_cents ||= Faker::Number.between(from: 100, to: 100_00)
     self.amount_currency ||= "USD"

--- a/lib/suma/fixtures/organization_memberships.rb
+++ b/lib/suma/fixtures/organization_memberships.rb
@@ -9,6 +9,10 @@ module Suma::Fixtures::OrganizationMemberships
 
   fixtured_class Suma::Organization::Membership
 
+  class << self
+    def ensure_fixturable(factory) = super.unverified
+  end
+
   base :organization_membership do
   end
 

--- a/lib/suma/fixtures/payout_transactions.rb
+++ b/lib/suma/fixtures/payout_transactions.rb
@@ -8,6 +8,10 @@ module Suma::Fixtures::PayoutTransactions
 
   fixtured_class Suma::Payment::PayoutTransaction
 
+  class << self
+    def ensure_fixturable(factory) = super.with_fake_strategy
+  end
+
   base :payout_transaction do
     self.amount_cents ||= Faker::Number.between(from: 100, to: 100_00)
     self.amount_currency ||= "USD"

--- a/lib/suma/fixtures/supported_geographies.rb
+++ b/lib/suma/fixtures/supported_geographies.rb
@@ -9,9 +9,9 @@ module Suma::Fixtures::SupportedGeographies
   fixtured_class Suma::SupportedGeography
 
   base :supported_geography do
-    self.value ||= Faker::Address.state
+    self.value ||= Faker::Address.country
     self.label ||= self.value
-    self.type ||= "province"
+    self.type ||= "country" # Default to country so we don't need a parent
   end
 
   decorator :state do |value=Faker::Address.state, label=nil|

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -430,6 +430,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
       ["Email address", self.email],
       :note,
       ["Organization memberships", orgnames],
+      ["Anonymous Contacts", self.anon_proxy_contacts.map { |c| c.phone || c.email }],
       ["Roles", self.roles.map(&:name)],
       ["Verified", self.onboarding_verified? ? "Verified" : "Unverified"],
       ["Deleted", self.soft_deleted? ? "Deleted" : "Undeleted"],

--- a/spec/suma/admin_api/anon_proxy_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Suma::AdminAPI::AnonProxy, :db do
     it_behaves_like "an endpoint with pagination" do
       let(:url) { "/v1/anon_proxy/vendor_accounts" }
       def make_item(i)
-        # Sorting is newest first, so the first items we create need to the the oldest.
+        # Sorting is newest first, so the first items we create need to the oldest.
         created = Time.now - i.days
         return Suma::Fixtures.anon_proxy_vendor_account.create(created_at: created)
       end
@@ -76,6 +76,18 @@ RSpec.describe Suma::AdminAPI::AnonProxy, :db do
         configuration: include(id: config.id),
         contact: include(id: member_contact.id),
       )
+    end
+  end
+
+  describe "POST /v1/anon_proxy/vendor_accounts/:id/destroy" do
+    it "destroys the resource" do
+      m = Suma::Fixtures.anon_proxy_vendor_account.create
+
+      post "/v1/anon_proxy/vendor_accounts/#{m.id}/destroy"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(id: m.id)
+      expect(m).to be_destroyed
     end
   end
 
@@ -143,6 +155,76 @@ RSpec.describe Suma::AdminAPI::AnonProxy, :db do
       post "/v1/anon_proxy/vendor_configurations/#{config.id}/programs", {program_ids: [0]}
 
       expect(last_response).to have_status(403)
+    end
+  end
+
+  describe "GET /v1/anon_proxy/member_contacts" do
+    it "returns all anon proxy vendor accounts" do
+      objs = Array.new(2) { Suma::Fixtures.anon_proxy_member_contact.create }
+
+      get "/v1/anon_proxy/member_contacts"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.
+        that_includes(items: have_same_ids_as(*objs))
+    end
+
+    it_behaves_like "an endpoint capable of search" do
+      let(:url) { "/v1/anon_proxy/member_contacts" }
+      let(:search_term) { "abc" }
+
+      def make_matching_items
+        return [
+          Suma::Fixtures.anon_proxy_member_contact.create(email: "abc  123"),
+        ]
+      end
+
+      def make_non_matching_items
+        return [
+          Suma::Fixtures.anon_proxy_member_contact.create(email: "not magic"),
+        ]
+      end
+    end
+
+    it_behaves_like "an endpoint with pagination" do
+      let(:url) { "/v1/anon_proxy/member_contacts" }
+      def make_item(i)
+        # Sorting is newest first, so the first items we create need to the oldest.
+        created = Time.now - i.days
+        return Suma::Fixtures.anon_proxy_member_contact.create(created_at: created)
+      end
+    end
+
+    it_behaves_like "an endpoint with member-supplied ordering" do
+      let(:url) { "/v1/anon_proxy/member_contacts" }
+      let(:order_by_field) { "id" }
+      def make_item(_i)
+        return Suma::Fixtures.anon_proxy_member_contact.create(
+          created_at: Time.now + rand(1..100).days,
+        )
+      end
+    end
+  end
+
+  describe "GET /v1/anon_proxy/member_contacts/:id" do
+    it "returns the resource" do
+      mc = Suma::Fixtures.anon_proxy_member_contact.create
+
+      get "/v1/anon_proxy/member_contacts/#{mc.id}"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(id: mc.id)
+    end
+  end
+
+  describe "POST /v1/anon_proxy/member_contacts/:id" do
+    it "updates the resource" do
+      mc = Suma::Fixtures.anon_proxy_member_contact.create
+
+      post "/v1/anon_proxy/member_contacts/#{mc.id}", email: "a@b.c"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(id: mc.id, email: "a@b.c")
     end
   end
 end

--- a/spec/suma/admin_api/vendors_spec.rb
+++ b/spec/suma/admin_api/vendors_spec.rb
@@ -105,4 +105,17 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
       expect(v.refresh).to have_attributes(name: "test")
     end
   end
+
+  describe "POST /v1/vendors/:id/destroy" do
+    it "destroys a vendor" do
+      v = Suma::Fixtures.vendor.create
+      # Need to destroy this for the destroy to work. Probably shouldn't create this automatically.
+      v.payment_account.destroy
+
+      post "/v1/vendors/#{v.id}/destroy"
+
+      expect(last_response).to have_status(200)
+      expect(v).to be_destroyed
+    end
+  end
 end

--- a/spec/suma/fixtures_spec.rb
+++ b/spec/suma/fixtures_spec.rb
@@ -2,12 +2,23 @@
 
 require "suma/fixtures"
 
-RSpec.describe Suma::Fixtures do
+RSpec.describe Suma::Fixtures, db: true  do
   it "sets the path prefix for fixtures" do
     expect(described_class.fixture_path_prefix).to eq("suma/fixtures")
   end
 
-  it "can call all decorators (improve fixture coverage)", db: true do
+  describe "can fixture" do
+    standard_modules = Suma::Fixtures.fixture_modules
+    standard_modules.each do |mod|
+      it mod.to_s do
+        factory = mod.base_factory
+        factory = mod.ensure_fixturable(factory)
+        factory.create
+      end
+    end
+  end
+
+  it "can call all decorators (improve fixture coverage)" do
     # This is gross, but we want to have coverage of fixtures. Ideally each decorator is tested
     # but in many cases it isn't really worth it.
     member = Suma::Fixtures.member.create
@@ -25,5 +36,11 @@ RSpec.describe Suma::Fixtures do
     Suma::Fixtures.reset_code.email.create
     Suma::Fixtures.translated_text.empty.create
     Suma::Fixtures.uploaded_file.uploaded_1x1_png.uploaded_bytes("x", "text/plain").create
+  end
+
+  it "keeps track of fixture and fixtured classes" do
+    expect(Suma::Fixtures.fixture_modules).to include(Suma::Fixtures::Members)
+    expect(Suma::Fixtures.fixtured_classes).to include(Suma::Member)
+    expect(Suma::Fixtures.fixture_module_for(Suma::Member)).to eq(Suma::Fixtures::Members)
   end
 end

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "behaviors"
-
 RSpec.describe "Suma::Member", :db do
   let(:described_class) { Suma::Member }
 
@@ -415,16 +413,18 @@ RSpec.describe "Suma::Member", :db do
   end
 
   describe "hybrid search" do
-    it_behaves_like "a hybrid searchable object" do
-      let(:instance) { Suma::Fixtures.organization_membership.verified.create.member }
-    end
-
     it "handles a bad or missing phone number" do
       m = Suma::Fixtures.member.email.instance(phone: "555")
       expect(m.hybrid_search_text).to match(/Phone number: 555/)
 
       m = Suma::Fixtures.member.email.instance(phone: nil)
       expect(m.hybrid_search_text).to match(/Phone number: /)
+    end
+
+    it "exercises coverage" do
+      member = Suma::Fixtures.member.create
+      Suma::Fixtures.anon_proxy_member_contact.create(member:)
+      expect(member.hybrid_search_text).to match(/Anonymous Contacts: \["u/)
     end
   end
 end

--- a/spec/suma/organization/membership_spec.rb
+++ b/spec/suma/organization/membership_spec.rb
@@ -21,4 +21,22 @@ RSpec.describe "Suma::Organization::Membership", :db do
       end.to raise_error(/unambiguous_verification_status/)
     end
   end
+
+  describe "remove_from_organization" do
+    it "sets the former org to the verified org and sets verified org nil" do
+      org = Suma::Fixtures.organization.create
+      m = Suma::Fixtures.organization_membership.verified(org).create
+      m.remove_from_organization
+      expect(m).to have_attributes(
+        verified_organization: nil,
+        former_organization: be === org,
+        formerly_in_organization_at: match_time(:now),
+      )
+    end
+
+    it "errors if there is no verified org" do
+      m = Suma::Fixtures.organization_membership.unverified.create
+      expect { m.remove_from_organization }.to raise_error(Suma::InvalidPrecondition)
+    end
+  end
 end

--- a/spec/suma/postgres/hybrid_search_spec.rb
+++ b/spec/suma/postgres/hybrid_search_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../behaviors"
+
 RSpec.describe Suma::Postgres::HybridSearch, :db do
   describe "configuration" do
     before(:each) do
@@ -58,6 +60,20 @@ RSpec.describe Suma::Postgres::HybridSearch, :db do
       m = Suma::Fixtures.member.create
       m.created_at = Time.parse("2023-01-01T12:00:00Z")
       expect(m.hybrid_search_text).to include("Created at: Sunday, January 1, 2023, 12:00:00 GMT")
+    end
+  end
+
+  describe "all hybrid searchable models" do
+    SequelHybridSearch.searchable_models.each do |m|
+      describe m.name do
+        it_behaves_like "a hybrid searchable object" do
+          let(:instance) do
+            mod = Suma::Fixtures.fixture_module_for(m)
+            fac = mod.ensure_fixturable(mod.base_factory)
+            fac.create
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Admin: Add Member contacts, destroy vendor accts

Member contacts: Add search support, api endpoints,
and admin pages.

Common endpoints: Add destroy endpoint.

Vendor accounts: Add destroy support.

Resource detail: Add helper to show a delete button
and confirmation dialog.

---

Allow organization removal

Add a new 'former organization' field to memberships,
along with a timestamp.

Admin required quite a bit of adjustment to make
organization memberships work properly between
unverified/verified/removed membership types.