### PR TITLE
Admin: Edit vendor configs; Web: Fix external account help markdown render

### DIFF
--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -67,6 +67,7 @@ import SignInPage from "./pages/SignInPage";
 import VendorAccountDetailPage from "./pages/VendorAccountDetailPage";
 import VendorAccountListPage from "./pages/VendorAccountListPage";
 import VendorConfigurationDetailPage from "./pages/VendorConfigurationDetailPage";
+import VendorConfigurationEditPage from "./pages/VendorConfigurationEditPage";
 import VendorConfigurationListPage from "./pages/VendorConfigurationListPage";
 import VendorCreatePage from "./pages/VendorCreatePage";
 import VendorDetailPage from "./pages/VendorDetailPage";
@@ -476,6 +477,15 @@ function PageSwitch() {
           redirectIfUnauthed,
           withLayout(),
           VendorConfigurationDetailPage
+        )}
+      />
+      <Route
+        exact
+        path="/vendor-configuration/:id/edit"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          VendorConfigurationEditPage
         )}
       />
       <Route

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -174,15 +174,17 @@ export default {
     post(`/adminapi/v1/vendor_services/${id}/programs`, data),
 
   getVendorAccounts: (data) => get("/adminapi/v1/anon_proxy/vendor_accounts", data),
-  getVendorAccount: ({ id, data }) =>
+  getVendorAccount: ({ id, ...data }) =>
     get(`/adminapi/v1/anon_proxy/vendor_accounts/${id}`, data),
-  destroyVendorAccount: ({ id, data }) =>
+  destroyVendorAccount: ({ id, ...data }) =>
     post(`/adminapi/v1/anon_proxy/vendor_accounts/${id}/destroy`, data),
 
   getVendorConfigurations: (data) =>
     get("/adminapi/v1/anon_proxy/vendor_configurations", data),
-  getVendorConfiguration: ({ id, data }) =>
+  getVendorConfiguration: ({ id, ...data }) =>
     get(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data),
+  updateVendorConfiguration: ({ id, ...data }) =>
+    postForm(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data),
   updateVendorConfigurationPrograms: ({ id, ...data }) =>
     post(`/adminapi/v1/anon_proxy/vendor_configurations/${id}/programs`, data),
 

--- a/adminapp/src/pages/VendorConfigurationDetailPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationDetailPage.jsx
@@ -12,6 +12,7 @@ export default function VendorConfigurationDetailPage() {
   return (
     <ResourceDetail
       resource="vendor_configuration"
+      canEdit
       apiGet={api.getVendorConfiguration}
       properties={(model) => [
         { label: "ID", value: model.id },

--- a/adminapp/src/pages/VendorConfigurationEditPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationEditPage.jsx
@@ -1,0 +1,14 @@
+import api from "../api";
+import ResourceEdit from "../components/ResourceEdit";
+import VendorConfigurationForm from "./VendorConfigurationForm";
+import React from "react";
+
+export default function VendorConfigurationEditPage() {
+  return (
+    <ResourceEdit
+      apiGet={api.getVendorConfiguration}
+      apiUpdate={api.updateVendorConfiguration}
+      Form={VendorConfigurationForm}
+    />
+  );
+}

--- a/adminapp/src/pages/VendorConfigurationForm.jsx
+++ b/adminapp/src/pages/VendorConfigurationForm.jsx
@@ -1,0 +1,73 @@
+import FormLayout from "../components/FormLayout";
+import MultiLingualText from "../components/MultiLingualText";
+import ResponsiveStack from "../components/ResponsiveStack";
+import { FormControlLabel, FormLabel, Stack, Switch, TextField } from "@mui/material";
+import React from "react";
+
+export default function VendorConfigurationForm({
+  isCreate,
+  resource,
+  setField,
+  setFieldFromInput,
+  register,
+  isBusy,
+  onSubmit,
+}) {
+  return (
+    <FormLayout
+      title={
+        isCreate
+          ? "Create an External Account Vendor Configuration"
+          : "Updaten External Account Vendor Configuration"
+      }
+      subtitle="External Account Vendor Configurations are available on
+      the 'External Accounts' area of the application,
+      and members who can access them via programs, can set up External Accounts
+      using this Configuration."
+      onSubmit={onSubmit}
+      isBusy={isBusy}
+    >
+      <Stack spacing={2}>
+        <TextField
+          {...register("appInstallLink")}
+          label="App Install Link"
+          name="appInstallLink"
+          value={resource.appInstallLink}
+          fullWidth
+          onChange={setFieldFromInput}
+        />
+        <FormControlLabel
+          control={<Switch />}
+          label="Enabled"
+          name="enabled"
+          checked={resource.enabled}
+          onChange={setFieldFromInput}
+        />
+        <FormLabel>Setup Instructions</FormLabel>
+        <ResponsiveStack>
+          <MultiLingualText
+            {...register("instructions")}
+            label=""
+            fullWidth
+            value={resource.instructions}
+            multiline
+            required
+            onChange={(v) => setField("instructions", v)}
+          />
+        </ResponsiveStack>
+        <FormLabel>Linked Success Instructions</FormLabel>
+        <ResponsiveStack>
+          <MultiLingualText
+            {...register("linkedSuccessInstructions")}
+            label=""
+            fullWidth
+            value={resource.linkedSuccessInstructions}
+            multiline
+            required
+            onChange={(v) => setField("linkedSuccessInstructions", v)}
+          />
+        </ResponsiveStack>
+      </Stack>
+    </FormLayout>
+  );
+}

--- a/lib/suma/admin_api/anon_proxy.rb
+++ b/lib/suma/admin_api/anon_proxy.rb
@@ -82,16 +82,30 @@ class Suma::AdminAPI::AnonProxy < Suma::AdminAPI::V1
     end
 
     resource :vendor_configurations do
-      Suma::AdminAPI::CommonEndpoints.get_one(
-        self,
-        Suma::AnonProxy::VendorConfiguration,
-        DetailedVendorConfigurationEntity,
-      )
       Suma::AdminAPI::CommonEndpoints.list(
         self,
         Suma::AnonProxy::VendorConfiguration,
         VendorConfigurationEntity,
       )
+
+      Suma::AdminAPI::CommonEndpoints.get_one(
+        self,
+        Suma::AnonProxy::VendorConfiguration,
+        DetailedVendorConfigurationEntity,
+      )
+
+      Suma::AdminAPI::CommonEndpoints.update(
+        self,
+        Suma::AnonProxy::VendorConfiguration,
+        DetailedVendorConfigurationEntity,
+      ) do
+        params do
+          optional :enabled, type: Boolean
+          optional :app_install_link, type: String
+          optional(:instructions, type: JSON) { use :translated_text }
+          optional(:linked_success_instructions, type: JSON) { use :translated_text }
+        end
+      end
 
       Suma::AdminAPI::CommonEndpoints.programs_update(
         self,

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,7 +20,7 @@
         "leaflet.animatedmarker": "^1.0.0",
         "leaflet.markercluster": "^1.5.3",
         "lodash": "^4.17.21",
-        "markdown-to-jsx": "^7.1.8",
+        "markdown-to-jsx": "^7.7.4",
         "payment": "^2.4.6",
         "react-bootstrap": "^2.7.0",
         "react-helmet-async": "^2.0.5",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -19,7 +19,7 @@
     "leaflet.animatedmarker": "^1.0.0",
     "leaflet.markercluster": "^1.5.3",
     "lodash": "^4.17.21",
-    "markdown-to-jsx": "^7.1.8",
+    "markdown-to-jsx": "^7.7.4",
     "payment": "^2.4.6",
     "react-bootstrap": "^2.7.0",
     "react-helmet-async": "^2.0.5",

--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -6,8 +6,7 @@ import LayoutContainer from "../components/LayoutContainer";
 import LinearBreadcrumbs from "../components/LinearBreadcrumbs";
 import PageLoader from "../components/PageLoader";
 import SumaImage from "../components/SumaImage";
-import SumaMarkdown from "../components/SumaMarkdown";
-import { t } from "../localization";
+import { dt, t } from "../localization";
 import ScrollTopOnMount from "../shared/ScrollToTopOnMount";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import useMountEffect from "../shared/react/useMountEffect";
@@ -79,7 +78,7 @@ export default function PrivateAccountsList() {
         <Modal.Body>
           <div className="d-flex justify-content-center align-items-center flex-column m-2">
             <ScrollTopOnMount />
-            <SumaMarkdown>{modalAccount?.instructions}</SumaMarkdown>
+            {dt(modalAccount?.instructions)}
             <div className="d-flex justify-content-end mt-2">
               <Button variant="outline-secondary" onClick={() => setModalAccount(null)}>
                 {t("common:close")}


### PR DESCRIPTION
Fix External Account help layout

We were using `SumaMarkdown` directly rather than using `dt`.
The string started with a `\u00d` flag though to indicate
the type of formatter the frontend should use.
This meant the markdown wasn't parsed properly.

Instead, use `dt` which will call `SumaMarkdown` as needed.

---

Admin: Edit vendor configuration
