### PR TITLE
Fix bug fetching lyft rides (or authing)

### DIFF
--- a/lib/suma/program.rb
+++ b/lib/suma/program.rb
@@ -77,6 +77,12 @@ class Suma::Program < Suma::Postgres::Model(:programs)
       :period_end,
     ]
   end
+
+  # @!attribute lyft_pass_program_id
+  # The program ID from Lyft. It is used for enrollment in the program.
+  # This is the '1234' in the URL at a URL like
+  # https://business.lyft.com/organization/myspecialorg/lyft-pass/programs/1234/overview.
+  # @return [String]
 end
 
 require "suma/program/has"

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -178,7 +178,13 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
         data: {cookies: {}}.to_json,
       )
 
-      req = stub_request(:post, "https://www.lyft.com/v1/enterprise-insights/search/transactions?organization_id=1234&start_time=1546300800000").
+      program_req = stub_request(:post, "https://www.lyft.com/v1/enterprise/external/get-program").
+        to_return(
+          status: 200,
+          headers: {"Content-Type" => "application/json"},
+          body: {program: {lyft_id: "9999"}}.to_json,
+        )
+      rides_req = stub_request(:post, "https://www.lyft.com/v1/enterprise-insights/search/transactions?organization_id=1234&start_time=1546300800000").
         to_return(
           status: 200,
           headers: {
@@ -194,7 +200,8 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
 
       Suma::Async::LyftPassTripSync.new.perform
 
-      expect(req).to have_been_made
+      expect(program_req).to have_been_made
+      expect(rides_req).to have_been_made
     end
 
     it "noops if not configured" do


### PR DESCRIPTION
The lyft program ID needs to come from the URL.
However that ID is NOT what's used to fetch rides.

Instead, use an endpoint to get the 'account id' (used to fetch rides) from the lyft program id.

NOTE: The wrong program ID will error when enrolling users, but will miss any rides when fetching rides.
This is why we didn't notice that there were two, not just one, ids in use.