### PR TITLE
Admin visual improvements; org ordinal; phone search fix

### DIFF
--- a/adminapp/src/components/AuditActivityList.jsx
+++ b/adminapp/src/components/AuditActivityList.jsx
@@ -9,7 +9,6 @@ export default function AuditActivityList({ activities }) {
       title="Audit Activities"
       headers={["At", "Summary", "Message", "Member"]}
       rows={activities}
-      showMore
       keyRowAttr="id"
       toCells={(row) => [
         formatDate(row.createdAt),

--- a/adminapp/src/components/DetailGrid.jsx
+++ b/adminapp/src/components/DetailGrid.jsx
@@ -1,5 +1,9 @@
 import { dayjs } from "../modules/dayConfig";
-import { Grid, Typography, Box } from "@mui/material";
+import { Typography, Card, CardContent } from "@mui/material";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
 import isBoolean from "lodash/isBoolean";
 import isEmpty from "lodash/isEmpty";
 import isUndefined from "lodash/isUndefined";
@@ -23,25 +27,29 @@ export default function DetailGrid({ title, properties }) {
       return !isEmpty(children);
     });
   return (
-    <Box mt={2}>
-      {title && (
-        <Typography variant="h6" gutterBottom mb={2}>
-          {title}
-        </Typography>
-      )}
-      <Grid container spacing={2} alignItems="center" justifyContent="flex-end">
-        {usedProperties.map(({ label, value, children }, index) => (
-          <React.Fragment key={index}>
-            <Grid item xs={4} sm={3} lg={2} sx={{ paddingTop: "5px!important" }}>
-              <Label>{label}</Label>
-            </Grid>
-            <Grid item xs={8} sm={9} lg={10} sx={{ paddingTop: "5px!important" }}>
-              <Value value={value}>{children}</Value>
-            </Grid>
-          </React.Fragment>
-        ))}
-      </Grid>
-    </Box>
+    <Card>
+      <CardContent sx={{ padding: 4 }}>
+        {title && (
+          <Typography variant="h6" gutterBottom mb={2}>
+            {title}
+          </Typography>
+        )}
+        <Table size="small">
+          <TableBody>
+            {usedProperties.map(({ label, value, children }, index) => (
+              <TableRow key={index}>
+                <TableCell sx={{ padding: 0.25, border: "none" }}>
+                  <Label>{label}</Label>
+                </TableCell>
+                <TableCell sx={{ padding: 0.25, border: "none" }}>
+                  <Value value={value}>{children}</Value>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/adminapp/src/components/OrganizationMembership.jsx
+++ b/adminapp/src/components/OrganizationMembership.jsx
@@ -1,0 +1,73 @@
+import formatDate from "../modules/formatDate";
+import AdminLink from "./AdminLink";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import VerifiedIcon from "@mui/icons-material/Verified";
+import React from "react";
+
+export function OrganizationMembershipUnverifiedIcon() {
+  return (
+    <CheckCircleOutlineIcon
+      color="error"
+      fontSize="small"
+      sx={{ verticalAlign: "middle", marginRight: 1 }}
+    />
+  );
+}
+
+export function OrganizationMembershipVerifiedIcon() {
+  return (
+    <VerifiedIcon
+      color="success"
+      fontSize="small"
+      sx={{ verticalAlign: "middle", marginRight: 1 }}
+    />
+  );
+}
+
+export function OrganizationMembershipRemovedIcon() {
+  return (
+    <VerifiedIcon
+      color="disabled"
+      fontSize="small"
+      sx={{ verticalAlign: "middle", marginRight: 1 }}
+    />
+  );
+}
+
+export default function OrganizationMembership({ membership, detailed }) {
+  if (membership.verifiedOrganization) {
+    return (
+      <>
+        <AdminLink model={membership.verifiedOrganization}>
+          <OrganizationMembershipVerifiedIcon />
+          {membership.verifiedOrganization.name}
+        </AdminLink>
+        {detailed && <>&nbsp;(verified)</>}
+      </>
+    );
+  }
+  if (membership.unverifiedOrganizationName) {
+    return (
+      <span>
+        <OrganizationMembershipUnverifiedIcon />
+        {membership.unverifiedOrganizationName}
+        {detailed && <>&nbsp;(unverified)</>}
+      </span>
+    );
+  }
+  return (
+    <AdminLink model={membership.formerOrganization}>
+      <OrganizationMembershipRemovedIcon />
+      {membership.formerOrganization?.name}
+      {detailed && (
+        <>
+          &nbsp;(removed{" "}
+          {formatDate(membership.formerlyInOrganizationAt, {
+            template: "l",
+          })}
+          )
+        </>
+      )}
+    </AdminLink>
+  );
+}

--- a/adminapp/src/components/RelatedList.jsx
+++ b/adminapp/src/components/RelatedList.jsx
@@ -4,7 +4,7 @@ import Link from "./Link";
 import "./RelatedList.css";
 import SimpleTable from "./SimpleTable";
 import ListAltIcon from "@mui/icons-material/ListAlt";
-import Box from "@mui/material/Box";
+import { Card, CardContent } from "@mui/material";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import clsx from "clsx";
@@ -47,6 +47,9 @@ export default function RelatedList({
     [expanded]
   );
 
+  if (showMore === undefined) {
+    showMore = true;
+  }
   if (showMore === true) {
     showMore = DEFAULT_SHOW_MORE;
   }
@@ -63,28 +66,35 @@ export default function RelatedList({
     className = clsx(className, "related-list-table-overflow");
   }
   return (
-    <Box mt={5}>
-      <div ref={topRef} />
-      {title && (
-        <Typography variant="h6" gutterBottom>
-          {title}
-        </Typography>
-      )}
-      {addNew && (
-        <Link to={addNewLink}>
-          <ListAltIcon sx={{ verticalAlign: "middle", marginRight: "5px" }} />
-          {addNewLabel}
-        </Link>
-      )}
-      <SimpleTable tableProps={tableProps} rows={rows} className={className} {...rest} />
-      {showExpandCollapse && (
-        <div className="related-list-expandcollapse">
-          {rowsTrimmed && <div className="related-list-overlay"></div>}
-          <Button variant="link" onClick={handleExpandCollapse}>
-            {rowsTrimmed ? "Expand" : "Collapse"}
-          </Button>
-        </div>
-      )}
-    </Box>
+    <Card>
+      <CardContent>
+        <div ref={topRef} />
+        {title && (
+          <Typography variant="h6" gutterBottom>
+            {title}
+          </Typography>
+        )}
+        {addNew && (
+          <Link to={addNewLink}>
+            <ListAltIcon sx={{ verticalAlign: "middle", marginRight: "5px" }} />
+            {addNewLabel}
+          </Link>
+        )}
+        <SimpleTable
+          tableProps={tableProps}
+          rows={rows}
+          className={className}
+          {...rest}
+        />
+        {showExpandCollapse && (
+          <div className="related-list-expandcollapse">
+            {rowsTrimmed && <div className="related-list-overlay"></div>}
+            <Button variant="link" onClick={handleExpandCollapse}>
+              {rowsTrimmed ? "Expand" : "Collapse"}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/adminapp/src/pages/AnonMemberContactDetailPage.jsx
+++ b/adminapp/src/pages/AnonMemberContactDetailPage.jsx
@@ -23,23 +23,20 @@ export default function AnonMemberContactDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
-          <RelatedList
-            title="Extenal Accounts"
-            rows={model.vendorAccounts}
-            showMore
-            headers={["Id", "Vendor"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink model={row} />,
-              <AdminLink model={row.configuration.vendor?.name}>
-                {row.configuration.vendor?.name}
-              </AdminLink>,
-            ]}
-          />
-        </>
-      )}
+      {(model) => [
+        <RelatedList
+          title="Extenal Accounts"
+          rows={model.vendorAccounts}
+          headers={["Id", "Vendor"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink model={row} />,
+            <AdminLink model={row.configuration.vendor?.name}>
+              {row.configuration.vendor?.name}
+            </AdminLink>,
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/BankAccountDetailPage.jsx
+++ b/adminapp/src/pages/BankAccountDetailPage.jsx
@@ -1,7 +1,7 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import DetailGrid from "../components/DetailGrid";
-import ResourceDetail from "../components/ResourceDetail";
+import ResourceDetail, { ResourceSummary } from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
@@ -38,14 +38,14 @@ export default function BankAccountDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
+      {(model) => [
+        <ResourceSummary>
           <LegalEntity
             address={model.legalEntity.address}
             name={model.legalEntity.name}
           />
-        </>
-      )}
+        </ResourceSummary>,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/BookTransactionDetailPage.jsx
+++ b/adminapp/src/pages/BookTransactionDetailPage.jsx
@@ -52,33 +52,31 @@ export default function BookTransactionDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
-          <RelatedList
-            title="Funding Transactions"
-            rows={model.fundingTransactions}
-            headers={["Id", "Created", "Status", "Amount"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              formatDate(row.createdAt),
-              row.status,
-              <Money key="amt">{row.amount}</Money>,
-            ]}
-          />
-          <RelatedList
-            title="Charges"
-            headers={["Id", "At", "Undiscounted Total", "Opaque Id"]}
-            rows={model.charges}
-            toCells={(row) => [
-              <AdminLink model={row} />,
-              formatDate(row.createdAt),
-              <Money key={3}>{row.undiscountedSubtotal}</Money>,
-              row.opaqueId,
-            ]}
-          />
-        </>
-      )}
+      {(model) => [
+        <RelatedList
+          title="Funding Transactions"
+          rows={model.fundingTransactions}
+          headers={["Id", "Created", "Status", "Amount"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            formatDate(row.createdAt),
+            row.status,
+            <Money key="amt">{row.amount}</Money>,
+          ]}
+        />,
+        <RelatedList
+          title="Charges"
+          headers={["Id", "At", "Undiscounted Total", "Opaque Id"]}
+          rows={model.charges}
+          toCells={(row) => [
+            <AdminLink model={row} />,
+            formatDate(row.createdAt),
+            <Money key={3}>{row.undiscountedSubtotal}</Money>,
+            row.opaqueId,
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/ChargeDetailPage.jsx
+++ b/adminapp/src/pages/ChargeDetailPage.jsx
@@ -34,90 +34,88 @@ export default function ChargeDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
-          {model.mobilityTrip && (
-            <DetailGrid
-              title="Mobility Trip"
-              properties={[
-                { label: "ID", value: <AdminLink model={model.mobilityTrip} /> },
-                {
-                  label: "Created At",
-                  value: formatDate(model.mobilityTrip.createdAt),
-                },
-                { label: "Vehicle ID", value: model.mobilityTrip.vehicleId },
-                {
-                  label: "Vendor Service",
-                  value: (
-                    <AdminLink model={model.mobilityTrip.vendorService}>
-                      {model.mobilityTrip.vendorService?.name}
-                    </AdminLink>
-                  ),
-                },
-                {
-                  label: "Started",
-                  value: formatDate(model.mobilityTrip.createdAt, { template: "ll LTS" }),
-                },
-                {
-                  label: "Ended",
-                  value: formatDate(model.mobilityTrip.createdAt, { template: "ll LTS" }),
-                },
-              ]}
-            />
-          )}
-          {model.commerceOrder && (
-            <DetailGrid
-              title="Commerce Order"
-              properties={[
-                { label: "ID", value: <AdminLink model={model.commerceOrder} /> },
-                {
-                  label: "Created At",
-                  value: formatDate(model.commerceOrder.createdAt),
-                },
-                { label: "Status", value: model.commerceOrder.statusLabel },
-              ]}
-            />
-          )}
-          <RelatedList
-            title="Line Items"
-            headers={["Id", "Amount", "Memo", "Originating", "Receiving"]}
-            rows={model.lineItems}
-            keyRowAttr="id"
-            toCells={(row) => [
-              row.id,
-              <Money key="amt" accounting>
-                {row.amount}
-              </Money>,
-              row.memo.en,
-              row.bookTransaction && (
-                <AdminLink key="originating" model={row.bookTransaction}>
-                  {row.bookTransaction.originatingLedger.adminLabel}
-                </AdminLink>
-              ),
-              row.bookTransaction && (
-                <AdminLink key="receiving" model={row.bookTransaction}>
-                  {row.bookTransaction.receivingLedger.adminLabel}
-                </AdminLink>
-              ),
+      {(model) => [
+        model.mobilityTrip && (
+          <DetailGrid
+            title="Mobility Trip"
+            properties={[
+              { label: "ID", value: <AdminLink model={model.mobilityTrip} /> },
+              {
+                label: "Created At",
+                value: formatDate(model.mobilityTrip.createdAt),
+              },
+              { label: "Vehicle ID", value: model.mobilityTrip.vehicleId },
+              {
+                label: "Vendor Service",
+                value: (
+                  <AdminLink model={model.mobilityTrip.vendorService}>
+                    {model.mobilityTrip.vendorService?.name}
+                  </AdminLink>
+                ),
+              },
+              {
+                label: "Started",
+                value: formatDate(model.mobilityTrip.createdAt, { template: "ll LTS" }),
+              },
+              {
+                label: "Ended",
+                value: formatDate(model.mobilityTrip.createdAt, { template: "ll LTS" }),
+              },
             ]}
           />
-          <RelatedList
-            title="Funding Transactions"
-            rows={model.associatedFundingTransactions}
-            headers={["Id", "Created", "Status", "Amount", "Originating Payment Account"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              formatDate(row.createdAt),
-              row.status,
-              <Money key="amt">{row.amount}</Money>,
-              <AdminLink model={row.originatingPaymentAccount}>
-                {row.originatingPaymentAccount.displayName}
-              </AdminLink>,
+        ),
+        model.commerceOrder && (
+          <DetailGrid
+            title="Commerce Order"
+            properties={[
+              { label: "ID", value: <AdminLink model={model.commerceOrder} /> },
+              {
+                label: "Created At",
+                value: formatDate(model.commerceOrder.createdAt),
+              },
+              { label: "Status", value: model.commerceOrder.statusLabel },
             ]}
           />
-        </>
-      )}
+        ),
+        <RelatedList
+          title="Line Items"
+          headers={["Id", "Amount", "Memo", "Originating", "Receiving"]}
+          rows={model.lineItems}
+          keyRowAttr="id"
+          toCells={(row) => [
+            row.id,
+            <Money key="amt" accounting>
+              {row.amount}
+            </Money>,
+            row.memo.en,
+            row.bookTransaction && (
+              <AdminLink key="originating" model={row.bookTransaction}>
+                {row.bookTransaction.originatingLedger.adminLabel}
+              </AdminLink>
+            ),
+            row.bookTransaction && (
+              <AdminLink key="receiving" model={row.bookTransaction}>
+                {row.bookTransaction.receivingLedger.adminLabel}
+              </AdminLink>
+            ),
+          ]}
+        />,
+        <RelatedList
+          title="Funding Transactions"
+          rows={model.associatedFundingTransactions}
+          headers={["Id", "Created", "Status", "Amount", "Originating Payment Account"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            formatDate(row.createdAt),
+            row.status,
+            <Money key="amt">{row.amount}</Money>,
+            <AdminLink model={row.originatingPaymentAccount}>
+              {row.originatingPaymentAccount.displayName}
+            </AdminLink>,
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/FundingTransactionDetailPage.jsx
+++ b/adminapp/src/pages/FundingTransactionDetailPage.jsx
@@ -31,49 +31,45 @@ export default function FundingTransactionDetailPage() {
     >
       {(model) => {
         const originated = model.originatedBookTransaction;
-        return (
-          <>
-            <DetailGrid
-              title="Book Transaction"
-              properties={[
-                { label: "ID", value: <AdminLink model={originated} /> },
-                { label: "Apply At", value: dayjs(originated.applyAt) },
-                { label: "Amount", value: <Money>{originated.amount}</Money> },
-                {
-                  label: "Category",
-                  value: originated.associatedVendorServiceCategory.name,
-                },
-                {
-                  label: "Originating",
-                  value: (
-                    <AdminLink model={originated.originatingLedger}>
-                      {originated.originatingLedger.adminLabel}
-                    </AdminLink>
-                  ),
-                },
-                {
-                  label: "Receiving",
-                  value: (
-                    <AdminLink model={originated.receivingLedger}>
-                      {originated.receivingLedger.adminLabel}
-                    </AdminLink>
-                  ),
-                },
-                {
-                  label: "Actor",
-                  hideEmpty: true,
-                  value: originated.actor ? (
-                    <AdminLink model={originated.actor}>
-                      {originated.actor.name}
-                    </AdminLink>
-                  ) : undefined,
-                },
-              ]}
-            />
-            <ExternalLinks externalLinks={model.externalLinks} />
-            <AuditLogs auditLogs={model.auditLogs} />
-          </>
-        );
+        return [
+          <DetailGrid
+            title="Book Transaction"
+            properties={[
+              { label: "ID", value: <AdminLink model={originated} /> },
+              { label: "Apply At", value: dayjs(originated.applyAt) },
+              { label: "Amount", value: <Money>{originated.amount}</Money> },
+              {
+                label: "Category",
+                value: originated.associatedVendorServiceCategory.name,
+              },
+              {
+                label: "Originating",
+                value: (
+                  <AdminLink model={originated.originatingLedger}>
+                    {originated.originatingLedger.adminLabel}
+                  </AdminLink>
+                ),
+              },
+              {
+                label: "Receiving",
+                value: (
+                  <AdminLink model={originated.receivingLedger}>
+                    {originated.receivingLedger.adminLabel}
+                  </AdminLink>
+                ),
+              },
+              {
+                label: "Actor",
+                hideEmpty: true,
+                value: originated.actor ? (
+                  <AdminLink model={originated.actor}>{originated.actor.name}</AdminLink>
+                ) : undefined,
+              },
+            ]}
+          />,
+          <ExternalLinks externalLinks={model.externalLinks} />,
+          <AuditLogs auditLogs={model.auditLogs} />,
+        ];
       }}
     </ResourceDetail>
   );

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -9,7 +9,7 @@ import OrganizationMembership from "../components/OrganizationMembership";
 import PaymentAccountRelatedLists from "../components/PaymentAccountRelatedLists";
 import ProgramEnrollmentRelatedList from "../components/ProgramEnrollmentRelatedList";
 import RelatedList from "../components/RelatedList";
-import ResourceDetail from "../components/ResourceDetail";
+import ResourceDetail, { ResourceSummary } from "../components/ResourceDetail";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
 import useRoleAccess from "../hooks/useRoleAccess";
 import { useUser } from "../hooks/user";
@@ -21,7 +21,6 @@ import SafeExternalLink from "../shared/react/SafeExternalLink";
 import useToggle from "../shared/react/useToggle";
 import DeleteIcon from "@mui/icons-material/Delete";
 import {
-  Divider,
   Typography,
   Switch,
   Button,
@@ -53,7 +52,6 @@ export default function MemberDetailPage() {
       <Typography variant="h5" gutterBottom>
         Member Details <ImpersonateButton id={id} />
       </Typography>
-      <Divider />
       <ResourceDetail
         resource="member"
         apiGet={api.getMember}
@@ -100,8 +98,8 @@ export default function MemberDetailPage() {
           },
         ]}
       >
-        {(model, setModel) => (
-          <>
+        {(model, setModel) => [
+          <ResourceSummary>
             <DetailGrid
               title="Other Information"
               properties={[
@@ -125,29 +123,31 @@ export default function MemberDetailPage() {
                 },
               ]}
             />
+          </ResourceSummary>,
+          <ResourceSummary>
             <LegalEntity {...model.legalEntity} />
-            <ProgramEnrollmentRelatedList
-              model={model}
-              resource="member"
-              enrollments={model.directProgramEnrollments}
-            />
-            <OrganizationMemberships
-              memberships={model.organizationMemberships}
-              model={model}
-            />
-            <Activities activities={model.activities} />
-            <Orders orders={model.orders} />
-            <Charges charges={model.charges} />
-            <BankAccounts bankAccounts={model.bankAccounts} />
-            <PaymentAccountRelatedLists paymentAccount={model.paymentAccount} />
-            <VendorAccounts vendorAccounts={model.vendorAccounts} />
-            <MessagePreferences preferences={model.preferences} />
-            <MessageDeliveries messageDeliveries={model.messageDeliveries} />
-            <Sessions sessions={model.sessions} />
-            <ResetCodes resetCodes={model.resetCodes} />
-            <AuditActivityList activities={model.auditActivities} />
-          </>
-        )}
+          </ResourceSummary>,
+          <ProgramEnrollmentRelatedList
+            model={model}
+            resource="member"
+            enrollments={model.directProgramEnrollments}
+          />,
+          <OrganizationMemberships
+            memberships={model.organizationMemberships}
+            model={model}
+          />,
+          <Activities activities={model.activities} />,
+          <Orders orders={model.orders} />,
+          <Charges charges={model.charges} />,
+          <BankAccounts bankAccounts={model.bankAccounts} />,
+          <PaymentAccountRelatedLists paymentAccount={model.paymentAccount} />,
+          <VendorAccounts vendorAccounts={model.vendorAccounts} />,
+          <MessagePreferences preferences={model.preferences} />,
+          <MessageDeliveries messageDeliveries={model.messageDeliveries} />,
+          <Sessions sessions={model.sessions} />,
+          <ResetCodes resetCodes={model.resetCodes} />,
+          <AuditActivityList activities={model.auditActivities} />,
+        ]}
       </ResourceDetail>
     </>
   );
@@ -206,7 +206,6 @@ function Activities({ activities }) {
       title="Activities"
       headers={["At", "Summary", "Message"]}
       rows={activities}
-      showMore
       keyRowAttr="id"
       toCells={(row) => [
         formatDate(row.createdAt),
@@ -225,7 +224,6 @@ function ResetCodes({ resetCodes }) {
       title="Login Codes"
       headers={["Sent", "Expires", "Token", "Used"]}
       rows={resetCodes}
-      showMore
       keyRowAttr="id"
       toCells={(row) => [
         formatDate(row.createdAt),
@@ -244,7 +242,6 @@ function Sessions({ sessions }) {
       headers={["Started", "IP", "User Agent"]}
       keyRowAttr="id"
       rows={sessions}
-      showMore
       toCells={(row) => [
         formatDate(row.createdAt),
         <SafeExternalLink key="ip" href={row.ipLookupLink}>
@@ -346,7 +343,6 @@ function MessageDeliveries({ messageDeliveries }) {
       title="Message Deliveries"
       headers={["Id", "Created", "Sent", "Template", "To"]}
       rows={messageDeliveries}
-      showMore
       keyRowAttr="id"
       toCells={(row) => [
         <AdminLink key="id" model={row} />,

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -5,6 +5,7 @@ import BoolCheckmark from "../components/BoolCheckmark";
 import Copyable from "../components/Copyable";
 import DetailGrid from "../components/DetailGrid";
 import InlineEditField from "../components/InlineEditField";
+import OrganizationMembership from "../components/OrganizationMembership";
 import PaymentAccountRelatedLists from "../components/PaymentAccountRelatedLists";
 import ProgramEnrollmentRelatedList from "../components/ProgramEnrollmentRelatedList";
 import RelatedList from "../components/RelatedList";
@@ -193,31 +194,10 @@ function OrganizationMemberships({ memberships, model }) {
       toCells={(row) => [
         <AdminLink key="id" model={row} />,
         formatDate(row.createdAt),
-        membershipOrgCell(row),
+        <OrganizationMembership membership={row} detailed />,
       ]}
     />
   );
-}
-
-function membershipOrgCell(row) {
-  if (row.verifiedOrganization) {
-    return (
-      <AdminLink key="org" model={row.verifiedOrganization}>
-        {row.verifiedOrganization.name}
-      </AdminLink>
-    );
-  }
-  if (row.formerOrganization) {
-    return (
-      <AdminLink key="org" model={row.formerOrganization}>
-        {row.formerOrganization?.name} (removed{" "}
-        {formatDate(row.formerlyInOrganizationAt, { template: "l" })})
-      </AdminLink>
-    );
-  }
-  if (row.unverifiedOrganizationName) {
-    return row.unverifiedOrganizationName;
-  }
 }
 
 function Activities({ activities }) {

--- a/adminapp/src/pages/MemberForm.jsx
+++ b/adminapp/src/pages/MemberForm.jsx
@@ -1,15 +1,8 @@
-import api from "../api";
 import AddressInputs from "../components/AddressInputs";
-import AutocompleteSearch from "../components/AutocompleteSearch";
 import FormLayout from "../components/FormLayout";
 import ResponsiveStack from "../components/ResponsiveStack";
 import RoleEditor from "../components/RoleEditor";
-import mergeAt from "../shared/mergeAt";
-import withoutAt from "../shared/withoutAt";
-import AddIcon from "@mui/icons-material/Add";
-import DeleteIcon from "@mui/icons-material/Delete";
-import { Box, Divider, FormLabel, Icon, Stack, TextField } from "@mui/material";
-import Button from "@mui/material/Button";
+import { Divider, FormLabel, Stack, TextField } from "@mui/material";
 import merge from "lodash/merge";
 import React from "react";
 
@@ -71,88 +64,7 @@ export default function MemberForm({
             setField("legalEntity", merge(resource.legalEntity, addressObj))
           }
         />
-        <Divider />
-        <OrganizationMemberships
-          memberships={resource.organizationMemberships}
-          setMemberships={(ms) => setField("organizationMemberships", ms)}
-          memberId={resource.id}
-        />
       </Stack>
     </FormLayout>
-  );
-}
-
-function OrganizationMemberships({ memberships, setMemberships, memberId }) {
-  // Include member id to associate with a new membership
-  const initialOrganizationMembership = {
-    verifiedOrganization: {},
-    member: { id: memberId },
-  };
-  const handleAdd = () => {
-    setMemberships([...memberships, initialOrganizationMembership]);
-  };
-  const handleRemove = (index) => {
-    setMemberships(withoutAt(memberships, index));
-  };
-  function handleChange(index, fields) {
-    setMemberships(mergeAt(memberships, index, fields));
-  }
-  return (
-    <>
-      <FormLabel>Organization Memberships</FormLabel>
-      {memberships.map((o, i) => (
-        <Membership
-          key={i}
-          {...o}
-          index={i}
-          onChange={(fields) => handleChange(i, fields)}
-          onRemove={() => handleRemove(i)}
-        />
-      ))}
-      <Button onClick={handleAdd}>
-        <AddIcon /> Add Organization Membership
-      </Button>
-    </>
-  );
-}
-
-function Membership({
-  index,
-  verifiedOrganization,
-  unverifiedOrganizationName,
-  onChange,
-  onRemove,
-}) {
-  let orgText = "The organization the member is a part of.";
-  if (unverifiedOrganizationName) {
-    orgText += ` The member has identified themselves with '${unverifiedOrganizationName}.'`;
-  }
-  return (
-    <Box sx={{ p: 2, border: "1px dashed grey" }}>
-      <Stack
-        direction="row"
-        spacing={2}
-        mb={2}
-        sx={{ justifyContent: "space-between", alignItems: "center" }}
-      >
-        <FormLabel>Membership {index + 1}</FormLabel>
-        <Button onClick={(e) => onRemove(e)} variant="warning" sx={{ marginLeft: "5px" }}>
-          <Icon color="warning">
-            <DeleteIcon />
-          </Icon>
-          Remove
-        </Button>
-      </Stack>
-      <AutocompleteSearch
-        label="Organization"
-        helperText={orgText}
-        value={verifiedOrganization?.name}
-        fullWidth
-        required
-        search={api.searchOrganizations}
-        style={{ flex: 1 }}
-        onValueSelect={(org) => onChange({ verifiedOrganization: org })}
-      />
-    </Box>
   );
 }

--- a/adminapp/src/pages/MobilityTripDetailPage.jsx
+++ b/adminapp/src/pages/MobilityTripDetailPage.jsx
@@ -50,50 +50,48 @@ export default function MobilityTripDetailPage() {
         { label: "Discount Amount", value: <Money>{model.discountAmount}</Money> },
       ]}
     >
-      {(model) => (
-        <>
-          {model.charge && (
-            <DetailGrid
-              title="Charge"
-              properties={[
-                { label: "ID", value: <AdminLink model={model.charge} /> },
-                {
-                  label: "Created At",
-                  value: formatDate(model.charge.createdAt),
-                },
-                { label: "Opaque ID", value: model.charge.opaqueId },
-                {
-                  label: "Discounted Subtotal",
-                  value: <Money>{model.charge.discountedSubtotal}</Money>,
-                },
-                {
-                  label: "Undiscounted Subtotal",
-                  value: <Money>{model.charge.undiscountedSubtotal}</Money>,
-                },
-              ]}
-            />
-          )}
+      {(model) => [
+        model.charge && (
           <DetailGrid
-            title="Rate"
+            title="Charge"
             properties={[
-              { label: "Id", value: model.rate.id },
-              { label: "Name", value: model.rate.name },
-              { label: "Created", value: formatDate(model.rate.createdAt) },
-              { label: "Unit Amount", value: <Money>{model.rate.unitAmount}</Money> },
-              { label: "Surcharge", value: <Money>{model.rate.surcharge}</Money> },
-              { label: "Unit Offset", value: model.rate.unitOffset },
+              { label: "ID", value: <AdminLink model={model.charge} /> },
               {
-                label: "Undiscounted Amount",
-                value: <Money>{model.rate.undiscountedAmount}</Money>,
+                label: "Created At",
+                value: formatDate(model.charge.createdAt),
+              },
+              { label: "Opaque ID", value: model.charge.opaqueId },
+              {
+                label: "Discounted Subtotal",
+                value: <Money>{model.charge.discountedSubtotal}</Money>,
               },
               {
-                label: "Undiscounted Surcharge",
-                value: <Money>{model.rate.undiscountedSurcharge}</Money>,
+                label: "Undiscounted Subtotal",
+                value: <Money>{model.charge.undiscountedSubtotal}</Money>,
               },
             ]}
           />
-        </>
-      )}
+        ),
+        <DetailGrid
+          title="Rate"
+          properties={[
+            { label: "Id", value: model.rate.id },
+            { label: "Name", value: model.rate.name },
+            { label: "Created", value: formatDate(model.rate.createdAt) },
+            { label: "Unit Amount", value: <Money>{model.rate.unitAmount}</Money> },
+            { label: "Surcharge", value: <Money>{model.rate.surcharge}</Money> },
+            { label: "Unit Offset", value: model.rate.unitOffset },
+            {
+              label: "Undiscounted Amount",
+              value: <Money>{model.rate.undiscountedAmount}</Money>,
+            },
+            {
+              label: "Undiscounted Surcharge",
+              value: <Money>{model.rate.undiscountedSurcharge}</Money>,
+            },
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/OfferingDetailPage.jsx
+++ b/adminapp/src/pages/OfferingDetailPage.jsx
@@ -85,68 +85,65 @@ export default function OfferingDetailPage() {
         },
       ]}
     >
-      {(model, setModel) => (
-        <>
-          <RelatedList
-            title="Fulfillment Options"
-            rows={model.fulfillmentOptions}
-            headers={["Id", "Description", "Type", "Address"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              row.id,
-              row.description.en,
-              row.type,
-              row.address && oneLineAddress(row.address, false),
-            ]}
-          />
-          <Programs
-            resource="offering"
-            programs={model.programs}
-            modelId={model.id}
-            replaceModelData={setModel}
-            makeUpdateRequest={api.updateOfferingPrograms}
-          />
-          <RelatedList
-            title={`Offering Products (${model.offeringProducts.length})`}
-            addNewLabel="Create Offering Product"
-            addNewLink={createRelativeUrl("/offering-product/new", {
-              offeringId: model.id,
-              offeringLabel: model.description.en,
-            })}
-            addNewRole="offering_product"
-            rows={model.offeringProducts}
-            headers={["Id", "Name", "Vendor", "Customer Price", "Full Price"]}
-            keyRowAttr="id"
-            rowClass={(row) => (row.closedAt ? classes.closed : "")}
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              <AdminLink key="id" model={row}>
-                {row.productName}
-              </AdminLink>,
-              row.vendorName,
-              <Money key="customer_price">{row.customerPrice}</Money>,
-              <Money key="undiscounted_price">{row.undiscountedPrice}</Money>,
-            ]}
-          />
-          <RelatedList
-            title={`Orders (${model.orders.length})`}
-            rows={model.orders}
-            showMore
-            headers={["Id", "Created", "Member", "Items", "Status"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              formatDate(row.createdAt),
-              <AdminLink key="mem" model={row.member}>
-                {row.member.name}
-              </AdminLink>,
-              row.totalItemCount,
-              row.statusLabel,
-            ]}
-          />
-          <AuditActivityList activities={model.auditActivities} />
-        </>
-      )}
+      {(model, setModel) => [
+        <RelatedList
+          title="Fulfillment Options"
+          rows={model.fulfillmentOptions}
+          headers={["Id", "Description", "Type", "Address"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            row.id,
+            row.description.en,
+            row.type,
+            row.address && oneLineAddress(row.address, false),
+          ]}
+        />,
+        <Programs
+          resource="offering"
+          programs={model.programs}
+          modelId={model.id}
+          replaceModelData={setModel}
+          makeUpdateRequest={api.updateOfferingPrograms}
+        />,
+        <RelatedList
+          title={`Offering Products (${model.offeringProducts.length})`}
+          addNewLabel="Create Offering Product"
+          addNewLink={createRelativeUrl("/offering-product/new", {
+            offeringId: model.id,
+            offeringLabel: model.description.en,
+          })}
+          addNewRole="offering_product"
+          rows={model.offeringProducts}
+          headers={["Id", "Name", "Vendor", "Customer Price", "Full Price"]}
+          keyRowAttr="id"
+          rowClass={(row) => (row.closedAt ? classes.closed : "")}
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            <AdminLink key="id" model={row}>
+              {row.productName}
+            </AdminLink>,
+            row.vendorName,
+            <Money key="customer_price">{row.customerPrice}</Money>,
+            <Money key="undiscounted_price">{row.undiscountedPrice}</Money>,
+          ]}
+        />,
+        <RelatedList
+          title={`Orders (${model.orders.length})`}
+          rows={model.orders}
+          headers={["Id", "Created", "Member", "Items", "Status"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            formatDate(row.createdAt),
+            <AdminLink key="mem" model={row.member}>
+              {row.member.name}
+            </AdminLink>,
+            row.totalItemCount,
+            row.statusLabel,
+          ]}
+        />,
+        <AuditActivityList activities={model.auditActivities} />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/OfferingProductDetailPage.jsx
+++ b/adminapp/src/pages/OfferingProductDetailPage.jsx
@@ -42,7 +42,7 @@ export default function OfferingProductDetailPage() {
         },
       ]}
     >
-      {(model) => (
+      {(model) => [
         <RelatedList
           title={`Orders (${model.orders.length})`}
           rows={model.orders}
@@ -57,8 +57,8 @@ export default function OfferingProductDetailPage() {
             row.totalItemCount,
             row.statusLabel,
           ]}
-        />
-      )}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/OrderDetailPage.jsx
+++ b/adminapp/src/pages/OrderDetailPage.jsx
@@ -33,62 +33,60 @@ export default function OrderDetailPage() {
         { label: "Total Charged", value: <Money>{model.fundedAmount}</Money> },
       ]}
     >
-      {(model) => (
-        <>
-          <DetailGrid
-            title="Checkout Details"
-            properties={[
-              {
-                label: "Undiscounted Cost",
-                value: <Money>{model.checkout.undiscountedCost}</Money>,
-              },
-              {
-                label: "Customer Cost",
-                value: <Money>{model.checkout.customerCost}</Money>,
-              },
-              { label: "Handling", value: <Money>{model.checkout.handling}</Money> },
-              { label: "Tax", value: <Money>{model.checkout.tax}</Money> },
-              { label: "Total", value: <Money>{model.checkout.total}</Money> },
-              {
-                label: "Instrument",
-                value: model.checkout.paymentInstrument?.adminLabel,
-              },
-              {
-                label: "Fulfillment (En)",
-                value: model.checkout.fulfillmentOption?.description.en,
-              },
-              {
-                label: "Fulfillment (Es)",
-                value: model.checkout.fulfillmentOption?.description.es,
-              },
-            ]}
-          />
-          <RelatedList
-            title="Items"
-            rows={model.items}
-            headers={[
-              "Quantity",
-              "Offering Product",
-              "Vendor",
-              "Customer Price",
-              "Full Price",
-            ]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              row.quantity,
-              <AdminLink key="id" model={row.offeringProduct}>
-                {row.offeringProduct.productName}
-              </AdminLink>,
-              row.offeringProduct.vendorName,
-              <Money key="customer_price">{row.offeringProduct.customerPrice}</Money>,
-              <Money key="undiscounted_price">
-                {row.offeringProduct.undiscountedPrice}
-              </Money>,
-            ]}
-          />
-          <AuditLogs auditLogs={model.auditLogs} />
-        </>
-      )}
+      {(model) => [
+        <DetailGrid
+          title="Checkout Details"
+          properties={[
+            {
+              label: "Undiscounted Cost",
+              value: <Money>{model.checkout.undiscountedCost}</Money>,
+            },
+            {
+              label: "Customer Cost",
+              value: <Money>{model.checkout.customerCost}</Money>,
+            },
+            { label: "Handling", value: <Money>{model.checkout.handling}</Money> },
+            { label: "Tax", value: <Money>{model.checkout.tax}</Money> },
+            { label: "Total", value: <Money>{model.checkout.total}</Money> },
+            {
+              label: "Instrument",
+              value: model.checkout.paymentInstrument?.adminLabel,
+            },
+            {
+              label: "Fulfillment (En)",
+              value: model.checkout.fulfillmentOption?.description.en,
+            },
+            {
+              label: "Fulfillment (Es)",
+              value: model.checkout.fulfillmentOption?.description.es,
+            },
+          ]}
+        />,
+        <RelatedList
+          title="Items"
+          rows={model.items}
+          headers={[
+            "Quantity",
+            "Offering Product",
+            "Vendor",
+            "Customer Price",
+            "Full Price",
+          ]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            row.quantity,
+            <AdminLink key="id" model={row.offeringProduct}>
+              {row.offeringProduct.productName}
+            </AdminLink>,
+            row.offeringProduct.vendorName,
+            <Money key="customer_price">{row.offeringProduct.customerPrice}</Money>,
+            <Money key="undiscounted_price">
+              {row.offeringProduct.undiscountedPrice}
+            </Money>,
+          ]}
+        />,
+        <AuditLogs auditLogs={model.auditLogs} />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -35,61 +35,57 @@ export default function OrganizationDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
-          <ProgramEnrollmentRelatedList
-            model={model}
-            resource="organization"
-            enrollments={model.programEnrollments}
-          />
-          <RelatedList
-            title={
-              <>
-                <OrganizationMembershipVerifiedIcon />
-                &nbsp;Memberships ({model.memberships.length}){" "}
-              </>
-            }
-            rows={model.memberships}
-            showMore
-            addNewLabel="Create another membership"
-            addNewLink={createRelativeUrl(`/membership/new`, {
-              organizationId: model.id,
-              organizationLabel: `(${model.id}) ${model.name || "-"}`,
-            })}
-            addNewRole="organizationMembership"
-            headers={["Id", "Member", "Added At"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink model={row} />,
-              <AdminLink key="member" model={row.member}>
-                {row.member.name}
-              </AdminLink>,
-              formatDate(row.createdAt),
-            ]}
-          />
-          <RelatedList
-            title={
-              <>
-                <OrganizationMembershipRemovedIcon />
-                &nbsp;Former Memberships ({model.formerMemberships.length})
-              </>
-            }
-            rows={model.formerMemberships}
-            showMore
-            headers={["Id", "Member", "Added At", "Removed At"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink model={row} />,
-              <AdminLink key="member" model={row.member}>
-                {row.member.name}
-              </AdminLink>,
-              formatDate(row.createdAt),
-              formatDate(row.formerlyInOrganizationAt),
-            ]}
-          />
-          <AuditActivityList activities={model.auditActivities} />
-        </>
-      )}
+      {(model) => [
+        <ProgramEnrollmentRelatedList
+          model={model}
+          resource="organization"
+          enrollments={model.programEnrollments}
+        />,
+        <RelatedList
+          title={
+            <>
+              <OrganizationMembershipVerifiedIcon />
+              &nbsp;Memberships ({model.memberships.length}){" "}
+            </>
+          }
+          rows={model.memberships}
+          addNewLabel="Create another membership"
+          addNewLink={createRelativeUrl(`/membership/new`, {
+            organizationId: model.id,
+            organizationLabel: `(${model.id}) ${model.name || "-"}`,
+          })}
+          addNewRole="organizationMembership"
+          headers={["Id", "Member", "Added At"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink model={row} />,
+            <AdminLink key="member" model={row.member}>
+              {row.member.name}
+            </AdminLink>,
+            formatDate(row.createdAt),
+          ]}
+        />,
+        <RelatedList
+          title={
+            <>
+              <OrganizationMembershipRemovedIcon />
+              &nbsp;Former Memberships ({model.formerMemberships.length})
+            </>
+          }
+          rows={model.formerMemberships}
+          headers={["Id", "Member", "Added At", "Removed At"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink model={row} />,
+            <AdminLink key="member" model={row.member}>
+              {row.member.name}
+            </AdminLink>,
+            formatDate(row.createdAt),
+            formatDate(row.formerlyInOrganizationAt),
+          ]}
+        />,
+        <AuditActivityList activities={model.auditActivities} />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -1,6 +1,10 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
 import AuditActivityList from "../components/AuditActivityList";
+import {
+  OrganizationMembershipRemovedIcon,
+  OrganizationMembershipVerifiedIcon,
+} from "../components/OrganizationMembership";
 import ProgramEnrollmentRelatedList from "../components/ProgramEnrollmentRelatedList";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
@@ -39,7 +43,12 @@ export default function OrganizationDetailPage() {
             enrollments={model.programEnrollments}
           />
           <RelatedList
-            title={`Memberships (${model.memberships.length})`}
+            title={
+              <>
+                <OrganizationMembershipVerifiedIcon />
+                &nbsp;Memberships ({model.memberships.length}){" "}
+              </>
+            }
             rows={model.memberships}
             showMore
             addNewLabel="Create another membership"
@@ -48,7 +57,7 @@ export default function OrganizationDetailPage() {
               organizationLabel: `(${model.id}) ${model.name || "-"}`,
             })}
             addNewRole="organizationMembership"
-            headers={["Id", "Member", "Created At"]}
+            headers={["Id", "Member", "Added At"]}
             keyRowAttr="id"
             toCells={(row) => [
               <AdminLink model={row} />,
@@ -56,6 +65,26 @@ export default function OrganizationDetailPage() {
                 {row.member.name}
               </AdminLink>,
               formatDate(row.createdAt),
+            ]}
+          />
+          <RelatedList
+            title={
+              <>
+                <OrganizationMembershipRemovedIcon />
+                &nbsp;Former Memberships ({model.formerMemberships.length})
+              </>
+            }
+            rows={model.formerMemberships}
+            showMore
+            headers={["Id", "Member", "Added At", "Removed At"]}
+            keyRowAttr="id"
+            toCells={(row) => [
+              <AdminLink model={row} />,
+              <AdminLink key="member" model={row.member}>
+                {row.member.name}
+              </AdminLink>,
+              formatDate(row.createdAt),
+              formatDate(row.formerlyInOrganizationAt),
             ]}
           />
           <AuditActivityList activities={model.auditActivities} />

--- a/adminapp/src/pages/OrganizationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationDetailPage.jsx
@@ -21,6 +21,7 @@ export default function OrganizationDetailPage() {
         { label: "Created At", value: dayjs(model.createdAt) },
         { label: "Updated At", value: dayjs(model.updatedAt) },
         { label: "Name", value: model.name },
+        { label: "Ordinal", value: model.ordinal },
         {
           label: "Roles",
           children: model.roles.map((role) => (

--- a/adminapp/src/pages/OrganizationForm.jsx
+++ b/adminapp/src/pages/OrganizationForm.jsx
@@ -1,6 +1,6 @@
 import FormLayout from "../components/FormLayout";
 import RoleEditor from "../components/RoleEditor";
-import { TextField } from "@mui/material";
+import { Stack, TextField } from "@mui/material";
 import React from "react";
 
 export default function OrganizationForm({
@@ -22,18 +22,32 @@ export default function OrganizationForm({
       onSubmit={onSubmit}
       isBusy={isBusy}
     >
-      <TextField
-        {...register("name")}
-        label="Name"
-        name="name"
-        value={resource.name}
-        type="name"
-        variant="outlined"
-        fullWidth
-        required
-        onChange={setFieldFromInput}
-      />
-      <RoleEditor roles={resource.roles} setRoles={(r) => setField("roles", r)} />
+      <Stack spacing={2}>
+        <TextField
+          {...register("name")}
+          label="Name"
+          name="name"
+          value={resource.name}
+          type="name"
+          variant="outlined"
+          fullWidth
+          required
+          onChange={setFieldFromInput}
+        />
+        <TextField
+          {...register("ordinal")}
+          label="Ordinal"
+          helperText="The order in which organizations are displayed in the member onboarding flow, higher first."
+          name="ordinal"
+          value={resource.ordinal}
+          type="number"
+          variant="outlined"
+          fullWidth
+          required
+          onChange={setFieldFromInput}
+        />
+        <RoleEditor roles={resource.roles} setRoles={(r) => setField("roles", r)} />
+      </Stack>
     </FormLayout>
   );
 }

--- a/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipDetailPage.jsx
@@ -1,8 +1,8 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import OrganizationMembership from "../components/OrganizationMembership";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
-import formatDate from "../modules/formatDate";
 import React from "react";
 
 export default function OrganizationMembershipDetailPage() {
@@ -23,26 +23,9 @@ export default function OrganizationMembershipDetailPage() {
             </AdminLink>
           ),
         },
-        model.verifiedOrganization && {
-          label: "Verified Organization",
-          value: (
-            <AdminLink key="org" model={model.verifiedOrganization}>
-              {model.verifiedOrganization?.name}
-            </AdminLink>
-          ),
-        },
-        model.unverifiedOrganizationName && {
-          label: "Unverified Organization",
-          value: model.unverifiedOrganizationName,
-        },
-        model.formerOrganization && {
-          label: "Former Organization",
-          value: (
-            <AdminLink key="org" model={model.formerOrganization}>
-              {model.formerOrganization?.name} (removed{" "}
-              {formatDate(model.formerlyInOrganizationAt)})
-            </AdminLink>
-          ),
+        {
+          label: "Organization",
+          value: <OrganizationMembership membership={model} detailed />,
         },
       ]}
     />

--- a/adminapp/src/pages/OrganizationMembershipListPage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipListPage.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import OrganizationMembership from "../components/OrganizationMembership";
 import ResourceList from "../components/ResourceList";
 import formatDate from "../modules/formatDate";
 import React from "react";
@@ -29,14 +30,7 @@ export default function OrganizationMembershipListPage() {
           id: "organization",
           label: "Organization",
           align: "left",
-          render: (c) =>
-            c.verifiedOrganization ? (
-              <AdminLink model={c.verifiedOrganization}>
-                {c.verifiedOrganization.name}
-              </AdminLink>
-            ) : (
-              c.unverifiedOrganizationName
-            ),
+          render: (c) => <OrganizationMembership membership={c} />,
         },
         {
           id: "created_at",

--- a/adminapp/src/pages/PaymentLedgerDetailPage.jsx
+++ b/adminapp/src/pages/PaymentLedgerDetailPage.jsx
@@ -28,22 +28,20 @@ export default function PaymentLedgerDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
-          <RelatedList
-            title="Vendor Service Categories"
-            headers={["Id", "Name", "Slug"]}
-            rows={model.vendorServiceCategories}
-            keyRowAttr="id"
-            toCells={(row) => [row.id, row.name, row.slug]}
-          />
-          <LedgerBookTransactionsRelatedList
-            ledger={model}
-            title="Book Transactions"
-            rows={model.combinedBookTransactions}
-          />
-        </>
-      )}
+      {(model) => [
+        <RelatedList
+          title="Vendor Service Categories"
+          headers={["Id", "Name", "Slug"]}
+          rows={model.vendorServiceCategories}
+          keyRowAttr="id"
+          toCells={(row) => [row.id, row.name, row.slug]}
+        />,
+        <LedgerBookTransactionsRelatedList
+          ledger={model}
+          title="Book Transactions"
+          rows={model.combinedBookTransactions}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/PaymentTriggerDetailPage.jsx
+++ b/adminapp/src/pages/PaymentTriggerDetailPage.jsx
@@ -49,61 +49,58 @@ export default function PaymentTriggerDetailPage() {
         },
       ]}
     >
-      {(model, setModel) => (
-        <>
-          <Programs
-            resource="payment_trigger"
-            programs={model.programs}
-            modelId={model.id}
-            replaceModelData={setModel}
-            makeUpdateRequest={api.updatePaymentTriggerPrograms}
-          />
-          <RelatedList
-            title="Executions"
-            rows={model.executions}
-            showMore
-            keyRowAttr="id"
-            headers={["Id", "At", "To"]}
-            toCells={(row) => [
-              <AdminLink key="bookx" model={row}>
-                {row.bookTransactionId}
-              </AdminLink>,
-              formatDate(row.at),
-              <AdminLink key="recledger" model={row}>
-                {row.receivingLedger.adminLabel}
-              </AdminLink>,
-            ]}
-          />
-          <RelatedList
-            title="Vendor Configurations"
-            rows={model.configurations}
-            keyRowAttr="id"
-            headers={[
-              "Id",
-              "Created",
-              "Vendor",
-              "App Install Link",
-              "Uses Email",
-              "Uses SMS",
-              "Enabled",
-            ]}
-            toCells={(row) => [
-              row.id,
-              formatDate(row.createdAt),
-              <AdminLink key={row.vendor.name} model={row.vendor}>
-                {row.vendor.name}
-              </AdminLink>,
-              <SafeExternalLink key={1} href={row.appInstallLink}>
-                {row.appInstallLink}
-              </SafeExternalLink>,
-              row.usesEmail ? "Yes" : "No",
-              row.usesSms ? "Yes" : "No",
-              row.enabled ? "Yes" : "No",
-            ]}
-          />
-          <AuditActivityList activities={model.auditActivities} />
-        </>
-      )}
+      {(model, setModel) => [
+        <Programs
+          resource="payment_trigger"
+          programs={model.programs}
+          modelId={model.id}
+          replaceModelData={setModel}
+          makeUpdateRequest={api.updatePaymentTriggerPrograms}
+        />,
+        <RelatedList
+          title="Executions"
+          rows={model.executions}
+          keyRowAttr="id"
+          headers={["Id", "At", "To"]}
+          toCells={(row) => [
+            <AdminLink key="bookx" model={row}>
+              {row.bookTransactionId}
+            </AdminLink>,
+            formatDate(row.at),
+            <AdminLink key="recledger" model={row}>
+              {row.receivingLedger.adminLabel}
+            </AdminLink>,
+          ]}
+        />,
+        <RelatedList
+          title="Vendor Configurations"
+          rows={model.configurations}
+          keyRowAttr="id"
+          headers={[
+            "Id",
+            "Created",
+            "Vendor",
+            "App Install Link",
+            "Uses Email",
+            "Uses SMS",
+            "Enabled",
+          ]}
+          toCells={(row) => [
+            row.id,
+            formatDate(row.createdAt),
+            <AdminLink key={row.vendor.name} model={row.vendor}>
+              {row.vendor.name}
+            </AdminLink>,
+            <SafeExternalLink key={1} href={row.appInstallLink}>
+              {row.appInstallLink}
+            </SafeExternalLink>,
+            row.usesEmail ? "Yes" : "No",
+            row.usesSms ? "Yes" : "No",
+            row.enabled ? "Yes" : "No",
+          ]}
+        />,
+        <AuditActivityList activities={model.auditActivities} />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/PayoutTransactionDetailPage.jsx
+++ b/adminapp/src/pages/PayoutTransactionDetailPage.jsx
@@ -27,70 +27,68 @@ export default function PayoutTransactionDetailPage() {
           originatedBookTransaction: originated,
           creditingBookTransaction: crediting,
         } = model;
-        return (
-          <>
+        return [
+          <DetailGrid
+            title="Originated Book Transaction"
+            properties={[
+              { label: "ID", value: <AdminLink model={originated} /> },
+              { label: "Apply At", value: dayjs(originated.applyAt) },
+              { label: "Amount", value: <Money>{originated.amount}</Money> },
+              {
+                label: "Category",
+                value: originated.associatedVendorServiceCategory?.name,
+              },
+              {
+                label: "Originating",
+                value: (
+                  <AdminLink model={originated.originatingLedger}>
+                    {originated.originatingLedger.adminLabel}
+                  </AdminLink>
+                ),
+              },
+              {
+                label: "Receiving",
+                value: (
+                  <AdminLink model={originated.receivingLedger}>
+                    {originated.receivingLedger.adminLabel}
+                  </AdminLink>
+                ),
+              },
+            ]}
+          />,
+          crediting && (
             <DetailGrid
-              title="Originated Book Transaction"
+              title="Crediting Book Transaction"
               properties={[
-                { label: "ID", value: <AdminLink model={originated} /> },
-                { label: "Apply At", value: dayjs(originated.applyAt) },
-                { label: "Amount", value: <Money>{originated.amount}</Money> },
+                { label: "ID", value: <AdminLink model={crediting} /> },
+                { label: "Apply At", value: dayjs(crediting.applyAt) },
+                { label: "Amount", value: <Money>{crediting.amount}</Money> },
                 {
                   label: "Category",
-                  value: originated.associatedVendorServiceCategory?.name,
+                  value: crediting.associatedVendorServiceCategory?.name,
                 },
                 {
                   label: "Originating",
                   value: (
-                    <AdminLink model={originated.originatingLedger}>
-                      {originated.originatingLedger.adminLabel}
+                    <AdminLink model={crediting.originatingLedger}>
+                      {crediting.originatingLedger.adminLabel}
                     </AdminLink>
                   ),
                 },
                 {
                   label: "Receiving",
                   value: (
-                    <AdminLink model={originated.receivingLedger}>
-                      {originated.receivingLedger.adminLabel}
+                    <AdminLink model={crediting.receivingLedger}>
+                      {crediting.receivingLedger.adminLabel}
                     </AdminLink>
                   ),
                 },
               ]}
             />
-            {crediting && (
-              <DetailGrid
-                title="Crediting Book Transaction"
-                properties={[
-                  { label: "ID", value: <AdminLink model={crediting} /> },
-                  { label: "Apply At", value: dayjs(crediting.applyAt) },
-                  { label: "Amount", value: <Money>{crediting.amount}</Money> },
-                  {
-                    label: "Category",
-                    value: crediting.associatedVendorServiceCategory?.name,
-                  },
-                  {
-                    label: "Originating",
-                    value: (
-                      <AdminLink model={crediting.originatingLedger}>
-                        {crediting.originatingLedger.adminLabel}
-                      </AdminLink>
-                    ),
-                  },
-                  {
-                    label: "Receiving",
-                    value: (
-                      <AdminLink model={crediting.receivingLedger}>
-                        {crediting.receivingLedger.adminLabel}
-                      </AdminLink>
-                    ),
-                  },
-                ]}
-              />
-            )}
-            <ExternalLinks externalLinks={model.externalLinks} />
-            <AuditLogs auditLogs={model.auditLogs} />
-          </>
-        );
+          ),
+          <ExternalLinks externalLinks={model.externalLinks} />,
+          <AuditLogs auditLogs={model.auditLogs} />,
+        ];
       }}
     </ResourceDetail>
   );

--- a/adminapp/src/pages/ProductDetailPage.jsx
+++ b/adminapp/src/pages/ProductDetailPage.jsx
@@ -55,45 +55,43 @@ export default function ProductDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
-          <RelatedList
-            title={`Offering Products (${model.offeringProducts?.length})`}
-            addNewLabel="Create Offering Product"
-            addNewLink={createRelativeUrl("/offering-product/new", {
-              productId: model.id,
-              productLabel: model.name.en,
-            })}
-            addNewRole="offering_product"
-            rows={model.offeringProducts}
-            headers={["Id", "Customer Price", "Full Price", "Offering", "Closed"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key={row.id} model={row} />,
-              <Money key="customer_price">{row.customerPrice}</Money>,
-              <Money key="undiscounted_price">{row.undiscountedPrice}</Money>,
-              <AdminLink key="offering" model={row.offering}>
-                {row.offering.description.en}
-              </AdminLink>,
-              row.isClosed ? dayjs(row.closedAt).format("lll") : "",
-            ]}
-          />
-          <RelatedList
-            title={`Orders (${model.orders?.length})`}
-            rows={model.orders}
-            headers={["Id", "Created At", "Status", "Member"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              formatDate(row.createdAt),
-              row.orderStatus,
-              <AdminLink key="member" model={row.member}>
-                {row.member.name}
-              </AdminLink>,
-            ]}
-          />
-        </>
-      )}
+      {(model) => [
+        <RelatedList
+          title={`Offering Products (${model.offeringProducts?.length})`}
+          addNewLabel="Create Offering Product"
+          addNewLink={createRelativeUrl("/offering-product/new", {
+            productId: model.id,
+            productLabel: model.name.en,
+          })}
+          addNewRole="offering_product"
+          rows={model.offeringProducts}
+          headers={["Id", "Customer Price", "Full Price", "Offering", "Closed"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key={row.id} model={row} />,
+            <Money key="customer_price">{row.customerPrice}</Money>,
+            <Money key="undiscounted_price">{row.undiscountedPrice}</Money>,
+            <AdminLink key="offering" model={row.offering}>
+              {row.offering.description.en}
+            </AdminLink>,
+            row.isClosed ? dayjs(row.closedAt).format("lll") : "",
+          ]}
+        />,
+        <RelatedList
+          title={`Orders (${model.orders?.length})`}
+          rows={model.orders}
+          headers={["Id", "Created At", "Status", "Member"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            formatDate(row.createdAt),
+            row.orderStatus,
+            <AdminLink key="member" model={row.member}>
+              {row.member.name}
+            </AdminLink>,
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/ProgramDetailPage.jsx
+++ b/adminapp/src/pages/ProgramDetailPage.jsx
@@ -43,102 +43,95 @@ export default function ProgramDetailPage() {
         { label: "Lyft Pass Program", value: model.lyftPassProgramId },
       ]}
     >
-      {(model) => (
-        <>
-          <RelatedList
-            title={`Commerce Offerings (${model.commerceOfferings?.length})`}
-            rows={model.commerceOfferings}
-            showMore
-            headers={["Id", "Description", "Opening Date", "Closing Date"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              <AdminLink model={row}>{row.description.en}</AdminLink>,
-              formatDate(row.periodBegin),
-              formatDate(row.periodEnd),
-            ]}
-          />
-          <RelatedList
-            title={`Vendor Services (${model.vendorServices?.length})`}
-            rows={model.vendorServices}
-            showMore
-            headers={["Id", "Name", "Vendor", "Opening Date", "Closing Date"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              <AdminLink key="name" model={row}>
-                {row.name}
-              </AdminLink>,
-              <AdminLink key="vendor_name" model={row.vendor}>
-                {row.vendor.name}
-              </AdminLink>,
-              formatDate(row.periodBegin),
-              formatDate(row.periodEnd),
-            ]}
-          />
-          <RelatedList
-            title={`Payment Triggers (${model.paymentTriggers?.length})`}
-            rows={model.paymentTriggers}
-            showMore
-            headers={["Id", "Label", "Opening Date", "Closing Date"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              <AdminLink model={row}>{row.label}</AdminLink>,
-              formatDate(row.activeDuringBegin),
-              formatDate(row.activeDuringEnd),
-            ]}
-          />
-          <RelatedList
-            title={`Vendor Configurations (${model.configurations?.length})`}
-            rows={model.configurations}
-            showMore
-            keyRowAttr="id"
-            headers={[
-              "Id",
-              "Created",
-              "Vendor",
-              "App Install Link",
-              "Uses Email",
-              "Uses SMS",
-              "Enabled",
-            ]}
-            toCells={(row) => [
-              <AdminLink model={row} />,
-              formatDate(row.createdAt),
-              <AdminLink key={row.vendor.name} model={row.vendor}>
-                {row.vendor.name}
-              </AdminLink>,
-              <SafeExternalLink key={1} href={row.appInstallLink}>
-                {row.appInstallLink}
-              </SafeExternalLink>,
-              row.usesEmail ? "Yes" : "No",
-              row.usesSms ? "Yes" : "No",
-              row.enabled ? "Yes" : "No",
-            ]}
-          />
-          <RelatedList
-            title="Program Enrollments"
-            headers={["Id", "Enrollee", "Enrollee Type", "Approved At", "Unenrolled At"]}
-            rows={model.enrollments}
-            showMore
-            addNewLabel="Enroll member, organization or role"
-            addNewLink={createRelativeUrl(`/program-enrollment/new`, {
-              programId: model.id,
-              programLabel: `(${model.id}) ${model.name.en}`,
-            })}
-            addNewRole="program"
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              <AdminLink model={row.enrollee}>{row.enrollee?.name}</AdminLink>,
-              row.enrolleeType,
-              dayjsOrNull(row.approvedAt)?.format("lll"),
-              dayjsOrNull(row.unenrolledAt)?.format("lll"),
-            ]}
-          />
-        </>
-      )}
+      {(model) => [
+        <RelatedList
+          title={`Commerce Offerings (${model.commerceOfferings?.length})`}
+          rows={model.commerceOfferings}
+          headers={["Id", "Description", "Opening Date", "Closing Date"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            <AdminLink model={row}>{row.description.en}</AdminLink>,
+            formatDate(row.periodBegin),
+            formatDate(row.periodEnd),
+          ]}
+        />,
+        <RelatedList
+          title={`Vendor Services (${model.vendorServices?.length})`}
+          rows={model.vendorServices}
+          headers={["Id", "Name", "Vendor", "Opening Date", "Closing Date"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            <AdminLink key="name" model={row}>
+              {row.name}
+            </AdminLink>,
+            <AdminLink key="vendor_name" model={row.vendor}>
+              {row.vendor.name}
+            </AdminLink>,
+            formatDate(row.periodBegin),
+            formatDate(row.periodEnd),
+          ]}
+        />,
+        <RelatedList
+          title={`Payment Triggers (${model.paymentTriggers?.length})`}
+          rows={model.paymentTriggers}
+          headers={["Id", "Label", "Opening Date", "Closing Date"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            <AdminLink model={row}>{row.label}</AdminLink>,
+            formatDate(row.activeDuringBegin),
+            formatDate(row.activeDuringEnd),
+          ]}
+        />,
+        <RelatedList
+          title={`Vendor Configurations (${model.configurations?.length})`}
+          rows={model.configurations}
+          keyRowAttr="id"
+          headers={[
+            "Id",
+            "Created",
+            "Vendor",
+            "App Install Link",
+            "Uses Email",
+            "Uses SMS",
+            "Enabled",
+          ]}
+          toCells={(row) => [
+            <AdminLink model={row} />,
+            formatDate(row.createdAt),
+            <AdminLink key={row.vendor.name} model={row.vendor}>
+              {row.vendor.name}
+            </AdminLink>,
+            <SafeExternalLink key={1} href={row.appInstallLink}>
+              {row.appInstallLink}
+            </SafeExternalLink>,
+            row.usesEmail ? "Yes" : "No",
+            row.usesSms ? "Yes" : "No",
+            row.enabled ? "Yes" : "No",
+          ]}
+        />,
+        <RelatedList
+          title="Program Enrollments"
+          headers={["Id", "Enrollee", "Enrollee Type", "Approved At", "Unenrolled At"]}
+          rows={model.enrollments}
+          addNewLabel="Enroll member, organization or role"
+          addNewLink={createRelativeUrl(`/program-enrollment/new`, {
+            programId: model.id,
+            programLabel: `(${model.id}) ${model.name.en}`,
+          })}
+          addNewRole="program"
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            <AdminLink model={row.enrollee}>{row.enrollee?.name}</AdminLink>,
+            row.enrolleeType,
+            dayjsOrNull(row.approvedAt)?.format("lll"),
+            dayjsOrNull(row.unenrolledAt)?.format("lll"),
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/RoleDetailPage.jsx
+++ b/adminapp/src/pages/RoleDetailPage.jsx
@@ -15,40 +15,38 @@ export default function RoleDetailPage() {
         { label: "Name", value: model.name },
       ]}
     >
-      {(model, setModel) => (
-        <>
-          <RelatedList
-            title="Members"
-            rows={model.members}
-            headers={["Id", "Name", "Phone"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              row.name,
-              formatPhoneNumber("+" + row.phone),
-            ]}
-          />
-          <RelatedList
-            title="Organizations"
-            rows={model.organizations}
-            headers={["Id", "Name"]}
-            keyRowAttr="id"
-            toCells={(row) => [<AdminLink key="id" model={row} />, row.name]}
-          />
-          <RelatedList
-            title="Program Enrollments"
-            rows={model.programEnrollments}
-            headers={["Id", "Program"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              <AdminLink key="name" model={row.program}>
-                {row.program.name.en}
-              </AdminLink>,
-            ]}
-          />
-        </>
-      )}
+      {(model, setModel) => [
+        <RelatedList
+          title="Members"
+          rows={model.members}
+          headers={["Id", "Name", "Phone"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            row.name,
+            formatPhoneNumber("+" + row.phone),
+          ]}
+        />,
+        <RelatedList
+          title="Organizations"
+          rows={model.organizations}
+          headers={["Id", "Name"]}
+          keyRowAttr="id"
+          toCells={(row) => [<AdminLink key="id" model={row} />, row.name]}
+        />,
+        <RelatedList
+          title="Program Enrollments"
+          rows={model.programEnrollments}
+          headers={["Id", "Program"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            <AdminLink key="name" model={row.program}>
+              {row.program.name.en}
+            </AdminLink>,
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -45,69 +45,66 @@ export default function VendorAccountDetailPage() {
         },
       ]}
     >
-      {(model) => (
-        <>
+      {(model) => [
+        <DetailGrid
+          title="Configuration"
+          properties={[
+            { label: "ID", value: <AdminLink model={model.configuration} /> },
+            {
+              label: "Vendor",
+              value: (
+                <AdminLink model={model.configuration.vendor}>
+                  {model.configuration.vendor?.name}
+                </AdminLink>
+              ),
+            },
+            {
+              label: "Auth to Vendor",
+              value: model.configuration.authToVendorKey,
+            },
+            {
+              label: "Enabled?",
+              value: <BoolCheckmark>{model.configuration.enabled}</BoolCheckmark>,
+            },
+          ]}
+        />,
+        model.contact && (
           <DetailGrid
-            title="Configuration"
+            title="Member Contact"
             properties={[
-              { label: "ID", value: <AdminLink model={model.configuration} /> },
-              {
-                label: "Vendor",
-                value: (
-                  <AdminLink model={model.configuration.vendor}>
-                    {model.configuration.vendor?.name}
-                  </AdminLink>
-                ),
-              },
-              {
-                label: "Auth to Vendor",
-                value: model.configuration.authToVendorKey,
-              },
-              {
-                label: "Enabled?",
-                value: <BoolCheckmark>{model.configuration.enabled}</BoolCheckmark>,
-              },
+              { label: "ID", value: <AdminLink model={model.contact} /> },
+              { label: "Email", value: model.contact.email },
+              { label: "Phone", value: model.contact.phone },
+              { label: "Relay Key", value: model.contact.relayKey },
             ]}
           />
-          {model.contact && (
-            <DetailGrid
-              title="Member Contact"
-              properties={[
-                { label: "ID", value: <AdminLink model={model.contact} /> },
-                { label: "Email", value: model.contact.email },
-                { label: "Phone", value: model.contact.phone },
-                { label: "Relay Key", value: model.contact.relayKey },
-              ]}
-            />
-          )}
-          <RelatedList
-            title="Messages"
-            rows={model.messages}
-            showMore
-            headers={[
-              "Id",
-              "Created",
-              "Content",
-              "From",
-              "To",
-              "Handler Key",
-              "Relay Key",
-              "Timestamp",
-            ]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              row.id,
-              formatDate(row.createdAt),
-              row.messageContent,
-              row.messageFrom,
-              row.messageTo,
-              row.messageHandlerKey,
-              row.relayKey,
-              formatDate(row.messageTimestamp),
-            ]}
-          />
-        </>
-      )}
+        ),
+        <RelatedList
+          title="Messages"
+          rows={model.messages}
+          headers={[
+            "Id",
+            "Created",
+            "Content",
+            "From",
+            "To",
+            "Handler Key",
+            "Relay Key",
+            "Timestamp",
+          ]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            row.id,
+            formatDate(row.createdAt),
+            row.messageContent,
+            row.messageFrom,
+            row.messageTo,
+            row.messageHandlerKey,
+            row.relayKey,
+            formatDate(row.messageTimestamp),
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/VendorConfigurationDetailPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationDetailPage.jsx
@@ -43,18 +43,16 @@ export default function VendorConfigurationDetailPage() {
         },
       ]}
     >
-      {(model, setModel) => (
-        <>
-          <Programs
-            resource="vendor_configuration"
-            programs={model.programs}
-            modelId={model.id}
-            replaceModelData={setModel}
-            makeUpdateRequest={api.updateVendorConfigurationPrograms}
-          />
-          <AuditActivityList activities={model.auditActivities} />
-        </>
-      )}
+      {(model, setModel) => [
+        <Programs
+          resource="vendor_configuration"
+          programs={model.programs}
+          modelId={model.id}
+          replaceModelData={setModel}
+          makeUpdateRequest={api.updateVendorConfigurationPrograms}
+        />,
+        <AuditActivityList activities={model.auditActivities} />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/VendorDetailPage.jsx
+++ b/adminapp/src/pages/VendorDetailPage.jsx
@@ -33,43 +33,41 @@ export default function VendorDetailPage() {
         { label: "Slug", value: model.slug },
       ]}
     >
-      {(model) => (
-        <>
-          <RelatedList
-            title="Services"
-            rows={model.services}
-            headers={["Id", "Name"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink model={row} />,
-              <AdminLink model={row}>{row.name}</AdminLink>,
-            ]}
-          />
-          <RelatedList
-            title="Configuration"
-            rows={model.configurations}
-            headers={["Id", "Vendor", "Auth to Vendor", "Enabled?"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              row.vendor.name,
-              row.authToVendorKey,
-              <BoolCheckmark>{row.enabled}</BoolCheckmark>,
-            ]}
-          />
-          <RelatedList
-            title="Products"
-            rows={model.products}
-            headers={["Id", "Created", "Name"]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              formatDate(row.createdAt),
-              row.name.en,
-            ]}
-          />
-        </>
-      )}
+      {(model) => [
+        <RelatedList
+          title="Services"
+          rows={model.services}
+          headers={["Id", "Name"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink model={row} />,
+            <AdminLink model={row}>{row.name}</AdminLink>,
+          ]}
+        />,
+        <RelatedList
+          title="Configuration"
+          rows={model.configurations}
+          headers={["Id", "Vendor", "Auth to Vendor", "Enabled?"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            row.vendor.name,
+            row.authToVendorKey,
+            <BoolCheckmark>{row.enabled}</BoolCheckmark>,
+          ]}
+        />,
+        <RelatedList
+          title="Products"
+          rows={model.products}
+          headers={["Id", "Created", "Name"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            formatDate(row.createdAt),
+            row.name.en,
+          ]}
+        />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/adminapp/src/pages/VendorServiceDetailPage.jsx
+++ b/adminapp/src/pages/VendorServiceDetailPage.jsx
@@ -43,84 +43,82 @@ export default function VendorServiceDetailPage() {
         { label: "Closing Date", value: dayjs(model.periodEnd) },
       ]}
     >
-      {(model, setModel) => (
-        <>
-          <Programs
-            resource="vendor_service"
-            modelId={model.id}
-            programs={model.programs}
-            makeUpdateRequest={api.updateVendorServicePrograms}
-            replaceModelData={setModel}
-          />
-          <RelatedList
-            title="Categories"
-            rows={model.categories}
-            headers={["Id", "Name", "Slug"]}
-            keyRowAttr="id"
-            toCells={(row) => [row.id, row.name, row.slug]}
-          />
-          <RelatedList
-            title="Rates"
-            rows={model.rates}
-            headers={[
-              "Id",
-              "Created",
-              "Name",
-              "Unit Amount",
-              "Surcharge",
-              "Unit Offset",
-              "Undiscounted Amount",
-              "Undiscounted Surcharge",
-            ]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              row.id,
-              formatDate(row.createdAt),
-              row.name,
-              <Money key="unit_amount">{row.unitAmount}</Money>,
-              <Money key="surcharge">{row.surcharge}</Money>,
-              row.unitOffset,
-              <Money key="undiscounted_amount">{row.undiscountedAmount}</Money>,
-              <Money key="undiscounted_surcharge">{row.undiscountedSurcharge}</Money>,
-            ]}
-          />
-          <RelatedList
-            title="Mobility Trips"
-            rows={model.mobilityTrips}
-            headers={[
-              "Id",
-              "Created",
-              "Vehicle Id",
-              "Rate",
-              "Began",
-              "Ended",
-              "Begin Latitude",
-              "Begin Longitude",
-              "Ending Latitude",
-              "Ending Longitude",
-              "Total Cost",
-              "Discount Amount",
-            ]}
-            keyRowAttr="id"
-            toCells={(row) => [
-              <AdminLink key="id" model={row} />,
-              formatDate(row.createdAt),
-              row.vehicleId,
-              row.rate.name,
-              // This formatting shows date and time with seconds
-              formatDate(row.beganAt, { template: "ll LTS" }),
-              formatDate(row.endedAt, { template: "ll LTS", default: "Ongoing" }),
-              row.beginLat,
-              row.beginLng,
-              row.endLat,
-              row.endLng,
-              <Money>{row.totalCost}</Money>,
-              <Money>{row.discountAmount}</Money>,
-            ]}
-          />
-          <AuditActivityList activities={model.auditActivities} />
-        </>
-      )}
+      {(model, setModel) => [
+        <Programs
+          resource="vendor_service"
+          modelId={model.id}
+          programs={model.programs}
+          makeUpdateRequest={api.updateVendorServicePrograms}
+          replaceModelData={setModel}
+        />,
+        <RelatedList
+          title="Categories"
+          rows={model.categories}
+          headers={["Id", "Name", "Slug"]}
+          keyRowAttr="id"
+          toCells={(row) => [row.id, row.name, row.slug]}
+        />,
+        <RelatedList
+          title="Rates"
+          rows={model.rates}
+          headers={[
+            "Id",
+            "Created",
+            "Name",
+            "Unit Amount",
+            "Surcharge",
+            "Unit Offset",
+            "Undiscounted Amount",
+            "Undiscounted Surcharge",
+          ]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            row.id,
+            formatDate(row.createdAt),
+            row.name,
+            <Money key="unit_amount">{row.unitAmount}</Money>,
+            <Money key="surcharge">{row.surcharge}</Money>,
+            row.unitOffset,
+            <Money key="undiscounted_amount">{row.undiscountedAmount}</Money>,
+            <Money key="undiscounted_surcharge">{row.undiscountedSurcharge}</Money>,
+          ]}
+        />,
+        <RelatedList
+          title="Mobility Trips"
+          rows={model.mobilityTrips}
+          headers={[
+            "Id",
+            "Created",
+            "Vehicle Id",
+            "Rate",
+            "Began",
+            "Ended",
+            "Begin Latitude",
+            "Begin Longitude",
+            "Ending Latitude",
+            "Ending Longitude",
+            "Total Cost",
+            "Discount Amount",
+          ]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            formatDate(row.createdAt),
+            row.vehicleId,
+            row.rate.name,
+            // This formatting shows date and time with seconds
+            formatDate(row.beganAt, { template: "ll LTS" }),
+            formatDate(row.endedAt, { template: "ll LTS", default: "Ongoing" }),
+            row.beginLat,
+            row.beginLng,
+            row.endLat,
+            row.endLng,
+            <Money>{row.totalCost}</Money>,
+            <Money>{row.discountAmount}</Money>,
+          ]}
+        />,
+        <AuditActivityList activities={model.auditActivities} />,
+      ]}
     </ResourceDetail>
   );
 }

--- a/db/migrations/072_org_ordinal.rb
+++ b/db/migrations/072_org_ordinal.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:organizations) do
+      add_column :ordinal, :float, null: false, default: 0
+    end
+  end
+end

--- a/lib/suma/admin_api/organization_memberships.rb
+++ b/lib/suma/admin_api/organization_memberships.rb
@@ -9,6 +9,7 @@ class Suma::AdminAPI::OrganizationMemberships < Suma::AdminAPI::V1
   class DetailedOrganizationMembershipEntity < OrganizationMembershipEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
+    expose :matched_organization, with: OrganizationEntity
   end
 
   resource :organization_memberships do

--- a/lib/suma/admin_api/organizations.rb
+++ b/lib/suma/admin_api/organizations.rb
@@ -12,6 +12,7 @@ class Suma::AdminAPI::Organizations < Suma::AdminAPI::V1
     expose :ordinal
     expose :audit_activities, with: ActivityEntity
     expose :memberships, with: OrganizationMembershipEntity
+    expose :former_memberships, with: OrganizationMembershipEntity
     expose :program_enrollments, with: ProgramEnrollmentEntity
     expose :roles, with: RoleEntity
   end

--- a/lib/suma/admin_api/organizations.rb
+++ b/lib/suma/admin_api/organizations.rb
@@ -9,6 +9,7 @@ class Suma::AdminAPI::Organizations < Suma::AdminAPI::V1
   class DetailedOrganizationEntity < OrganizationEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
+    expose :ordinal
     expose :audit_activities, with: ActivityEntity
     expose :memberships, with: OrganizationMembershipEntity
     expose :program_enrollments, with: ProgramEnrollmentEntity
@@ -35,6 +36,7 @@ class Suma::AdminAPI::Organizations < Suma::AdminAPI::V1
     ) do
       params do
         requires :name, type: String, allow_blank: false
+        optional :ordinal, type: Float, default: 0
       end
     end
 
@@ -58,6 +60,7 @@ class Suma::AdminAPI::Organizations < Suma::AdminAPI::V1
     ) do
       params do
         optional :name, type: String, allow_blank: false
+        optional :ordinal, type: Float, default: 0
         optional :roles, type: Array[JSON] do
           use :model_with_id
         end

--- a/lib/suma/api/meta.rb
+++ b/lib/suma/api/meta.rb
@@ -56,7 +56,8 @@ class Suma::API::Meta < Suma::API::V1
 
     get :supported_organizations do
       use_http_expires_caching 30.minutes
-      orgs = Suma::Organization.order(:name).all.map { |o| {name: o.name} }
+      ds = Suma::Organization.order(Sequel.desc(:ordinal), :name)
+      orgs = ds.select(:name).all.map { |o| {name: o.name} }
       present_collection orgs
     end
   end

--- a/lib/suma/organization.rb
+++ b/lib/suma/organization.rb
@@ -13,6 +13,7 @@ class Suma::Organization < Suma::Postgres::Model(:organizations)
   plugin :timestamps
 
   one_to_many :memberships, class: "Suma::Organization::Membership", key: :verified_organization_id
+  one_to_many :former_memberships, class: "Suma::Organization::Membership", key: :former_organization_id
   one_to_many :program_enrollments, class: "Suma::Program::Enrollment"
   many_to_many :roles, class: "Suma::Role", join_table: :roles_organizations
 

--- a/lib/suma/organization/membership.rb
+++ b/lib/suma/organization/membership.rb
@@ -18,8 +18,9 @@ class Suma::Organization::Membership < Suma::Postgres::Model(:organization_membe
     def verified = self.exclude(verified_organization_id: nil)
   end
 
-  def verified? = !self.verified_organization.nil?
-  def unverified? = !self.verified?
+  def verified? = !self.verified_organization_id.nil?
+  def unverified? = self.unverified_organization_name.to_s != ""
+  def removed? = !self.former_organization_id.nil?
 
   def verified_organization_id=(id)
     self.unverified_organization_name = nil unless id.nil?
@@ -38,6 +39,11 @@ class Suma::Organization::Membership < Suma::Postgres::Model(:organization_membe
     return "verified" if self.verified_organization
     return "removed" if self.former_organization
     return "unverified"
+  end
+
+  def matched_organization
+    return nil unless self.unverified?
+    return Suma::Organization[name: self.unverified_organization_name]
   end
 
   def rel_admin_link = "/membership/#{self.id}"

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -170,7 +170,14 @@ module Suma::Service::Helpers
   end
 
   def hybrid_search(dataset, params)
-    return dataset.hybrid_search(params.fetch(:search))
+    search = params.fetch(:search)
+    # Convert US-formatted phone numbers to E164 format (no leading country code)
+    # so they can be matched more explicitly. Otherwise, the spaces in the phone number
+    # are split as tokens, and we get bad results.
+    search = search.gsub(/\(\d\d\d\) \d\d\d-\d\d\d\d/) do |match|
+      match.gsub(/\D/, "")
+    end
+    return dataset.hybrid_search(search)
   end
 
   def use_http_expires_caching(expiration)

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe Suma::AdminAPI::Members, :db do
       end
     end
 
+    it "will search a US phone number as an E164 form in search", :hybrid_search do
+      nomatch = Suma::Fixtures.member(phone: "13334445556").create
+      match = Suma::Fixtures.member(phone: "13334445555").create
+
+      Suma::Member.hybrid_search_reindex_all
+
+      get "/v1/members", search: "x (333) 444-5555 y"
+
+      expect(last_response).to have_status(200)
+      expect(last_response_json_body[:items]).to have_same_ids_as(match).ordered
+    end
+
     it_behaves_like "an endpoint with pagination" do
       let(:url) { "/v1/members" }
       def make_item(i)

--- a/spec/suma/api/meta_spec.rb
+++ b/spec/suma/api/meta_spec.rb
@@ -123,15 +123,23 @@ RSpec.describe Suma::API::Meta, :db do
   end
 
   describe "GET /v1/meta/supported_organizations" do
-    it "returns supported organizations" do
+    it "returns supported organizations ordered by ordinal, name, and id" do
       orgb = Suma::Fixtures.organization.create(name: "b")
       orgc = Suma::Fixtures.organization.create(name: "c")
       orga = Suma::Fixtures.organization.create(name: "a")
+      orgup = Suma::Fixtures.organization.create(name: "d", ordinal: 1)
 
       get "/v1/meta/supported_organizations"
 
       expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(items: [{name: "a"}, {name: "b"}, {name: "c"}])
+      expect(last_response).to have_json_body.that_includes(
+        items: [
+          {name: "d"},
+          {name: "a"},
+          {name: "b"},
+          {name: "c"},
+        ],
+      )
     end
   end
 end

--- a/spec/suma/organization/membership_spec.rb
+++ b/spec/suma/organization/membership_spec.rb
@@ -39,4 +39,31 @@ RSpec.describe "Suma::Organization::Membership", :db do
       expect { m.remove_from_organization }.to raise_error(Suma::InvalidPrecondition)
     end
   end
+
+  it "has accessors about verified status" do
+    m = Suma::Fixtures.organization_membership.unverified.create
+    expect(m).to be_unverified
+    expect(m).to_not be_verified
+    expect(m).to_not be_removed
+    m.verified_organization = Suma::Fixtures.organization.create
+    expect(m).to_not be_unverified
+    expect(m).to be_verified
+    expect(m).to_not be_removed
+    m.remove_from_organization
+    expect(m).to_not be_unverified
+    expect(m).to_not be_verified
+    expect(m).to be_removed
+  end
+
+  describe "matched_organization" do
+    it "finds an org with the unverified name" do
+      o = Suma::Fixtures.organization.create
+      m = Suma::Fixtures.organization_membership.unverified.create
+      expect(m.matched_organization).to be_nil
+      m.unverified_organization_name = o.name
+      expect(m.matched_organization).to be === o
+      m.verified_organization = o
+      expect(m.matched_organization).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Use cards on admin pages

It helps with visual layout. Also standardize a
few other visual things, like flexing cards for detail grids,
and always using showMore on related lists.

---

Improve admin phone search

Whenever we search, convert US-formatted phone numbers
into E.164 format, so we can do explicit token matching-
ie, (333) 444-5555 should not match as '333' and '444-5555',
it should match as '3334445555'.

Write the US-formatted and E.164 phone numbers into the
member search content field.

Requires member re-indexing.

---

Improve membership management in admin

- Use consistent iconography for unverified/verified/removed
  across the full UI (list page, related lists, etc).
- Automatically select the org matching the name, when verifying
- Remove org membership list from the member edit page.
  Membership management is too complex to have it
  embedded in the member form for now.

---

Add organization ordinal sorting

Sort the member onboarding org dropdown by ordinal,
highest first.
Allows admins to put SNAP/WIC at the top.
