### PR TITLE
Refund funding transactions from admin

### DIFF
--- a/adminapp/src/App.jsx
+++ b/adminapp/src/App.jsx
@@ -14,6 +14,7 @@ import DashboardPage from "./pages/DashboardPage";
 import FundingTransactionCreatePage from "./pages/FundingTransactionCreatePage";
 import FundingTransactionDetailPage from "./pages/FundingTransactionDetailPage";
 import FundingTransactionListPage from "./pages/FundingTransactionListPage";
+import FundingTransactionRefundPage from "./pages/FundingTransactionRefundPage";
 import MemberDetailPage from "./pages/MemberDetailPage";
 import MemberEditPage from "./pages/MemberEditPage";
 import MemberListPage from "./pages/MemberListPage";
@@ -203,6 +204,15 @@ function PageSwitch() {
           redirectIfUnauthed,
           withLayout(),
           FundingTransactionDetailPage
+        )}
+      />
+      <Route
+        exact
+        path="/funding-transaction/:id/refund"
+        element={renderWithHocs(
+          redirectIfUnauthed,
+          withLayout(),
+          FundingTransactionRefundPage
         )}
       />
       <Route

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -102,6 +102,8 @@ export default {
     get(`/adminapi/v1/funding_transactions/${id}`, data),
   createForSelfFundingTransaction: (data) =>
     post(`/adminapi/v1/funding_transactions/create_for_self`, data),
+  refundFundingTransaction: ({ id, ...data }) =>
+    post(`/adminapi/v1/funding_transactions/${id}/refund`, data),
   getPayoutTransactions: (data) => get(`/adminapi/v1/payout_transactions`, data),
   getPayoutTransaction: ({ id, ...data }) =>
     get(`/adminapi/v1/payout_transactions/${id}`, data),

--- a/adminapp/src/pages/FundingTransactionDetailPage.jsx
+++ b/adminapp/src/pages/FundingTransactionDetailPage.jsx
@@ -3,8 +3,10 @@ import AdminLink from "../components/AdminLink";
 import AuditLogs from "../components/AuditLogs";
 import DetailGrid from "../components/DetailGrid";
 import ExternalLinks from "../components/ExternalLinks";
+import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
 import React from "react";
 
@@ -26,6 +28,10 @@ export default function FundingTransactionDetailPage() {
         },
         { label: "Status", value: model.status },
         { label: "Amount", value: <Money>{model.amount}</Money> },
+        model.refundedAmount.cents > 0 && {
+          label: "Refunded Amount",
+          value: <Money>{model.refundedAmount}</Money>,
+        },
         { label: "Memo", value: model.memo },
       ]}
     >
@@ -65,6 +71,27 @@ export default function FundingTransactionDetailPage() {
                   <AdminLink model={originated.actor}>{originated.actor.name}</AdminLink>
                 ) : undefined,
               },
+            ]}
+          />,
+          <RelatedList
+            title="Refund Payout Transactions"
+            rows={model.refundPayoutTransactions}
+            headers={["Id", "Created", "Amount"]}
+            keyRowAttr="id"
+            addNewLabel={model.canRefund && "Refund this transaction"}
+            addNewLink={
+              model.canRefund &&
+              `/funding-transaction/${
+                model.id
+              }/refund?refundableAmount=${encodeURIComponent(
+                JSON.stringify(model.refundableAmount)
+              )}`
+            }
+            addNewRole="payoutTransaction"
+            toCells={(row) => [
+              <AdminLink key="id" model={row} />,
+              formatDate(row.createdAt),
+              <Money key="amt">{row.amount}</Money>,
             ]}
           />,
           <ExternalLinks externalLinks={model.externalLinks} />,

--- a/adminapp/src/pages/FundingTransactionRefundPage.jsx
+++ b/adminapp/src/pages/FundingTransactionRefundPage.jsx
@@ -1,0 +1,77 @@
+import api from "../api";
+import CurrencyTextField from "../components/CurrencyTextField";
+import FormLayout from "../components/FormLayout";
+import config from "../config";
+import useBusy from "../hooks/useBusy";
+import useErrorSnackbar from "../hooks/useErrorSnackbar";
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+} from "@mui/material";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate, useParams } from "react-router-dom";
+
+export default function FundingTransactionRefundPage() {
+  const { enqueueErrorSnackbar } = useErrorSnackbar();
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  const [mode, setMode] = React.useState("full");
+  let defaultMoney = config.defaultZeroMoney;
+  try {
+    defaultMoney = JSON.parse(
+      new URLSearchParams(window.location.search).get("refundableAmount")
+    );
+  } catch (e) {
+    console.log(e);
+  }
+  const [amount, setAmount] = React.useState(defaultMoney);
+  const { isBusy, busy, notBusy } = useBusy();
+  const { register, handleSubmit } = useForm();
+
+  function submit() {
+    busy();
+    const params = mode === "full" ? { full: true } : { amount };
+    api
+      .refundFundingTransaction({ id: Number(id), ...params })
+      .then(api.followRedirect(navigate))
+      .tapCatch(notBusy)
+      .catch(enqueueErrorSnackbar);
+  }
+
+  return (
+    <FormLayout
+      title="Refund a Funding Transaction"
+      subtitle="Refund all or part of this transaction.
+      The refund will be credited to whatever payment instrument (credit card, etc)
+      the member used to pay."
+      onSubmit={handleSubmit(submit)}
+      isBusy={isBusy}
+    >
+      <Stack spacing={2}>
+        <FormControl>
+          <FormLabel>Amount</FormLabel>
+          <RadioGroup value={mode} row onChange={(e) => setMode(e.target.value)}>
+            <FormControlLabel value="full" control={<Radio />} label="Full" />
+            <FormControlLabel value="partial" control={<Radio />} label="Partial" />
+          </RadioGroup>
+        </FormControl>
+        <CurrencyTextField
+          {...register("amount")}
+          label="Amount"
+          helperText="How much to refund?"
+          money={amount}
+          disabled={mode === "full"}
+          sx={{ width: { xs: "100%", sm: "50%" } }}
+          required
+          onMoneyChange={setAmount}
+        />
+      </Stack>
+    </FormLayout>
+  );
+}

--- a/adminapp/src/pages/PayoutTransactionDetailPage.jsx
+++ b/adminapp/src/pages/PayoutTransactionDetailPage.jsx
@@ -26,8 +26,19 @@ export default function PayoutTransactionDetailPage() {
         const {
           originatedBookTransaction: originated,
           creditingBookTransaction: crediting,
+          refundedFundingTransaction: refund,
         } = model;
         return [
+          refund && (
+            <DetailGrid
+              title="Refunded Transaction"
+              properties={[
+                { label: "ID", value: <AdminLink model={refund} /> },
+                { label: "Created At", value: dayjs(refund.createdAt) },
+                { label: "Amount", value: <Money>{refund.amount}</Money> },
+              ]}
+            />
+          ),
           <DetailGrid
             title="Originated Book Transaction"
             properties={[

--- a/lib/suma/admin_api/payment_triggers.rb
+++ b/lib/suma/admin_api/payment_triggers.rb
@@ -73,7 +73,7 @@ class Suma::AdminAPI::PaymentTriggers < Suma::AdminAPI::V1
         optional :match_multiplier, type: Float
         optional :maximum_cumulative_subsidy_cents, type: Integer
         optional(:memo, type: JSON) { use :translated_text }
-        optional :originating_ledger_id, type: Integer
+        optional(:originating_ledger, type: JSON) { use :model_with_id }
         optional :receiving_ledger_name, type: String
         optional(:receiving_ledger_contribution_text, type: JSON) { use :translated_text }
       end

--- a/lib/suma/admin_api/payout_transactions.rb
+++ b/lib/suma/admin_api/payout_transactions.rb
@@ -14,6 +14,7 @@ class Suma::AdminAPI::PayoutTransactions < Suma::AdminAPI::V1
     expose :platform_ledger, with: SimpleLedgerEntity
     expose :crediting_book_transaction, with: BookTransactionEntity
     expose :originated_book_transaction, with: BookTransactionEntity
+    expose :refunded_funding_transaction, with: FundingTransactionEntity
     expose :audit_activities, with: ActivityEntity
     expose :audit_logs, with: AuditLogEntity
   end

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -39,6 +39,7 @@ module Suma::Async
     "suma/async/message_dispatched",
     "suma/async/offering_schedule_fulfillment",
     "suma/async/order_confirmation",
+    "suma/async/payout_transaction_processor",
     "suma/async/plaid_update_institutions",
     "suma/async/process_anon_proxy_inbound_webhookdb_relays",
     "suma/async/reset_code_create_dispatch",

--- a/lib/suma/async/payout_transaction_processor.rb
+++ b/lib/suma/async/payout_transaction_processor.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "amigo/scheduled_job"
+
+class Suma::Async::PayoutTransactionProcessor
+  extend Amigo::ScheduledJob
+
+  sidekiq_options(Suma::Async.cron_job_options)
+  cron "*/5 * * * *"
+  splay 30.seconds
+
+  def _perform
+    Suma::Payment::PayoutTransaction.where(status: "created").each { |x| x.process(:send_funds) }
+    Suma::Payment::PayoutTransaction.where(status: "sending").each { |x| x.process(:send_funds) }
+  end
+end

--- a/lib/suma/fixtures/payout_transactions.rb
+++ b/lib/suma/fixtures/payout_transactions.rb
@@ -33,17 +33,19 @@ module Suma::Fixtures::PayoutTransactions
     self.fake_strategy = strategy
   end
 
-  def self.refund_of(fx, originating_instrument, apply_credit:, amount: fx.amount, apply_at: Time.now)
+  def self.refund_of(fx, originating_instrument, apply_credit: :infer, amount: fx.amount, apply_at: Time.now)
     fx.strategy.set_response(:originating_instrument, originating_instrument)
     strategy = Suma::Payment::FakeStrategy.new
     strategy.set_response(:check_validity, [])
     strategy.set_response(:ready_to_send_funds?, false)
-    return Suma::Payment::PayoutTransaction.initiate_refund(
+    px = Suma::Payment::PayoutTransaction.initiate_refund(
       fx,
       amount:,
       apply_at:,
       strategy:,
       apply_credit:,
     )
+    fx.associations.delete(:refund_payout_transactions)
+    return px
   end
 end

--- a/lib/suma/moneyutil.rb
+++ b/lib/suma/moneyutil.rb
@@ -16,4 +16,8 @@ class Suma::Moneyutil
   def self.to_h(m)
     return {currency: m.currency.iso_code, cents: m.cents}
   end
+
+  def self.from_h(h)
+    return Money.new(h.fetch(:cents), h.fetch(:currency))
+  end
 end

--- a/lib/suma/payment/funding_transaction.rb
+++ b/lib/suma/payment/funding_transaction.rb
@@ -38,6 +38,10 @@ class Suma::Payment::FundingTransaction < Suma::Postgres::Model(:payment_funding
                right_key: :charge_id,
                left_key: :funding_transaction_id
 
+  one_to_many :refund_payout_transactions,
+              class: "Suma::Payment::PayoutTransaction",
+              key: :refunded_funding_transaction_id
+
   state_machine :status, initial: :created do
     state :created,
           :collecting,
@@ -140,6 +144,10 @@ class Suma::Payment::FundingTransaction < Suma::Postgres::Model(:payment_funding
       end
     end
   end
+
+  def refunded_amount = self.refund_payout_transactions.sum(Money.new(0), &:amount)
+  def refundable_amount = self.amount - self.refunded_amount
+  def can_refund? = self.refundable_amount.positive?
 
   def rel_admin_link = "/funding-transaction/#{self.id}"
 

--- a/lib/suma/payment/payout_transaction/stripe_charge_refund_strategy.rb
+++ b/lib/suma/payment/payout_transaction/stripe_charge_refund_strategy.rb
@@ -36,6 +36,7 @@ class Suma::Payment::PayoutTransaction::StripeChargeRefundStrategy <
     refund = Stripe::Refund.create(
       {
         charge: self.stripe_charge_id,
+        amount: self.payout_transaction.amount.cents,
         metadata: Suma::Stripe.build_metadata(
           [
             self.payout_transaction.originating_payment_account.member,

--- a/lib/suma/stripe.rb
+++ b/lib/suma/stripe.rb
@@ -39,10 +39,16 @@ module Suma::Stripe
     return true
   end
 
-  def self.default_metadata
-    return {
+  def self.build_metadata(relations=[])
+    h = {
       suma_api_version: Suma::VERSION,
     }
+    relations.select(&:itself).each do |r|
+      ns = r.class.name.split("::").last.underscore
+      h[:"suma_#{ns}_id"] = r.id
+      h[:"suma_#{ns}_name"] = r.name if r.respond_to?(:name) && r.name.present?
+    end
+    return h
   end
 
   # @param [Stripe::CardError] e

--- a/spec/data/stripe/refund.json
+++ b/spec/data/stripe/refund.json
@@ -1,0 +1,25 @@
+{
+  "id": "re_1Nispe2eZvKYlo2Cd31jOCgZ",
+  "object": "refund",
+  "amount": 1000,
+  "balance_transaction": "txn_1Nispe2eZvKYlo2CYezqFhEx",
+  "charge": "ch_1Cgkfs2eZvKYlo2CVPsK4I3f",
+  "created": 1692942318,
+  "currency": "usd",
+  "destination_details": {
+    "card": {
+      "reference": "123456789012",
+      "reference_status": "available",
+      "reference_type": "acquirer_reference_number",
+      "type": "refund"
+    },
+    "type": "card"
+  },
+  "metadata": {},
+  "payment_intent": "pi_1GszsK2eZvKYlo2CfhZyoZLp",
+  "reason": null,
+  "receipt_number": null,
+  "source_transfer_reversal": null,
+  "status": "succeeded",
+  "transfer_reversal": null
+}

--- a/spec/suma/member/stripe_attributes_spec.rb
+++ b/spec/suma/member/stripe_attributes_spec.rb
@@ -90,29 +90,4 @@ RSpec.describe Suma::Member::StripeAttributes, :db do
       end.to raise_error(Suma::InvalidPrecondition)
     end
   end
-
-  describe "card update" do
-    let(:member) { Suma::Fixtures.member.registered_as_stripe_customer.create }
-    let(:card) { Suma::Fixtures.card.member(member).create }
-
-    it "updates the card" do
-      url = "https://api.stripe.com/v1/customers/#{member.stripe.customer_id}/sources/card_1LxbQmAqRmWQecssc7Yf9Wr7"
-      req = stub_request(:post, url).
-        with(body: {"exp_month" => "12", "exp_year" => "2030"}).
-        to_return(fixture_response("stripe/customer"))
-
-      expect do
-        member.stripe.update_card(card:, exp_month: "12", exp_year: "2030")
-      end.to(change { member.updated_at })
-
-      expect(req).to have_been_made
-    end
-
-    it "errors if the card does not belong to the member" do
-      card = Suma::Fixtures.card.create
-      expect do
-        member.stripe.update_card(card:, exp_month: "12", exp_year: "2030")
-      end.to raise_error(Suma::InvalidPrecondition)
-    end
-  end
 end

--- a/spec/suma/payment/payout_transaction/stripe_charge_refund_strategy_spec.rb
+++ b/spec/suma/payment/payout_transaction/stripe_charge_refund_strategy_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Suma::Payment::PayoutTransaction::StripeChargeRefundStrategy", :
   describe "send_funds" do
     it "creates a refund in Stripe if no refund is set" do
       req = stub_request(:post, "https://api.stripe.com/v1/refunds").
-        with(body: hash_including("charge" => "ch_1")).
+        with(body: hash_including("charge" => "ch_1", amount: xaction.amount.cents.to_s)).
         to_return(json_response(load_fixture_data("stripe/refund")))
 
       expect(strategy.send_funds).to eq(true)

--- a/spec/suma/stripe_spec.rb
+++ b/spec/suma/stripe_spec.rb
@@ -16,4 +16,27 @@ RSpec.describe Suma::Stripe, :db do
       expect(Suma::Service.localized_error_codes).to be_include(described_class.localized_error_code(err))
     end
   end
+
+  describe "build_metadata" do
+    it "builds metadata for models" do
+      v = Suma::Fixtures.vendor.create
+      bx = Suma::Fixtures.book_transaction.create
+      expect(described_class.build_metadata).to eq({suma_api_version: "unknown-version"})
+      expect(described_class.build_metadata([v, nil])).to eq(
+        {
+          suma_api_version: "unknown-version",
+          suma_vendor_id: v.id,
+          suma_vendor_name: v.name,
+        },
+      )
+      expect(described_class.build_metadata([v, bx])).to eq(
+        {
+          suma_api_version: "unknown-version",
+          suma_vendor_id: v.id,
+          suma_vendor_name: v.name,
+          suma_book_transaction_id: bx.id,
+        },
+      )
+    end
+  end
 end


### PR DESCRIPTION
Hookup refunds to admin

- Add page for creating a refund
- Add refunds to funding transaction detail page
- Support partial refunds more thoroughly

---

Payment Triggers: Fix bug setting originating ledger

---

Refunds can be created, not just backfilled

Previously the only way to create refunds was to backfill them
from stripe. Now we can create a refund for
a funding transaction directly. It will be processed like a normal
payout transaction, create the resource in Stripe.

---

Stripe: Standardize metadata usage

- Add a method that sets :id and :name in metadata automatically
  based on the model.
- Use it for all calls to Stripe.