### PR TITLE
Auto-reload app; audit program app_link changes

### DIFF
--- a/adminapp/index.html
+++ b/adminapp/index.html
@@ -1,27 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <meta name="theme-color" content="#000000"/>
-    <meta name="description" content="Admin site for https://app.mysuma.org"/>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Admin site for https://app.mysuma.org" />
 
-    <title>Admin | Suma</title>
+  <title>Admin | Suma</title>
 
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
-    <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="theme-color" content="#ffffff">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="theme-color" content="#ffffff">
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"/>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>
-    <link rel="stylesheet" media="print" href="/styles/print.css" />
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <script type="module" src="/src/index.jsx"></script>
-  </body>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+  <link rel="stylesheet" media="print" href="/styles/print.css" />
+</head>
+<body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+<script type="module" src="/src/index.jsx"></script>
+<script type="text/javascript" data-csp="ok">
+  // See commit this code was added in for an explanation.
+  (function() {
+    const hashedIndexJs = (window.sumaDynamicEnv || {}).VITE_HASHED_INDEX_JS;
+    if (!hashedIndexJs) {
+      return;
+    }
+    fetch(hashedIndexJs, { method: "HEAD" })
+      .then((r) => r.status >= 300 ? Promise.reject(`Server Error: ${r.status}`) : null)
+      .catch((e) => {
+        console.warn(`Suma failed to load ${hashedIndexJs}`, e);
+        const content = document.createElement("div");
+        content.style.padding = "30px";
+        if (!window.location.href.includes("clearcache=")) {
+          console.warn("Suma reloading with clearcache to bust the cache.");
+          content.innerText = "This application has been updated. If the page does not automatically refresh, please pull down or open your browser menu to refresh the page.";
+          document.body.appendChild(content);
+          window.location = window.location.href + "?clearcache=" + Date.now();
+        } else {
+          console.warn("Suma reloaded due to stale cache, but JS still not found. Not reloading.");
+          content.innerText = "Sorry, something went wrong loading the application. You can try refreshing, or reach out to info@mysuma.org.";
+          document.body.appendChild(content);
+        }
+      });
+  })();
+</script>
+</body>
 </html>

--- a/adminapp/src/pages/ProgramDetailPage.jsx
+++ b/adminapp/src/pages/ProgramDetailPage.jsx
@@ -1,5 +1,6 @@
 import api from "../api";
 import AdminLink from "../components/AdminLink";
+import AuditActivityList from "../components/AuditActivityList";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
 import SumaImage from "../components/SumaImage";
@@ -131,6 +132,7 @@ export default function ProgramDetailPage() {
             dayjsOrNull(row.unenrolledAt)?.format("lll"),
           ]}
         />,
+        <AuditActivityList activities={model.auditActivities} />,
       ]}
     </ResourceDetail>
   );

--- a/lib/suma/admin_api/programs.rb
+++ b/lib/suma/admin_api/programs.rb
@@ -16,6 +16,7 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
     expose :anon_proxy_vendor_configurations, as: :configurations, with: VendorConfigurationEntity
     expose :payment_triggers, with: PaymentTriggerEntity
     expose :enrollments, with: ProgramEnrollmentEntity
+    expose :audit_activities, with: ActivityEntity
   end
 
   resource :programs do
@@ -71,6 +72,14 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
         if vendor_services
           vendor_service_models = Suma::Vendor::Service.where(id: vendor_services.map { |o| o[:id] }).all
           m.replace_vendor_services(vendor_service_models)
+        end
+        if rt.params[:app_link]
+          # Audit app_link changes, since they could be used maliciously.
+          m.audit_activity(
+            "applinkchange",
+            member: rt.admin_member,
+            action: rt.params[:app_link],
+          )
         end
       end,
     ) do

--- a/lib/suma/apps.rb
+++ b/lib/suma/apps.rb
@@ -220,6 +220,7 @@ module Suma::Apps
       policy: {
         safe: ["'self' mysuma.org *.mysuma.org", Suma::Sentry.dsn_host],
         inline_scripts: [script],
+        script_hashes: Rack::Csp.extract_script_hashes(File.read("build-adminapp/index.html")),
         img_data: true,
         img_blob: true,
         parts: {

--- a/lib/suma/program.rb
+++ b/lib/suma/program.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "suma/admin_linked"
+require "suma/has_activity_audit"
 require "suma/image"
 require "suma/postgres/model"
 
 class Suma::Program < Suma::Postgres::Model(:programs)
   include Suma::Postgres::HybridSearch
   include Suma::AdminLinked
+  include Suma::HasActivityAudit
   include Suma::Image::SingleAssociatedMixin
 
   plugin :hybrid_search

--- a/spec/rack/spa_rewrite_spec.rb
+++ b/spec/rack/spa_rewrite_spec.rb
@@ -118,5 +118,11 @@ RSpec.describe Rack::SpaRewrite do
         ],
       )
     end
+
+    it "404s if the underlying app if the file is an asset" do
+      expect(mw.call(Rack::MockRequest.env_for("/w.js", method: :get))).to eq(
+        [404, {"content-length" => 10, "content-type" => "text/plain"}, ["Not found\n"]],
+      )
+    end
   end
 end

--- a/spec/suma/admin_api/programs_spec.rb
+++ b/spec/suma/admin_api/programs_spec.rb
@@ -126,6 +126,15 @@ RSpec.describe Suma::AdminAPI::Programs, :db do
       expect(program.refresh).to have_attributes(name: have_attributes(en: "pwb program"))
     end
 
+    it "audits some changes" do
+      program = Suma::Fixtures.program.create
+      post "/v1/programs/#{program.id}", app_link: "hello"
+
+      expect(last_response).to have_status(200)
+      expect(program.refresh).to have_attributes(app_link: "hello")
+      expect(program.refresh.audit_activities).to contain_exactly(have_attributes(message_name: "applinkchange"))
+    end
+
     it "handles adding and removing nested resources" do
       offering_fac = Suma::Fixtures.offering
       offering_to_remove = offering_fac.create

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,51 +1,78 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
-    <meta name="description" content="Suma provides affordable housing residents and other frontline community members access to low-cost, secure and easy to use access to clean mobility, food, transportation and utility options.">
-    <title>Suma</title>
-    <!-- Android  -->
-    <meta name="theme-color" content="#CDA671FF">
-    <meta name="mobile-web-app-capable" content="yes">
-    <!-- iOS -->
-    <meta name="apple-mobile-web-app-title" content="Suma">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <!-- Pinned Sites  -->
-    <meta name="application-name" content="Suma">
-    <!-- UC Mobile Browser  -->
-    <meta name="full-screen" content="yes">
-    <meta name="browsermode" content="application">
-    <!-- Layout mode -->
-    <meta name="layoutmode" content="fitscreen">
-    <!-- Orientation  -->
-    <meta name="screen-orientation" content="portrait">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+  <meta name="description"
+        content="Suma provides affordable housing residents and other frontline community members access to low-cost, secure and easy to use access to clean mobility, food, transportation and utility options.">
+  <title>Suma</title>
+  <!-- Android  -->
+  <meta name="theme-color" content="#CDA671FF">
+  <meta name="mobile-web-app-capable" content="yes">
+  <!-- iOS -->
+  <meta name="apple-mobile-web-app-title" content="Suma">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <!-- Pinned Sites  -->
+  <meta name="application-name" content="Suma">
+  <!-- UC Mobile Browser  -->
+  <meta name="full-screen" content="yes">
+  <meta name="browsermode" content="application">
+  <!-- Layout mode -->
+  <meta name="layoutmode" content="fitscreen">
+  <!-- Orientation  -->
+  <meta name="screen-orientation" content="portrait">
 
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <link rel="apple-touch-icon" sizes="57x57" href="/icons/apple-touch-icon-57x57.png" />
-    <link rel="apple-touch-icon" sizes="72x72" href="/icons/apple-touch-icon-72x72.png" />
-    <link rel="apple-touch-icon" sizes="76x76" href="/icons/apple-touch-icon-76x76.png" />
-    <link rel="apple-touch-icon" sizes="114x114" href="/icons/apple-touch-icon-114x114.png" />
-    <link rel="apple-touch-icon" sizes="120x120" href="/icons/apple-touch-icon-120x120.png" />
-    <link rel="apple-touch-icon" sizes="144x144" href="/icons/apple-touch-icon-144x144.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/icons/apple-touch-icon-152x152.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon-180x180.png" />
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/index.jsx"></script>
-    <script type="text/javascript" data-csp="ok">
-      // AddToHomeScreen service worker must register here.
-      if ("serviceWorker" in navigator) {
-        window.addEventListener("load", () => {
-          navigator.serviceWorker
-            .register("%BASE_URL%/add-to-homescreen-service-worker.js", { scope: "%BASE_URL%" })
-            .catch((error) => error);
-        });
-      }
-    </script>
-  </body>
+  <link rel="manifest" href="/manifest.json" />
+  <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+  <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+  <link rel="apple-touch-icon" sizes="57x57" href="/icons/apple-touch-icon-57x57.png" />
+  <link rel="apple-touch-icon" sizes="72x72" href="/icons/apple-touch-icon-72x72.png" />
+  <link rel="apple-touch-icon" sizes="76x76" href="/icons/apple-touch-icon-76x76.png" />
+  <link rel="apple-touch-icon" sizes="114x114" href="/icons/apple-touch-icon-114x114.png" />
+  <link rel="apple-touch-icon" sizes="120x120" href="/icons/apple-touch-icon-120x120.png" />
+  <link rel="apple-touch-icon" sizes="144x144" href="/icons/apple-touch-icon-144x144.png" />
+  <link rel="apple-touch-icon" sizes="152x152" href="/icons/apple-touch-icon-152x152.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon-180x180.png" />
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="/src/index.jsx"></script>
+<script type="text/javascript" data-csp="ok">
+  // AddToHomeScreen service worker must register here.
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", () => {
+      navigator.serviceWorker
+        .register("%BASE_URL%/add-to-homescreen-service-worker.js", { scope: "%BASE_URL%" })
+        .catch((error) => error);
+    });
+  }
+</script>
+<script type="text/javascript" data-csp="ok">
+  // See commit this code was added in for an explanation.
+  (function() {
+    const hashedIndexJs = (window.sumaDynamicEnv || {}).VITE_HASHED_INDEX_JS;
+    if (!hashedIndexJs) {
+      return;
+    }
+    fetch(hashedIndexJs, { method: "HEAD" })
+      .then((r) => r.status >= 300 ? Promise.reject(`Server Error: ${r.status}`) : null)
+      .catch((e) => {
+        console.warn(`Suma failed to load ${hashedIndexJs}`, e);
+        const content = document.createElement("div");
+        content.style.padding = "30px";
+        if (!window.location.href.includes("clearcache=")) {
+          console.warn("Suma reloading with clearcache to bust the cache.");
+          content.innerText = "This application has been updated. If the page does not automatically refresh, please pull down or open your browser menu to refresh the page.";
+          document.body.appendChild(content);
+          window.location = window.location.href + "?clearcache=" + Date.now();
+        } else {
+          console.warn("Suma reloaded due to stale cache, but JS still not found. Not reloading.");
+          content.innerText = "Sorry, something went wrong loading the application. You can try refreshing, or reach out to info@mysuma.org.";
+          document.body.appendChild(content);
+        }
+      });
+  })();
+</script>
+</body>
 </html>

--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
     }),
   ],
   build: {
+    manifest: true,
     outDir: "../build-webapp",
     emptyOutDir: true,
   },


### PR DESCRIPTION
Audit program app_link changes

Since they are potentially malicous (could send users off-site),
audit any changes.

---

Automatically reload when asset js not found

Instead of a broken app with a missing asset,
reload the page.

When loading the app, make a HEAD to the hashed JS file.
If it isn't found, it's probably because the site has been
redeployed. If this happens, automatically reload the entire page,
using 'clearcache=(now)' to bust the recent cache
(use Date.now(), not just 'true', to make sure this works
even in the face of rapid deploys).

If the index still fails to load, maybe because the entire site
is down, show an error message.

This requires:

- Writing out the build manifest
- Parsing the manifest at runtime, to load the hashed index.js path.
  vite does not make it available to template into index.html.
- Writing this hashed file path into dynamic config.
- An inline JS function as described above.

Also fix an issue where a 404 on a JS or CSS file,
would return as a valid HTML file which would of course
fail to parse.