### PR TITLE
Edit image captions; improve app with scaled fonts

### DIFF
--- a/adminapp/src/components/ImageFileInput.jsx
+++ b/adminapp/src/components/ImageFileInput.jsx
@@ -1,5 +1,6 @@
+import MultiLingualText from "./MultiLingualText";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
-import { Button, FormHelperText, FormLabel, Stack, Typography } from "@mui/material";
+import { Button, FormHelperText, FormLabel, Stack } from "@mui/material";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 
@@ -8,12 +9,14 @@ import React from "react";
  * If you pass in an image file object or blob, it will be displayed
  * along with the image caption.
  * @param image the image source file or image blob
+ * @param caption
  * @param required sets the input field as required
  * @param onImageChange callback func which passes image file
+ * @param onCaptionChange callback func which receives the new multilingual value
  * @returns {JSX.Element}
  * @constructor
  */
-function ImageFileInput({ image, required, onImageChange }) {
+function ImageFileInput({ image, caption, required, onImageChange, onCaptionChange }) {
   let src = {};
   if (image?.url) {
     src = image.url;
@@ -43,10 +46,15 @@ function ImageFileInput({ image, required, onImageChange }) {
         display issues.
       </FormHelperText>
       {!isEmpty(src) && (
-        <>
-          <img src={src} alt={image.name || image.caption} />
-          <Typography variant="body2">{image.name || image.caption}</Typography>
-        </>
+        <Stack gap={3}>
+          <img src={src} alt={caption.en} />
+          <MultiLingualText
+            label="Caption"
+            fullWidth
+            value={caption}
+            onChange={onCaptionChange}
+          />
+        </Stack>
       )}
     </Stack>
   );

--- a/adminapp/src/components/detailPageImageProperties.jsx
+++ b/adminapp/src/components/detailPageImageProperties.jsx
@@ -1,0 +1,23 @@
+import SumaImage from "./SumaImage";
+import React from "react";
+
+export default function detailPageImageProperties(image, { h, label } = {}) {
+  return [
+    {
+      label: label || "Image",
+      value: (
+        <SumaImage
+          image={image}
+          className="w-100"
+          params={{ crop: "none" }}
+          h={h || 150}
+        />
+      ),
+    },
+    {
+      label: "Caption (En)",
+      value: image.caption.en,
+    },
+    { label: "Caption (Es)", value: image.caption.es },
+  ];
+}

--- a/adminapp/src/pages/OfferingCreatePage.jsx
+++ b/adminapp/src/pages/OfferingCreatePage.jsx
@@ -8,6 +8,7 @@ import React from "react";
 export default function OfferingCreatePage() {
   const empty = {
     image: null,
+    imageCaption: formHelpers.initialTranslation,
     description: formHelpers.initialTranslation,
     fulfillmentPrompt: formHelpers.initialTranslation,
     fulfillmentConfirmation: formHelpers.initialTranslation,

--- a/adminapp/src/pages/OfferingDetailPage.jsx
+++ b/adminapp/src/pages/OfferingDetailPage.jsx
@@ -5,7 +5,7 @@ import Link from "../components/Link";
 import Programs from "../components/Programs";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import SumaImage from "../components/SumaImage";
+import detailPageImageProperties from "../components/detailPageImageProperties";
 import { dayjs } from "../modules/dayConfig";
 import formatDate from "../modules/formatDate";
 import oneLineAddress from "../modules/oneLineAddress";
@@ -26,26 +26,15 @@ export default function OfferingDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        {
-          label: "Image",
-          value: (
-            <SumaImage
-              image={model.image}
-              alt={model.image.name}
-              className="w-100"
-              params={{ crop: "none" }}
-              h={150}
-            />
-          ),
-        },
+        ...detailPageImageProperties(model.image),
+        { label: "Description (En)", value: model.description.en },
+        { label: "Description (Es)", value: model.description.es },
         { label: "Opening Date", value: dayjs(model.periodBegin) },
         { label: "Closing Date", value: dayjs(model.periodEnd) },
         {
           label: "Begin Fulfillment At",
           value: model.beginFulfillmentAt && dayjs(model.beginFulfillmentAt),
         },
-        { label: "Description (En)", value: model.description.en },
-        { label: "Description (Es)", value: model.description.es },
         { label: "Fulfillment Prompt (En)", value: model.fulfillmentPrompt.en },
         { label: "Fulfillment Prompt (Es)", value: model.fulfillmentPrompt.es },
         {

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -47,7 +47,9 @@ export default function OfferingForm({
       <Stack spacing={2}>
         <ImageFileInput
           image={resource.image}
+          caption={resource.imageCaption}
           onImageChange={(f) => setField("image", f)}
+          onCaptionChange={(f) => setField("imageCaption", f)}
           required={isCreate}
         />
         <FormLabel>Description (text in offering list)</FormLabel>

--- a/adminapp/src/pages/ProductCreatePage.jsx
+++ b/adminapp/src/pages/ProductCreatePage.jsx
@@ -8,6 +8,7 @@ import React from "react";
 export default function ProductCreatePage() {
   const product = {
     image: null,
+    imageCaption: formHelpers.initialTranslation,
     description: formHelpers.initialTranslation,
     name: formHelpers.initialTranslation,
     ourCost: config.defaultZeroMoney,

--- a/adminapp/src/pages/ProductDetailPage.jsx
+++ b/adminapp/src/pages/ProductDetailPage.jsx
@@ -2,7 +2,7 @@ import api from "../api";
 import AdminLink from "../components/AdminLink";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import SumaImage from "../components/SumaImage";
+import detailPageImageProperties from "../components/detailPageImageProperties";
 import { dayjs } from "../modules/dayConfig";
 import formatDate from "../modules/formatDate";
 import createRelativeUrl from "../shared/createRelativeUrl";
@@ -18,18 +18,7 @@ export default function ProductDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        {
-          label: "Image",
-          value: (
-            <SumaImage
-              image={model.image}
-              alt={model.image.name}
-              className="w-100"
-              params={{ crop: "none" }}
-              h={150}
-            />
-          ),
-        },
+        ...detailPageImageProperties(model.image),
         { label: "Name (En)", value: model.name.en },
         { label: "Name (Es)", value: model.name.es },
         { label: "Description (En)", value: model.description.en },

--- a/adminapp/src/pages/ProductForm.jsx
+++ b/adminapp/src/pages/ProductForm.jsx
@@ -40,7 +40,9 @@ export default function ProductForm({
       <Stack spacing={2}>
         <ImageFileInput
           image={resource.image}
+          caption={resource.imageCaption}
           onImageChange={(f) => setField("image", f)}
+          onCaptionChange={(f) => setField("imageCaption", f)}
           required={isCreate}
         />
         <Stack spacing={2}>

--- a/adminapp/src/pages/ProgramCreatePage.jsx
+++ b/adminapp/src/pages/ProgramCreatePage.jsx
@@ -8,6 +8,7 @@ import React from "react";
 export default function ProgramCreatePage() {
   const empty = {
     image: null,
+    imageCaption: formHelpers.initialTranslation,
     name: formHelpers.initialTranslation,
     description: formHelpers.initialTranslation,
     appLink: "",

--- a/adminapp/src/pages/ProgramDetailPage.jsx
+++ b/adminapp/src/pages/ProgramDetailPage.jsx
@@ -3,7 +3,7 @@ import AdminLink from "../components/AdminLink";
 import AuditActivityList from "../components/AuditActivityList";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import SumaImage from "../components/SumaImage";
+import detailPageImageProperties from "../components/detailPageImageProperties";
 import { dayjs, dayjsOrNull } from "../modules/dayConfig";
 import formatDate from "../modules/formatDate";
 import createRelativeUrl from "../shared/createRelativeUrl";
@@ -19,18 +19,7 @@ export default function ProgramDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        {
-          label: "Image",
-          value: (
-            <SumaImage
-              image={model.image}
-              alt=""
-              className="w-100"
-              params={{ crop: "none" }}
-              h={150}
-            />
-          ),
-        },
+        ...detailPageImageProperties(model.image),
         { label: "Name EN", value: model.name.en },
         { label: "Name ES", value: model.name.es },
         { label: "Description EN", value: model.description.en },

--- a/adminapp/src/pages/ProgramForm.jsx
+++ b/adminapp/src/pages/ProgramForm.jsx
@@ -37,7 +37,9 @@ export default function ProgramForm({
       <Stack spacing={2}>
         <ImageFileInput
           image={resource.image}
+          caption={resource.imageCaption}
           onImageChange={(f) => setField("image", f)}
+          onCaptionChange={(f) => setField("imageCaption", f)}
           required={isCreate}
         />
         <FormLabel>Name</FormLabel>

--- a/adminapp/src/pages/VendorCreatePage.jsx
+++ b/adminapp/src/pages/VendorCreatePage.jsx
@@ -1,9 +1,10 @@
 import api from "../api";
 import ResourceCreate from "../components/ResourceCreate";
+import formHelpers from "../modules/formHelpers";
 import VendorForm from "./VendorForm";
 import React from "react";
 
 export default function VendorCreatePage() {
-  const empty = { image: null, name: "" };
+  const empty = { image: null, imageCaption: formHelpers.initialTranslation, name: "" };
   return <ResourceCreate empty={empty} apiCreate={api.createVendor} Form={VendorForm} />;
 }

--- a/adminapp/src/pages/VendorDetailPage.jsx
+++ b/adminapp/src/pages/VendorDetailPage.jsx
@@ -3,7 +3,7 @@ import AdminLink from "../components/AdminLink";
 import BoolCheckmark from "../components/BoolCheckmark";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import SumaImage from "../components/SumaImage";
+import detailPageImageProperties from "../components/detailPageImageProperties";
 import { dayjs } from "../modules/dayConfig";
 import formatDate from "../modules/formatDate";
 import React from "react";
@@ -17,20 +17,9 @@ export default function VendorDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        {
-          label: "Image",
-          value: (
-            <SumaImage
-              image={model.image}
-              alt={model.image.name}
-              className="w-100"
-              params={{ crop: "none" }}
-              h={60}
-            />
-          ),
-        },
         { label: "Name", value: model.name },
         { label: "Slug", value: model.slug },
+        ...detailPageImageProperties(model.image),
       ]}
     >
       {(model) => [

--- a/adminapp/src/pages/VendorForm.jsx
+++ b/adminapp/src/pages/VendorForm.jsx
@@ -24,8 +24,10 @@ export default function VendorForm({
       <Stack spacing={2}>
         <ImageFileInput
           image={resource.image}
+          caption={resource.imageCaption}
           required={isCreate}
           onImageChange={(f) => setField("image", f)}
+          onCaptionChange={(f) => setField("imageCaption", f)}
         />
         <TextField
           {...register("name")}

--- a/adminapp/src/pages/VendorServiceDetailPage.jsx
+++ b/adminapp/src/pages/VendorServiceDetailPage.jsx
@@ -4,7 +4,7 @@ import AuditActivityList from "../components/AuditActivityList";
 import Programs from "../components/Programs";
 import RelatedList from "../components/RelatedList";
 import ResourceDetail from "../components/ResourceDetail";
-import SumaImage from "../components/SumaImage";
+import detailPageImageProperties from "../components/detailPageImageProperties";
 import { dayjs } from "../modules/dayConfig";
 import formatDate from "../modules/formatDate";
 import Money from "../shared/react/Money";
@@ -19,18 +19,7 @@ export default function VendorServiceDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Created At", value: dayjs(model.createdAt) },
-        {
-          label: "Image",
-          value: (
-            <SumaImage
-              image={model.image}
-              alt={model.image.name}
-              className="w-100"
-              params={{ crop: "none" }}
-              h={150}
-            />
-          ),
-        },
+        ...detailPageImageProperties(model.image),
         { label: "Name", value: model.name },
         { label: "Internal Name", value: model.internalName },
         { label: "Mobility Vendor Adapter", value: model.mobilityVendorAdapterKey },

--- a/adminapp/src/pages/VendorServiceForm.jsx.jsx
+++ b/adminapp/src/pages/VendorServiceForm.jsx.jsx
@@ -28,8 +28,10 @@ export default function VendorServiceForm({
       <Stack spacing={2}>
         <ImageFileInput
           image={resource.image}
+          caption={resource.imageCaption}
           required={isCreate}
           onImageChange={(f) => setField("image", f)}
+          onCaptionChange={(f) => setField("imageCaption", f)}
         />
         <TextField
           {...register("externalName")}

--- a/lib/suma/admin_api/commerce_offerings.rb
+++ b/lib/suma/admin_api/commerce_offerings.rb
@@ -26,7 +26,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
     expose :fulfillment_confirmation, with: TranslatedTextEntity
     expose :fulfillment_options, with: OfferingFulfillmentOptionEntity
     expose :begin_fulfillment_at
-    expose :image, with: ImageEntity, &self.delegate_to(:images?, :first)
+    expose_image :image
     expose :offering_products, with: OfferingProductEntity
     expose :orders, with: OrderInOfferingEntity
     expose :programs, with: ProgramEntity
@@ -85,6 +85,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
     ) do
       params do
         requires :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
         requires(:description, type: JSON) { use :translated_text }
         optional(:fulfillment_prompt, type: JSON) { use :translated_text, allow_blank: true  }
         optional(:fulfillment_instructions, type: JSON) { use :translated_text, allow_blank: true  }
@@ -118,6 +119,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
     ) do
       params do
         optional :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
         optional(:description, type: JSON) { use :translated_text }
         optional(:fulfillment_prompt, type: JSON) { use :translated_text, allow_blank: true }
         optional(:fulfillment_instructions, type: JSON) { use :translated_text, allow_blank: true }

--- a/lib/suma/admin_api/commerce_products.rb
+++ b/lib/suma/admin_api/commerce_products.rb
@@ -26,7 +26,7 @@ class Suma::AdminAPI::CommerceProducts < Suma::AdminAPI::V1
     expose :offerings, with: OfferingEntity
     expose :orders, with: OrderEntity
     expose :offering_products, with: OfferingProductWithOfferingEntity
-    expose :image, with: ImageEntity, &self.delegate_to(:images?, :first)
+    expose_image :image
     expose :vendor_service_categories, with: VendorServiceCategoryEntity
   end
 
@@ -44,6 +44,7 @@ class Suma::AdminAPI::CommerceProducts < Suma::AdminAPI::V1
     ) do
       params do
         requires :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
         requires(:name, type: JSON) { use :translated_text }
         requires(:description, type: JSON) { use :translated_text }
         requires(:our_cost, type: JSON) { use :money }
@@ -71,6 +72,7 @@ class Suma::AdminAPI::CommerceProducts < Suma::AdminAPI::V1
     ) do
       params do
         optional :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
         optional(:name, type: JSON) { use :translated_text }
         optional(:description, type: JSON) { use :translated_text }
         optional(:our_cost, type: JSON) { use :money }

--- a/lib/suma/admin_api/programs.rb
+++ b/lib/suma/admin_api/programs.rb
@@ -9,7 +9,7 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
   class DetailedProgramEntity < ProgramEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
-    expose :image, with: ImageEntity, &self.delegate_to(:images?, :first)
+    expose_image :image
     expose :lyft_pass_program_id
     expose :commerce_offerings, with: OfferingEntity
     expose :vendor_services, with: VendorServiceEntity
@@ -34,6 +34,7 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
     ) do
       params do
         requires :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
         requires(:name, type: JSON) { use :translated_text }
         requires(:description, type: JSON) { use :translated_text }
         optional :app_link, type: String
@@ -85,6 +86,7 @@ class Suma::AdminAPI::Programs < Suma::AdminAPI::V1
     ) do
       params do
         optional :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
         optional(:name, type: JSON) { use :translated_text }
         optional(:description, type: JSON) { use :translated_text }
         optional :app_link, type: String

--- a/lib/suma/admin_api/vendor_services.rb
+++ b/lib/suma/admin_api/vendor_services.rb
@@ -29,7 +29,7 @@ class Suma::AdminAPI::VendorServices < Suma::AdminAPI::V1
     expose :vendor_service_categories, as: :categories, with: VendorServiceCategoryEntity
     expose :rates, with: VendorServiceRateEntity
     expose :mobility_trips, with: DetailedMobilityTripEntity
-    expose :image, with: ImageEntity, &self.delegate_to(:images?, :first)
+    expose_image :image
   end
 
   resource :vendor_services do
@@ -50,6 +50,7 @@ class Suma::AdminAPI::VendorServices < Suma::AdminAPI::V1
     ) do
       params do
         optional :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
         optional :external_name, type: String
         optional :period_begin, type: Time
         optional :period_end, type: Time

--- a/lib/suma/admin_api/vendors.rb
+++ b/lib/suma/admin_api/vendors.rb
@@ -13,7 +13,7 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
     expose :services, with: VendorServiceEntity
     expose :products, with: ProductEntity
     expose :configurations, with: VendorConfigurationEntity
-    expose :image, with: ImageEntity, &self.delegate_to(:images?, :first)
+    expose_image :image
   end
 
   resource :vendors do
@@ -29,8 +29,9 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
       DetailedVendorEntity,
     ) do
       params do
-        requires :image, type: File
         requires :name, type: String, allow_blank: false
+        requires :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
       end
     end
 
@@ -46,8 +47,9 @@ class Suma::AdminAPI::Vendors < Suma::AdminAPI::V1
       DetailedVendorEntity,
     ) do
       params do
-        optional :image, type: File
         optional :name, type: String, allow_blank: false
+        optional :image, type: File
+        optional(:image_caption, type: JSON) { use :translated_text, allow_blank: true }
       end
     end
 

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -50,13 +50,14 @@ module Suma::Service::Entities
       end
     end
 
+    def evaluate_exposure(name, block, instance, options)
+      return instance.send(name) unless block
+      return block.arity == 1 ? block[instance] : block[instance, options]
+    end
+
     def self.expose_translated(name, *args, &block)
       self.expose(name, *args) do |instance, options|
-        txt = if block
-                block.arity == 1 ? block[instance] : block[instance, options]
-        else
-          instance.send(name)
-        end
+        txt = self.evaluate_exposure(name, block, instance, options)
         s = txt&.string || ""
         i18n_fmt = Suma::I18n::Formatter.for(s)
         "#{i18n_fmt.flag}#{s}"

--- a/spec/suma/admin_api/vendors_spec.rb
+++ b/spec/suma/admin_api/vendors_spec.rb
@@ -65,10 +65,11 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
 
   describe "POST /v1/vendors/create" do
     it "creates a vendor" do
-      post("/v1/vendors/create", name: "test", image:)
+      post "/v1/vendors/create", name: "test", image:, image_caption: {en: "hi", es: ""}
 
       expect(last_response).to have_status(200)
       expect(Suma::Vendor.all).to have_length(1)
+      expect(Suma::Vendor.first.image).to have_attributes(caption: have_attributes(en: "hi", es: ""))
     end
   end
 
@@ -99,10 +100,21 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
     it "updates a vendor" do
       v = Suma::Fixtures.vendor.create
 
-      post("/v1/vendors/#{v.id}", name: "test", image:)
+      post("/v1/vendors/#{v.id}", name: "test", image:, image_caption: {en: "hi", es: "hola"})
 
       expect(last_response).to have_status(200)
       expect(v.refresh).to have_attributes(name: "test")
+      expect(v.image).to have_attributes(caption: have_attributes(en: "hi", es: "hola"))
+    end
+
+    it "can update only image captions" do
+      v = Suma::Fixtures.vendor.create
+      Suma::Fixtures.image.create(vendor: v)
+
+      post("/v1/vendors/#{v.id}", image_caption: {en: "hi", es: "hola"})
+
+      expect(last_response).to have_status(200)
+      expect(v.image).to have_attributes(caption: have_attributes(en: "hi", es: "hola"))
     end
   end
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=4,user-scalable=yes">
   <meta name="description"
         content="Suma provides affordable housing residents and other frontline community members access to low-cost, secure and easy to use access to clean mobility, food, transportation and utility options.">
   <title>Suma</title>

--- a/webapp/src/assets/styles/topnav.scss
+++ b/webapp/src/assets/styles/topnav.scss
@@ -7,6 +7,11 @@
   font-size: 1.5rem;
   letter-spacing: 1.2px;
   margin-bottom: 0;
+  z-index: 1;
+}
+
+.navbar-container {
+  position: relative;
 }
 
 .navbar-toggler-icon-bar {
@@ -23,6 +28,8 @@
 .navbar-toggler {
   border: none;
   background-image: none !important;
+  position: absolute;
+  right: 0;
 
   &:focus-visible, &:focus {
     box-shadow: none;
@@ -72,6 +79,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  position: absolute;
+  right: 65px;
 }
 
 .offline-status-fadein {

--- a/webapp/src/components/TopNav.jsx
+++ b/webapp/src/components/TopNav.jsx
@@ -32,7 +32,7 @@ export default function TopNav() {
       expanded={expanded}
       onToggle={() => setExpanded(!expanded)}
     >
-      <Container>
+      <Container className="navbar-container">
         <Navbar.Brand
           href="/dashboard"
           className="me-auto d-flex align-items-center"


### PR DESCRIPTION
Improve app nav with scaled fonts

Enable pinch zooming on the web app.

Fix the top nav so that elements do not try to lay out normally;
this causes them to break and stack, which isn't suitable for the nav.
Instead, use absolute positioning so they are aligned to the right,
even if they have to stack on each other.
The need for this is clear when the offline nav indicator is visible.

---

Edit image caption in admin

- Add captions to the ImageFileInput component.
- Expose `image_caption` on resources with `image`.
- Send `image_caption` in as a parameter on create/updated.
  Pull it out to update the associated image.
- Standardize how we display images on a properties list.