### PR TITLE
Signalwire relay: Only look for inbound messages

### DIFF
--- a/lib/suma/anon_proxy/relay.rb
+++ b/lib/suma/anon_proxy/relay.rb
@@ -16,8 +16,9 @@ class Suma::AnonProxy::Relay
   def transport = raise NotImplementedError
 
   # Every relay requires at least one way to process inbound messages.
-  # If WebhookDB is used (see proxy-accounts.md), return the table name.
-  def webhookdb_table = raise NotImplementedError
+  # If WebhookDB is used (see proxy-accounts.md), return the dataset.
+  # This dataset can be limited to only relevant messages, if needed.
+  def webhookdb_dataset = raise NotImplementedError
 
   # Provision an address in the provider.
   # For example, this can be generating an email address

--- a/lib/suma/anon_proxy/relay/fake_relay.rb
+++ b/lib/suma/anon_proxy/relay/fake_relay.rb
@@ -5,7 +5,7 @@ class Suma::AnonProxy::Relay::FakeRelay < Suma::AnonProxy::Relay
 
   def self.deprovision(_addr) = nil
 
-  def webhookdb_table = nil
+  def webhookdb_dataset = nil
   def parse_message(row) = Suma::AnonProxy::ParsedMessage.new(**row)
   def deprovision(addr) = self.class.deprovision(addr)
 end

--- a/lib/suma/anon_proxy/relay/postmark.rb
+++ b/lib/suma/anon_proxy/relay/postmark.rb
@@ -3,7 +3,7 @@
 class Suma::AnonProxy::Relay::Postmark < Suma::AnonProxy::Relay
   def key = "postmark"
   def transport = :email
-  def webhookdb_table = Suma::Webhookdb.postmark_inbound_messages_table
+  def webhookdb_dataset = Suma::Webhookdb.postmark_inbound_messages_dataset
   def provision(member) = ProvisionedAddress.new(Suma::AnonProxy.postmark_email_template % {member_id: member.id})
   def deprovision(_addr) = nil
 

--- a/lib/suma/anon_proxy/relay/signalwire.rb
+++ b/lib/suma/anon_proxy/relay/signalwire.rb
@@ -5,7 +5,7 @@ require "suma/async/anon_proxy_destroyed_member_contact_cleanup"
 class Suma::AnonProxy::Relay::Signalwire < Suma::AnonProxy::Relay
   def key = "signalwire"
   def transport = :phone
-  def webhookdb_table = Suma::Webhookdb.signalwire_messages_table
+  def webhookdb_dataset = Suma::Webhookdb.signalwire_messages_dataset.where(direction: "inbound")
 
   def provision(member)
     raise Suma::InvalidPrecondition, "Member[#{member.id}] phone #{member.phone} is not in the SMS_ALLOWLIST" unless

--- a/lib/suma/async/process_anon_proxy_inbound_webhookdb_relays.rb
+++ b/lib/suma/async/process_anon_proxy_inbound_webhookdb_relays.rb
@@ -33,11 +33,11 @@ class Suma::Async::ProcessAnonProxyInboundWebhookdbRelays
   def _inner_perform
     Suma::AnonProxy::Relay.registry.each_value do |relay_cls|
       relay = relay_cls.new
-      next unless relay.webhookdb_table
+      next unless relay.webhookdb_dataset
       cache_key = self.class.relay_cache_key(relay)
       last_synced_pk = Suma::Redis.cache.with { |c| c.call("GET", cache_key) }.to_i
       highest_pk = last_synced_pk
-      Suma::Webhookdb.dataset_for_table(relay.webhookdb_table).where { pk > last_synced_pk }.each do |row|
+      relay.webhookdb_dataset.where { pk > last_synced_pk }.each do |row|
         highest_pk = [highest_pk, row[:pk]].max
         message = relay.parse_message(row)
         Suma::AnonProxy::MessageHandler.handle(relay, message)


### PR DESCRIPTION
We were checking all Signalwire messages for relay handling. Some don't have a from or to address though.
Instead we should only process inbound messages
(which will always have both).
This only makes sense for a relay anyway; it doesn't care about outbound messages.

Also change Relay#webhookdb_table to Relay#webhookdb_dataset, so we can do this filtering at the relay level.