### PR TITLE
Make verifications safe to use on staging

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ SERVICE_ENFORCE_SSL=false
 SERVICE_VERIFY_LOCALIZED_RESPONSE_CODES=true
 DATABASE_URL=postgres://suma:suma@localhost:22006/suma_test
 REDIS_URL=redis://localhost:22007/0
+WEBHOOKDB_MODELS_ENABLED=true

--- a/adminapp/src/api.js
+++ b/adminapp/src/api.js
@@ -79,229 +79,279 @@ export default {
   put,
   del,
   signOut: () => del("/adminapi/v1/auth"),
-  signIn: (data) => post("/adminapi/v1/auth", data),
-  getCurrentUser: (data) => get(`/adminapi/v1/auth`, data),
-  impersonate: ({ id, ...data }) => post(`/adminapi/v1/auth/impersonate/${id}`, data),
-  unimpersonate: (data) => del(`/adminapi/v1/auth/impersonate`, data),
-  getCurrencies: (data) => get(`/adminapi/v1/meta/currencies`, data),
-  getSupportedGeographies: (data) => get(`/adminapi/v1/meta/geographies`, data),
-  getVendorServiceCategories: (data) =>
-    get(`/adminapi/v1/meta/vendor_service_categories`, data),
-  getProgramsMeta: (data) => get(`/adminapi/v1/meta/programs`, data),
-  getResourceAccessMeta: (data) => get(`/adminapi/v1/meta/resource_access`, data),
+  signIn: (data, ...args) => post("/adminapi/v1/auth", data, ...args),
+  getCurrentUser: (data, ...args) => get(`/adminapi/v1/auth`, data, ...args),
+  impersonate: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/auth/impersonate/${id}`, data, ...args),
+  unimpersonate: (data, ...args) => del(`/adminapi/v1/auth/impersonate`, data, ...args),
+  getCurrencies: (data, ...args) => get(`/adminapi/v1/meta/currencies`, data, ...args),
+  getSupportedGeographies: (data, ...args) =>
+    get(`/adminapi/v1/meta/geographies`, data, ...args),
+  getVendorServiceCategories: (data, ...args) =>
+    get(`/adminapi/v1/meta/vendor_service_categories`, data, ...args),
+  getProgramsMeta: (data, ...args) => get(`/adminapi/v1/meta/programs`, data, ...args),
+  getResourceAccessMeta: (data, ...args) =>
+    get(`/adminapi/v1/meta/resource_access`, data, ...args),
 
-  getBankAccount: ({ id, ...data }) => get(`/adminapi/v1/bank_accounts/${id}`, data),
+  getBankAccount: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/bank_accounts/${id}`, data, ...args),
 
-  getBookTransactions: (data) => get(`/adminapi/v1/book_transactions`, data),
-  getBookTransaction: ({ id, ...data }) =>
-    get(`/adminapi/v1/book_transactions/${id}`, data),
-  createBookTransaction: (data) => post(`/adminapi/v1/book_transactions/create`, data),
+  getBookTransactions: (data, ...args) =>
+    get(`/adminapi/v1/book_transactions`, data, ...args),
+  getBookTransaction: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/book_transactions/${id}`, data, ...args),
+  createBookTransaction: (data, ...args) =>
+    post(`/adminapi/v1/book_transactions/create`, data, ...args),
 
-  getFundingTransactions: (data) => get(`/adminapi/v1/funding_transactions`, data),
-  getFundingTransaction: ({ id, ...data }) =>
-    get(`/adminapi/v1/funding_transactions/${id}`, data),
-  createForSelfFundingTransaction: (data) =>
-    post(`/adminapi/v1/funding_transactions/create_for_self`, data),
-  refundFundingTransaction: ({ id, ...data }) =>
-    post(`/adminapi/v1/funding_transactions/${id}/refund`, data),
-  getPayoutTransactions: (data) => get(`/adminapi/v1/payout_transactions`, data),
-  getPayoutTransaction: ({ id, ...data }) =>
-    get(`/adminapi/v1/payout_transactions/${id}`, data),
+  getFundingTransactions: (data, ...args) =>
+    get(`/adminapi/v1/funding_transactions`, data, ...args),
+  getFundingTransaction: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/funding_transactions/${id}`, data, ...args),
+  createForSelfFundingTransaction: (data, ...args) =>
+    post(`/adminapi/v1/funding_transactions/create_for_self`, data, ...args),
+  refundFundingTransaction: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/funding_transactions/${id}/refund`, data, ...args),
+  getPayoutTransactions: (data, ...args) =>
+    get(`/adminapi/v1/payout_transactions`, data, ...args),
+  getPayoutTransaction: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/payout_transactions/${id}`, data, ...args),
 
-  getCharges: (data) => get(`/adminapi/v1/charges`, data),
-  getCharge: ({ id, ...data }) => get(`/adminapi/v1/charges/${id}`, data),
+  getCharges: (data, ...args) => get(`/adminapi/v1/charges`, data, ...args),
+  getCharge: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/charges/${id}`, data, ...args),
 
-  getPaymentLedgers: (data) => get(`/adminapi/v1/payment_ledgers`, data),
-  getPaymentLedger: ({ id, ...data }) => get(`/adminapi/v1/payment_ledgers/${id}`, data),
+  getPaymentLedgers: (data, ...args) =>
+    get(`/adminapi/v1/payment_ledgers`, data, ...args),
+  getPaymentLedger: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/payment_ledgers/${id}`, data, ...args),
 
-  getPaymentTriggers: (data) => get(`/adminapi/v1/payment_triggers`, data),
-  createPaymentTrigger: (data) => post(`/adminapi/v1/payment_triggers/create`, data),
-  getPaymentTrigger: ({ id, ...data }) =>
-    get(`/adminapi/v1/payment_triggers/${id}`, data),
-  updatePaymentTrigger: ({ id, ...data }) =>
-    post(`/adminapi/v1/payment_triggers/${id}`, data),
-  updatePaymentTriggerPrograms: ({ id, ...data }) =>
-    post(`/adminapi/v1/payment_triggers/${id}/programs`, data),
-  subdividePaymentTrigger: ({ id, ...data }) =>
-    post(`/adminapi/v1/payment_triggers/${id}/subdivide`, data),
+  getPaymentTriggers: (data, ...args) =>
+    get(`/adminapi/v1/payment_triggers`, data, ...args),
+  createPaymentTrigger: (data, ...args) =>
+    post(`/adminapi/v1/payment_triggers/create`, data, ...args),
+  getPaymentTrigger: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/payment_triggers/${id}`, data, ...args),
+  updatePaymentTrigger: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/payment_triggers/${id}`, data, ...args),
+  updatePaymentTriggerPrograms: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/payment_triggers/${id}/programs`, data, ...args),
+  subdividePaymentTrigger: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/payment_triggers/${id}/subdivide`, data, ...args),
 
-  getCommerceOfferings: (data) => get("/adminapi/v1/commerce_offerings", data),
-  getCommerceOffering: ({ id, ...data }) =>
-    get(`/adminapi/v1/commerce_offerings/${id}`, data),
-  createCommerceOffering: (data) =>
-    postForm("/adminapi/v1/commerce_offerings/create", data),
-  updateCommerceOffering: ({ id, ...data }) =>
-    postForm(`/adminapi/v1/commerce_offerings/${id}`, data),
-  updateOfferingPrograms: ({ id, ...data }) =>
-    post(`/adminapi/v1/commerce_offerings/${id}/programs`, data),
-  getCommerceOfferingPickList: ({ id, ...data }) =>
-    get(`/adminapi/v1/commerce_offerings/${id}/picklist`, data),
+  getCommerceOfferings: (data, ...args) =>
+    get("/adminapi/v1/commerce_offerings", data, ...args),
+  getCommerceOffering: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/commerce_offerings/${id}`, data, ...args),
+  createCommerceOffering: (data, ...args) =>
+    postForm("/adminapi/v1/commerce_offerings/create", data, ...args),
+  updateCommerceOffering: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/commerce_offerings/${id}`, data, ...args),
+  updateOfferingPrograms: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/commerce_offerings/${id}/programs`, data, ...args),
+  getCommerceOfferingPickList: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/commerce_offerings/${id}/picklist`, data, ...args),
 
-  getCommerceProducts: (data) => get("/adminapi/v1/commerce_products", data),
-  createCommerceProduct: (data) =>
-    postForm("/adminapi/v1/commerce_products/create", data),
-  getCommerceProduct: ({ id, ...data }) =>
-    get(`/adminapi/v1/commerce_products/${id}`, data),
-  updateCommerceProduct: ({ id, ...data }) =>
-    postForm(`/adminapi/v1/commerce_products/${id}`, data),
+  getCommerceProducts: (data, ...args) =>
+    get("/adminapi/v1/commerce_products", data, ...args),
+  createCommerceProduct: (data, ...args) =>
+    postForm("/adminapi/v1/commerce_products/create", data, ...args),
+  getCommerceProduct: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/commerce_products/${id}`, data, ...args),
+  updateCommerceProduct: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/commerce_products/${id}`, data, ...args),
 
-  createCommerceOfferingProduct: (data) =>
-    postForm("/adminapi/v1/commerce_offering_products/create", data),
-  getCommerceOfferingProduct: ({ id, ...data }) =>
-    get(`/adminapi/v1/commerce_offering_products/${id}`, data),
-  updateCommerceOfferingProduct: ({ id, ...data }) =>
-    post(`/adminapi/v1/commerce_offering_products/${id}`, data),
+  createCommerceOfferingProduct: (data, ...args) =>
+    postForm("/adminapi/v1/commerce_offering_products/create", data, ...args),
+  getCommerceOfferingProduct: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/commerce_offering_products/${id}`, data, ...args),
+  updateCommerceOfferingProduct: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/commerce_offering_products/${id}`, data, ...args),
 
-  getVendors: (data) => get(`/adminapi/v1/vendors`, data),
-  createVendor: (data) => postForm("/adminapi/v1/vendors/create", data),
-  getVendor: ({ id, ...data }) => get(`/adminapi/v1/vendors/${id}`, data),
-  updateVendor: ({ id, ...data }) => postForm(`/adminapi/v1/vendors/${id}`, data),
+  getVendors: (data, ...args) => get(`/adminapi/v1/vendors`, data, ...args),
+  createVendor: (data, ...args) => postForm("/adminapi/v1/vendors/create", data, ...args),
+  getVendor: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/vendors/${id}`, data, ...args),
+  updateVendor: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/vendors/${id}`, data, ...args),
 
-  getMarketingLists: (data) => get(`/adminapi/v1/marketing_lists`, data),
-  createMarketingList: (data) => post("/adminapi/v1/marketing_lists/create", data),
-  getMarketingList: ({ id, ...data }) => get(`/adminapi/v1/marketing_lists/${id}`, data),
-  updateMarketingList: ({ id, ...data }) =>
-    post(`/adminapi/v1/marketing_lists/${id}`, data),
+  getMarketingLists: (data, ...args) =>
+    get(`/adminapi/v1/marketing_lists`, data, ...args),
+  createMarketingList: (data, ...args) =>
+    post("/adminapi/v1/marketing_lists/create", data, ...args),
+  getMarketingList: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/marketing_lists/${id}`, data, ...args),
+  updateMarketingList: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/marketing_lists/${id}`, data, ...args),
 
-  getMarketingSmsBroadcasts: (data) => get(`/adminapi/v1/marketing_sms_broadcasts`, data),
-  createMarketingSmsBroadcast: (data) =>
-    post("/adminapi/v1/marketing_sms_broadcasts/create", data),
-  getMarketingSmsBroadcast: ({ id, ...data }) =>
-    get(`/adminapi/v1/marketing_sms_broadcasts/${id}`, data),
-  updateMarketingSmsBroadcast: ({ id, ...data }) =>
-    post(`/adminapi/v1/marketing_sms_broadcasts/${id}`, data),
-  sendMarketingSmsBroadcast: ({ id, ...data }) =>
-    post(`/adminapi/v1/marketing_sms_broadcasts/${id}/send`, data),
-  previewMarketingSmsBroadcast: (data) =>
-    post(`/adminapi/v1/marketing_sms_broadcasts/preview`, data),
-  getMarketingSmsBroadcastReview: ({ id, ...data }) =>
-    get(`/adminapi/v1/marketing_sms_broadcasts/${id}/review`, data),
+  getMarketingSmsBroadcasts: (data, ...args) =>
+    get(`/adminapi/v1/marketing_sms_broadcasts`, data, ...args),
+  createMarketingSmsBroadcast: (data, ...args) =>
+    post("/adminapi/v1/marketing_sms_broadcasts/create", data, ...args),
+  getMarketingSmsBroadcast: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/marketing_sms_broadcasts/${id}`, data, ...args),
+  updateMarketingSmsBroadcast: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/marketing_sms_broadcasts/${id}`, data, ...args),
+  sendMarketingSmsBroadcast: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/marketing_sms_broadcasts/${id}/send`, data, ...args),
+  previewMarketingSmsBroadcast: (data, ...args) =>
+    post(`/adminapi/v1/marketing_sms_broadcasts/preview`, data, ...args),
+  getMarketingSmsBroadcastReview: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/marketing_sms_broadcasts/${id}/review`, data, ...args),
 
-  getMarketingSmsDispatches: (data) => get(`/adminapi/v1/marketing_sms_dispatches`, data),
-  getMarketingSmsDispatch: ({ id, ...data }) =>
-    get(`/adminapi/v1/marketing_sms_dispatches/${id}`, data),
-  cancelMarketingSmsDispatch: ({ id, ...data }) =>
-    post(`/adminapi/v1/marketing_sms_dispatches/${id}/cancel`, data),
+  getMarketingSmsDispatches: (data, ...args) =>
+    get(`/adminapi/v1/marketing_sms_dispatches`, data, ...args),
+  getMarketingSmsDispatch: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/marketing_sms_dispatches/${id}`, data, ...args),
+  cancelMarketingSmsDispatch: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/marketing_sms_dispatches/${id}/cancel`, data, ...args),
 
-  getPrograms: (data) => get(`/adminapi/v1/programs`, data),
-  createProgram: (data) => postForm("/adminapi/v1/programs/create", data),
-  getProgram: ({ id, ...data }) => get(`/adminapi/v1/programs/${id}`, data),
-  updateProgram: ({ id, ...data }) => postForm(`/adminapi/v1/programs/${id}`, data),
+  getPrograms: (data, ...args) => get(`/adminapi/v1/programs`, data, ...args),
+  createProgram: (data, ...args) =>
+    postForm("/adminapi/v1/programs/create", data, ...args),
+  getProgram: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/programs/${id}`, data, ...args),
+  updateProgram: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/programs/${id}`, data, ...args),
 
-  getProgramEnrollments: (data) => get(`/adminapi/v1/program_enrollments`, data),
-  createProgramEnrollment: (data) =>
-    postForm("/adminapi/v1/program_enrollments/create", data),
-  getProgramEnrollment: ({ id, ...data }) =>
-    get(`/adminapi/v1/program_enrollments/${id}`, data),
-  updateProgramEnrollment: ({ id, ...data }) =>
-    postForm(`/adminapi/v1/program_enrollments/${id}`, data),
+  getProgramEnrollments: (data, ...args) =>
+    get(`/adminapi/v1/program_enrollments`, data, ...args),
+  createProgramEnrollment: (data, ...args) =>
+    postForm("/adminapi/v1/program_enrollments/create", data, ...args),
+  getProgramEnrollment: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/program_enrollments/${id}`, data, ...args),
+  updateProgramEnrollment: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/program_enrollments/${id}`, data, ...args),
 
-  getVendorServices: (data) => get(`/adminapi/v1/vendor_services`, data),
-  getVendorService: ({ id, ...data }) => get(`/adminapi/v1/vendor_services/${id}`, data),
-  updateVendorService: ({ id, ...data }) =>
-    postForm(`/adminapi/v1/vendor_services/${id}`, data),
-  updateVendorServicePrograms: ({ id, ...data }) =>
-    post(`/adminapi/v1/vendor_services/${id}/programs`, data),
+  getVendorServices: (data, ...args) =>
+    get(`/adminapi/v1/vendor_services`, data, ...args),
+  getVendorService: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/vendor_services/${id}`, data, ...args),
+  updateVendorService: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/vendor_services/${id}`, data, ...args),
+  updateVendorServicePrograms: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/vendor_services/${id}/programs`, data, ...args),
 
-  getVendorAccounts: (data) => get("/adminapi/v1/anon_proxy/vendor_accounts", data),
-  getVendorAccount: ({ id, ...data }) =>
-    get(`/adminapi/v1/anon_proxy/vendor_accounts/${id}`, data),
-  destroyVendorAccount: ({ id, ...data }) =>
-    post(`/adminapi/v1/anon_proxy/vendor_accounts/${id}/destroy`, data),
+  getVendorAccounts: (data, ...args) =>
+    get("/adminapi/v1/anon_proxy/vendor_accounts", data, ...args),
+  getVendorAccount: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/anon_proxy/vendor_accounts/${id}`, data, ...args),
+  destroyVendorAccount: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/anon_proxy/vendor_accounts/${id}/destroy`, data, ...args),
 
-  getVendorConfigurations: (data) =>
-    get("/adminapi/v1/anon_proxy/vendor_configurations", data),
-  getVendorConfiguration: ({ id, ...data }) =>
-    get(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data),
-  updateVendorConfiguration: ({ id, ...data }) =>
-    postForm(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data),
-  updateVendorConfigurationPrograms: ({ id, ...data }) =>
-    post(`/adminapi/v1/anon_proxy/vendor_configurations/${id}/programs`, data),
+  getVendorConfigurations: (data, ...args) =>
+    get("/adminapi/v1/anon_proxy/vendor_configurations", data, ...args),
+  getVendorConfiguration: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data, ...args),
+  updateVendorConfiguration: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/anon_proxy/vendor_configurations/${id}`, data, ...args),
+  updateVendorConfigurationPrograms: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/anon_proxy/vendor_configurations/${id}/programs`, data, ...args),
 
-  getAnonMemberContacts: (data) => get(`/adminapi/v1/anon_proxy/member_contacts`, data),
-  provisionAnonMemberContact: (data) =>
-    post("/adminapi/v1/anon_proxy/member_contacts/provision", data),
-  getAnonMemberContact: ({ id, ...data }) =>
-    get(`/adminapi/v1/anon_proxy/member_contacts/${id}`, data),
-  updateAnonMemberContact: ({ id, ...data }) =>
-    post(`/adminapi/v1/anon_proxy/member_contacts/${id}`, data),
-  destroyMemberContact: ({ id, ...data }) =>
-    post(`/adminapi/v1/anon_proxy/member_contacts/${id}/destroy`, data),
+  getAnonMemberContacts: (data, ...args) =>
+    get(`/adminapi/v1/anon_proxy/member_contacts`, data, ...args),
+  provisionAnonMemberContact: (data, ...args) =>
+    post("/adminapi/v1/anon_proxy/member_contacts/provision", data, ...args),
+  getAnonMemberContact: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/anon_proxy/member_contacts/${id}`, data, ...args),
+  updateAnonMemberContact: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/anon_proxy/member_contacts/${id}`, data, ...args),
+  destroyMemberContact: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/anon_proxy/member_contacts/${id}/destroy`, data, ...args),
 
-  getCommerceOrders: (data) => get(`/adminapi/v1/commerce_orders`, data),
-  getCommerceOrder: ({ id, ...data }) => get(`/adminapi/v1/commerce_orders/${id}`, data),
+  getCommerceOrders: (data, ...args) =>
+    get(`/adminapi/v1/commerce_orders`, data, ...args),
+  getCommerceOrder: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/commerce_orders/${id}`, data, ...args),
 
-  getMessageDeliveries: (data) => get(`/adminapi/v1/message_deliveries`, data),
-  getMessageDelivery: ({ id, ...data }) =>
-    get(`/adminapi/v1/message_deliveries/${id}`, data),
+  getMessageDeliveries: (data, ...args) =>
+    get(`/adminapi/v1/message_deliveries`, data, ...args),
+  getMessageDelivery: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/message_deliveries/${id}`, data, ...args),
 
-  getMembers: (data) => get(`/adminapi/v1/members`, data),
-  getMember: ({ id, ...data }) => get(`/adminapi/v1/members/${id}`, data),
-  updateMember: ({ id, ...data }) => post(`/adminapi/v1/members/${id}`, data),
-  softDeleteMember: ({ id, ...data }) => post(`/adminapi/v1/members/${id}/close`, data),
+  getMembers: (data, ...args) => get(`/adminapi/v1/members`, data, ...args),
+  getMember: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/members/${id}`, data, ...args),
+  updateMember: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/members/${id}`, data, ...args),
+  softDeleteMember: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/members/${id}/close`, data, ...args),
 
-  getOrganizations: (data) => get(`/adminapi/v1/organizations`, data),
+  getOrganizations: (data, ...args) => get(`/adminapi/v1/organizations`, data, ...args),
   getOrganization: ({ id }) => get(`/adminapi/v1/organizations/${id}`),
-  createOrganization: (data) => post("/adminapi/v1/organizations/create", data),
-  updateOrganization: ({ id, ...data }) => post(`/adminapi/v1/organizations/${id}`, data),
+  createOrganization: (data, ...args) =>
+    post("/adminapi/v1/organizations/create", data, ...args),
+  updateOrganization: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/organizations/${id}`, data, ...args),
 
-  getOrganizationMemberships: (data) =>
-    get(`/adminapi/v1/organization_memberships`, data),
+  getOrganizationMemberships: (data, ...args) =>
+    get(`/adminapi/v1/organization_memberships`, data, ...args),
   getOrganizationMembership: ({ id }) =>
     get(`/adminapi/v1/organization_memberships/${id}`),
-  createOrganizationMembership: (data) =>
-    post("/adminapi/v1/organization_memberships/create", data),
-  updateOrganizationMembership: ({ id, ...data }) =>
-    post(`/adminapi/v1/organization_memberships/${id}`, data),
+  createOrganizationMembership: (data, ...args) =>
+    post("/adminapi/v1/organization_memberships/create", data, ...args),
+  updateOrganizationMembership: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/organization_memberships/${id}`, data, ...args),
 
-  getOrganizationMembershipVerifications: (data) =>
-    get(`/adminapi/v1/organization_membership_verifications`, data),
-  getOrganizationMembershipVerification: ({ id, ...data }) =>
-    get(`/adminapi/v1/organization_membership_verifications/${id}`, data),
-  transitionOrganizationMembershipVerification: ({ id, ...data }) =>
-    post(`/adminapi/v1/organization_membership_verifications/${id}/transition`, data),
-  beginOrganizationMembershipVerificationPartnerOutreach: ({ id, ...data }) =>
+  getOrganizationMembershipVerifications: (data, ...args) =>
+    get(`/adminapi/v1/organization_membership_verifications`, data, ...args),
+  getOrganizationMembershipVerification: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/organization_membership_verifications/${id}`, data, ...args),
+  transitionOrganizationMembershipVerification: ({ id, ...data }, ...args) =>
+    post(
+      `/adminapi/v1/organization_membership_verifications/${id}/transition`,
+      data,
+      ...args
+    ),
+  beginOrganizationMembershipVerificationPartnerOutreach: ({ id, ...data }, ...args) =>
     post(
       `/adminapi/v1/organization_membership_verifications/${id}/begin_partner_outreach`,
       data
     ),
-  beginOrganizationMembershipVerificationMemberOutreach: ({ id, ...data }) =>
+  beginOrganizationMembershipVerificationMemberOutreach: ({ id, ...data }, ...args) =>
     post(
       `/adminapi/v1/organization_membership_verifications/${id}/begin_member_outreach`,
       data
     ),
-  addOrganizationMembershipVerificationNote: ({ id, ...data }) =>
-    post(`/adminapi/v1/organization_membership_verifications/${id}/notes`, data),
+  addOrganizationMembershipVerificationNote: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/organization_membership_verifications/${id}/notes`, data, ...args),
   editOrganizationMembershipVerificationNote: ({ id, noteId, ...data }) =>
     post(
       `/adminapi/v1/organization_membership_verifications/${id}/notes/${noteId}`,
       data
     ),
 
-  getMobilityTrips: (data) => get(`/adminapi/v1/mobility_trips`, data),
-  getMobilityTrip: ({ id, ...data }) => get(`/adminapi/v1/mobility_trips/${id}`, data),
-  updateMobilityTrip: ({ id, ...data }) =>
-    post(`/adminapi/v1/mobility_trips/${id}`, data),
+  getMobilityTrips: (data, ...args) => get(`/adminapi/v1/mobility_trips`, data, ...args),
+  getMobilityTrip: ({ id, ...data }, ...args) =>
+    get(`/adminapi/v1/mobility_trips/${id}`, data, ...args),
+  updateMobilityTrip: ({ id, ...data }, ...args) =>
+    post(`/adminapi/v1/mobility_trips/${id}`, data, ...args),
 
-  getRoles: (data) => get(`/adminapi/v1/roles`, data),
-  createRole: (data) => postForm("/adminapi/v1/roles/create", data),
-  getRole: ({ id, ...data }) => get(`/adminapi/v1/roles/${id}`, data),
-  updateRole: ({ id, ...data }) => postForm(`/adminapi/v1/roles/${id}`, data),
+  getRoles: (data, ...args) => get(`/adminapi/v1/roles`, data, ...args),
+  createRole: (data, ...args) => postForm("/adminapi/v1/roles/create", data, ...args),
+  getRole: ({ id, ...data }, ...args) => get(`/adminapi/v1/roles/${id}`, data, ...args),
+  updateRole: ({ id, ...data }, ...args) =>
+    postForm(`/adminapi/v1/roles/${id}`, data, ...args),
 
-  searchProducts: (data) => post(`/adminapi/v1/search/products`, data),
-  searchOfferings: (data) => post(`/adminapi/v1/search/offerings`, data),
-  searchPaymentInstruments: (data) =>
-    post(`/adminapi/v1/search/payment_instruments`, data),
-  searchLedgers: (data) => post(`/adminapi/v1/search/ledgers`, data),
-  searchLedgersLookup: (data) => post(`/adminapi/v1/search/ledgers/lookup`, data),
-  searchTranslations: (data) => post(`/adminapi/v1/search/translations`, data),
-  searchVendors: (data) => post(`/adminapi/v1/search/vendors`, data),
-  searchMembers: (data) => post(`/adminapi/v1/search/members`, data),
-  searchOrganizations: (data) => post(`/adminapi/v1/search/organizations`, data),
-  searchRoles: (data) => post(`/adminapi/v1/search/roles`, data),
-  searchVendorServices: (data) => post(`/adminapi/v1/search/vendor_services`, data),
-  searchCommerceOffering: (data) => post(`/adminapi/v1/search/commerce_offerings`, data),
-  searchPrograms: (data) => post(`/adminapi/v1/search/programs`, data),
+  searchProducts: (data, ...args) => post(`/adminapi/v1/search/products`, data, ...args),
+  searchOfferings: (data, ...args) =>
+    post(`/adminapi/v1/search/offerings`, data, ...args),
+  searchPaymentInstruments: (data, ...args) =>
+    post(`/adminapi/v1/search/payment_instruments`, data, ...args),
+  searchLedgers: (data, ...args) => post(`/adminapi/v1/search/ledgers`, data, ...args),
+  searchLedgersLookup: (data, ...args) =>
+    post(`/adminapi/v1/search/ledgers/lookup`, data, ...args),
+  searchTranslations: (data, ...args) =>
+    post(`/adminapi/v1/search/translations`, data, ...args),
+  searchVendors: (data, ...args) => post(`/adminapi/v1/search/vendors`, data, ...args),
+  searchMembers: (data, ...args) => post(`/adminapi/v1/search/members`, data, ...args),
+  searchOrganizations: (data, ...args) =>
+    post(`/adminapi/v1/search/organizations`, data, ...args),
+  searchRoles: (data, ...args) => post(`/adminapi/v1/search/roles`, data, ...args),
+  searchVendorServices: (data, ...args) =>
+    post(`/adminapi/v1/search/vendor_services`, data, ...args),
+  searchCommerceOffering: (data, ...args) =>
+    post(`/adminapi/v1/search/commerce_offerings`, data, ...args),
+  searchPrograms: (data, ...args) => post(`/adminapi/v1/search/programs`, data, ...args),
 
   /**
    * Return an API url.

--- a/lib/suma/admin_api.rb
+++ b/lib/suma/admin_api.rb
@@ -64,6 +64,33 @@ module Suma::AdminAPI
       end
     end
   end
+
+  # Mixin for endpoints using Server Sent Events.
+  # The endpoints should:
+  # - Return an event subscription auth token in some GET endpoint (usually the list or resource being subscribed to)
+  # - Include that auth token in all mutating methods using the same header.
+  # - Any events that happen during a reuqest using that auth token, will not be published to the subscriber
+  #   registered with that token. This avoids notifying about an action the user took, in the same browser window.
+  module ServerSentEvents
+    def self.included(mod)
+      super
+      mod.instance_eval do
+        before do
+          if Suma::Http::UNSAFE_METHODS.include?(env["REQUEST_METHOD"]) && !headers.key?(Suma::SSE::TOKEN_HEADER)
+            # If we are taking an action that would result in an update, make sure the caller has included
+            # an event token so we don't replay events back to the client.
+            msg = "Endpoint uses Server Sent Events so requires a '#{Suma::SSE::TOKEN_HEADER}' header"
+            adminerror!(400, msg, code: "missing_sse_token")
+          end
+          Suma::SSE.current_session_id = headers[Suma::SSE::TOKEN_HEADER]
+        end
+
+        after do
+          Suma::SSE.current_session_id = nil
+        end
+      end
+    end
+  end
 end
 
 require "suma/admin_api/common_endpoints"

--- a/lib/suma/admin_api/organization_membership_verifications.rb
+++ b/lib/suma/admin_api/organization_membership_verifications.rb
@@ -4,6 +4,7 @@ require "suma/admin_api"
 
 class Suma::AdminAPI::OrganizationMembershipVerifications < Suma::AdminAPI::V1
   include Suma::AdminAPI::Entities
+  include Suma::AdminAPI::ServerSentEvents
 
   class MembershipVerificationNoteEntity < BaseEntity
     include Suma::AdminAPI::Entities
@@ -89,7 +90,8 @@ class Suma::AdminAPI::OrganizationMembershipVerifications < Suma::AdminAPI::V1
       end
       ds = paginate(ds, params)
       ds = ds.select(Sequel[:organization_membership_verifications][Sequel.lit("*")])
-      header Suma::SSE::Auth::HEADER, Suma::SSE::Auth.generate_token
+      header Suma::SSE::TOKEN_HEADER, Suma::SSE::Auth.generate_token
+      header("Suma-Front-Enabled", "1") if Suma::Frontapp.configured?
       present_collection ds, with: VerificationListEntity
     end
 

--- a/lib/suma/http.rb
+++ b/lib/suma/http.rb
@@ -8,6 +8,9 @@ require "appydays/loggable/httparty_formatter"
 module Suma::Http
   include Appydays::Configurable
 
+  SAFE_METHODS = ["GET", "HEAD", "OPTIONS", "TRACE"].freeze
+  UNSAFE_METHODS = ["POST", "PUT", "PATCH", "DELETE", "CONNECT"].freeze
+
   configurable(:sumahttp) do
     # Keys are hosts ('app.mysuma.org'), values are env vars names ('QUOTAGUARDSTATIC_URL').
     # A value of '{"app.mysuma.org":"QUOTAGUARDSTATIC_URL"}' would proxy all requests to app.mysuma.org

--- a/lib/suma/redis.rb
+++ b/lib/suma/redis.rb
@@ -44,8 +44,6 @@ module Suma::Redis
   configurable(:redis) do
     setting :cache_url, ""
     setting :cache_url_provider, "REDIS_URL"
-    setting :pubsub_url, ""
-    setting :pubsub_url_provider, "REDIS_URL"
 
     after_configured do
       self.cache = self.create_pool(self.cache_url_provider, self.cache_url)

--- a/lib/suma/sse.rb
+++ b/lib/suma/sse.rb
@@ -7,6 +7,7 @@ module Suma::SSE
   include Appydays::Configurable
   include Appydays::Loggable
 
+  TOKEN_HEADER = "Suma-Events-Token"
   ORGANIZATION_MEMBERSHIP_VERIFICATIONS = "organization_membership_verifications"
 
   class << self
@@ -24,10 +25,23 @@ module Suma::SSE
   end
 
   class << self
+    # The SSE session cookie uniquely identifies a connected client (browser tab)
+    # so it does not get it publishes.
+    def generate_session_id = SecureRandom.base36(12)
+    def current_session_id = Thread.current[:sse_session_id]
+
+    def current_session_id=(id)
+      Thread.current[:sse_session_id] = id
+    end
+
     # Publish a payload via Redis.
     # Note that the payload here should be
     def publish(topic, payload, t: Time.now)
-      self.publisher_redis.publish(topic, {payload:, t: t.to_f}.to_json)
+      msg = {payload:, t: t.to_f}
+      if (sid = self.current_session_id)
+        msg[:sid] = sid
+      end
+      self.publisher_redis.publish(topic, msg.to_json)
     end
 
     def new_subscriber_redis
@@ -35,12 +49,20 @@ module Suma::SSE
       return Redis.new(**Suma::Redis.conn_params(redis_url))
     end
 
-    def subscribe(topic)
+    def subscribe(topic, session_id: nil)
       redis = self.new_subscriber_redis
       redis.subscribe(topic) do |on|
         on.message do |_channel, data|
           msg = JSON.parse(data)
-          yield(msg)
+          msg_sid = msg["sid"]
+          # The subscriber should know about the message if:
+          # - We don't have a subscriber
+          # - The message was published by an anonymous subscriber
+          # - The message was published by another subscriber
+          subscriber_cares = session_id.nil? ||
+            msg_sid.nil? ||
+            session_id != msg_sid
+          yield(msg) if subscriber_cares
         end
       end
     rescue IOError

--- a/lib/suma/sse/auth.rb
+++ b/lib/suma/sse/auth.rb
@@ -8,7 +8,6 @@
 #
 # The TTL is short because once the event session is established, it stays open.
 module Suma::SSE::Auth
-  HEADER = "Suma-Events-Token"
   TTL = 5.minutes
 
   class Error < StandardError; end
@@ -31,6 +30,9 @@ module Suma::SSE::Auth
       plain = payload.to_json
       encrypted = c.update(plain) + c.final
       b64 = Base64.urlsafe_encode64(encrypted)
+      # Equal sign ends up being encoded, and can cause issues since this token is being passed around
+      # in a body, header, and query param. We don't need to include the padding, so remove it.
+      b64.gsub!(/=+$/, "")
       encoded = URI.encode_uri_component(b64)
       return encoded
     end

--- a/lib/suma/sse/middleware.rb
+++ b/lib/suma/sse/middleware.rb
@@ -52,7 +52,7 @@ class Suma::SSE::Middleware
     socket = env["rack.hijack_io"]
     client = self.class.clients.add_client(@path, socket)
     Thread.new do
-      Suma::SSE.subscribe(@topic) do |msg|
+      Suma::SSE.subscribe(@topic, session_id: token) do |msg|
         break unless self.class.clients.senddata(client, msg.to_json)
       end
     rescue StandardError => e
@@ -88,6 +88,8 @@ class Suma::SSE::Middleware
           end
         end
       end
+      # We don't need to know about exceptions, we kill this thread forcefully.
+      @pinger.report_on_exception = false
     end
 
     def add_client(path, socket)

--- a/lib/suma/webhookdb.rb
+++ b/lib/suma/webhookdb.rb
@@ -18,6 +18,8 @@ module Suma::Webhookdb
   configurable(:webhookdb) do
     setting :database_url, ENV.fetch("DATABASE_URL", nil)
     setting :schema, :public
+    # See +Suma::Webhookdb::Model+ for more information.
+    setting :models_enabled, false
     setting :front_conversations_table, :front_conversation_v1_fixture
     setting :front_messages_table, :front_message_v1_fixture
     setting :postmark_inbound_messages_table, :postmark_inbound_message_v1_fixture

--- a/lib/suma/webhookdb/model.rb
+++ b/lib/suma/webhookdb/model.rb
@@ -15,7 +15,14 @@ class Suma::Webhookdb::Model
   extend Suma::Postgres::ModelUtilities
 
   class << self
-    def db = Suma::Webhookdb.connection
+    def db
+      # If models are enabled, assume the configured tables existing in WebhookDB.
+      # If models are not enabled, we can mock out the connection with a mock:// database connection
+      # using Postgres semantics. We'll never get any results, so it should be okay.
+      return Suma::Webhookdb.connection if Suma::Webhookdb.models_enabled
+      return @_mock_db ||= Sequel.connect("mock://", host: "postgres")
+    end
+
     def read_only? = true
   end
 end

--- a/spec/suma/webhookdb_spec.rb
+++ b/spec/suma/webhookdb_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "suma/webhookdb"
+
+RSpec.describe Suma::Webhookdb, reset_configuration: Suma::Webhookdb do
+  describe "models" do
+    it "can be disabled, in which case a mock connection is used" do
+      expect(Suma::Webhookdb.models_enabled).to be(true)
+      expect(Suma::Webhookdb::Model.db["SELECT 1 AS one"].first).to eq({one: 1})
+      Suma::Webhookdb.models_enabled = false
+      # this is a mock dataset now
+      expect(Suma::Webhookdb::Model.db["SELECT 1 AS one"].first).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
=== WebhookDB Tables

Verification code required a legit webhookdb connection and tables to load models; this wasn't easy to just skip the code path using config, since it's in models.

So use a mock database if webhookdb models are not enabled.

=== Disable Front on verification list

If Front is not configured, disable the buttons that work with conversations. These codepaths call Front,
so better not to call them.

=== Redundant events

Also fix the bug where taking an action on the verification list would result in the same browser window seeing the update.

Instead, the event token acts like a session token, and events taken by a given session are not reported to the subscriber for that session.

Add an api helper to enforce the presence of the Suma-Events-Token header when making unsafe (POST, etc) requests.

=== Fixes

Fix api.js so it accepts all Axios params,
not just the body/query.