### PR TITLE
Verification and message forward fixes

### DIFF
--- a/lib/suma/fixtures/organization_membership_verifications.rb
+++ b/lib/suma/fixtures/organization_membership_verifications.rb
@@ -8,27 +8,42 @@ module Suma::Fixtures::OrganizationMembershipVerifications
 
   fixtured_class Suma::Organization::Membership::Verification
 
+  def self.create_unassociated_membership(fac)
+    Suma::Organization::Membership.disable_auto_verification_creation = true
+    return fac.create
+  ensure
+    Suma::Organization::Membership.disable_auto_verification_creation = false
+  end
+
   base :organization_membership_verification do
   end
 
   before_saving do |instance|
-    instance.membership ||= Suma::Fixtures.organization_membership.unverified.create
+    instance.membership ||= Suma::Fixtures::OrganizationMembershipVerifications.create_unassociated_membership(
+      Suma::Fixtures.organization_membership.unverified,
+    )
     instance
   end
 
   decorator :member do |member={}|
     member = Suma::Fixtures.member.create(member) unless member.is_a?(Suma::Member)
-    self.membership ||= Suma::Fixtures.organization_membership.unverified.create(member:)
+    self.membership ||= Suma::Fixtures::OrganizationMembershipVerifications.create_unassociated_membership(
+      Suma::Fixtures.organization_membership(member:).unverified,
+    )
     self.membership.update(member:)
   end
 
   decorator :organization do |organization={}|
     organization = Suma::Fixtures.organization.create(organization) unless organization.is_a?(Suma::Organization)
-    self.membership = Suma::Fixtures.organization_membership.unverified(organization.name).create
+    self.membership = Suma::Fixtures::OrganizationMembershipVerifications.create_unassociated_membership(
+      Suma::Fixtures.organization_membership.unverified(organization.name),
+    )
   end
 
   decorator :able_to_verify do
     org = Suma::Fixtures.organization.create
-    self.membership = Suma::Fixtures.organization_membership.unverified(org.name).create
+    self.membership = Suma::Fixtures::OrganizationMembershipVerifications.create_unassociated_membership(
+      Suma::Fixtures.organization_membership.unverified(org.name),
+    )
   end
 end

--- a/lib/suma/frontapp.rb
+++ b/lib/suma/frontapp.rb
@@ -3,11 +3,10 @@
 require "frontapp"
 
 require "suma/http"
-require "suma/method_utilities"
 
 module Suma::Frontapp
   include Appydays::Configurable
-  extend Suma::MethodUtilities
+  include Appydays::Loggable
 
   UNCONFIGURED_AUTH_TOKEN = "get-from-front-add-to-env"
 
@@ -36,6 +35,18 @@ module Suma::Frontapp
     def to_template_id(id) = to_api_id("rsp", id)
     def to_channel_id(id) = to_api_id("cha", id)
     def to_inbox_id(id) = to_api_id("inb", id)
+
+    def make_http_request(method, url, **options)
+      options[:headers] ||= {}
+      options[:headers]["Authorization"] = "Bearer #{self.auth_token}"
+      resp = Suma::Http.execute(
+        method,
+        "https://api2.frontapp.com#{url}",
+        logger: self.logger,
+        **options,
+      )
+      return resp
+    end
   end
 
   configurable(:frontapp) do

--- a/lib/suma/message/forwarder.rb
+++ b/lib/suma/message/forwarder.rb
@@ -21,30 +21,63 @@ class Suma::Message::Forwarder
     raise Suma::InvalidPrecondition, "NUMBER_FORWARDER_PHONE_NUMBERS must be set" unless
       self.class.configured?
     rows = self.fetch_rows
-    inbox_id = Suma::Frontapp.to_inbox_id(self.class.front_inbox_id)
     results = []
     rows.each do |row|
       Suma::Idempotency.once_ever.under_key("sw-forwarder-#{row.fetch(:signalwire_id)}") do
-        results << Suma::Frontapp.client.import_message(
-          inbox_id,
-          {
-            sender: {
-              handle: Suma::Frontapp.contact_phone_handle(row.fetch(:from)),
-            },
-            to: [Suma::Frontapp.contact_phone_handle(row.fetch(:from))],
-            body: row.fetch(:body),
-            external_id: row.fetch(:signalwire_id),
-            created_at: row.fetch(:date_created).to_i,
-            type: "sms",
-            metadata: {
-              is_inbound: true,
-              is_archived: false,
-            },
-          },
-        )
+        results << self.import_row(row)
       end
     end
     return results
+  end
+
+  def import_row(row)
+    body = row.fetch(:data).fetch("body")
+    body = "<blank>" if body.blank?
+    attachments = []
+    if row.fetch(:data).fetch("num_media").positive?
+      media_url = row.fetch(:data).fetch("subresource_uris").fetch("media")
+      media_resp = Suma::Signalwire.make_rest_request(:get, media_url)
+      # Save attachments into tempfiles so they will be uploaded properly as part of a multipart request to Front.
+      # Use a tempdir so we can get predictable filenames.
+      tempdir = Dir.mktmpdir("suma-msg-importer")
+      media_resp.fetch("media_list").each_with_index do |image, i|
+        body_resp = Suma::Signalwire.make_rest_request(
+          :get,
+          image.fetch("uri").delete_suffix(".json"),
+          headers: {"Accept" => "*/*"}, # Needed to download non-JSON
+        )
+        filename = row.fetch(:date_created).strftime("%Y%m%d")
+        filename += "-attachment#{i + 1}"
+        filename += "." + image.fetch("content_type").split("/").last
+        attachment = File.open(Pathname(tempdir) + filename, "wb+")
+        attachment.write(body_resp)
+        attachment.rewind
+        attachments << attachment
+      end
+      # Turn an array ['x', 'y'] into a Hash {0=>'x', 1=>'y'} so we get 'attachments[0]' in form-data.
+      attachments = attachments.each_with_index.to_h { |a, i| [i, a] }
+    end
+    body = {
+      sender: {
+        handle: Suma::Frontapp.contact_phone_handle(row.fetch(:from)),
+      },
+      to: [Suma::Frontapp.contact_phone_handle(row.fetch(:from))],
+      body:,
+      external_id: row.fetch(:signalwire_id),
+      created_at: row.fetch(:date_created).to_i,
+      type: "sms",
+      metadata: {
+        is_inbound: true,
+        is_archived: false,
+      },
+      attachments:,
+    }
+    Suma::Frontapp.make_http_request(
+      :post,
+      "/inboxes/#{Suma::Frontapp.to_inbox_id(self.class.front_inbox_id)}/imported_messages",
+      body:,
+      multipart: attachments.any?,
+    )
   end
 
   def fetch_rows
@@ -56,7 +89,6 @@ class Suma::Message::Forwarder
       to: self.class.phone_numbers.map { |n| Suma::PhoneNumber.format_e164(n) },
     )
     ds = ds.order(:date_created)
-    ds = ds.select(:signalwire_id, :date_created, :from, Sequel.pg_json(:data).get_text("body").as(:body))
     return ds.all
   end
 end

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
         direction: "inbound",
         from: "+15556667777",
         to: "+12225550000",
-        data: "{}",
+        data: {body: "x", num_media: 0}.to_json,
       )
       req = stub_request(:post, "https://api2.frontapp.com/inboxes/inb_ya/imported_messages").
         to_return(json_response({}))

--- a/spec/suma/frontapp_spec.rb
+++ b/spec/suma/frontapp_spec.rb
@@ -12,4 +12,23 @@ RSpec.describe Suma::Frontapp do
     expect(described_class.to_api_id("cnv", nil)).to be_nil
     expect { described_class.to_api_id("cnv", "msg_123") }.to raise_exception(ArgumentError)
   end
+
+  describe "make_http_request" do
+    it "makes an http request" do
+      req = stub_request(:post, "https://api2.frontapp.com/foo").
+        with(
+          body: '{"x":1}',
+          headers: {
+            "Accept" => "*/*",
+            "Authorization" => "Bearer get-from-front-add-to-env",
+            "Content-Type" => "application/json",
+            "Y" => "z",
+          },
+        ).
+        to_return(json_response({z: 1}))
+      r = Suma::Frontapp.make_http_request(:post, "/foo", body: {x: 1}, headers: {"Y" => "z"})
+      expect(req).to have_been_made
+      expect(r.parsed_response).to eq({"z" => 1})
+    end
+  end
 end

--- a/spec/suma/message/forwarder_spec.rb
+++ b/spec/suma/message/forwarder_spec.rb
@@ -9,12 +9,16 @@ RSpec.describe Suma::Message::Forwarder, :db, :no_transaction_check, reset_confi
   end
 
   def messagerow(swid, data={})
+    data[:to] ||= Suma::PhoneNumber.format_e164(Suma::Message::Forwarder.phone_numbers.sample)
+    data[:from] ||= "+14445551234"
+    data[:date_created] ||= Time.now
+    data[:num_media] ||= 0
     r = {
       signalwire_id: swid,
-      date_created: data[:date_created] || Time.now,
+      date_created: data[:date_created],
       direction: "inbound",
-      from: data[:from] || "+14445551234",
-      to: data[:to] || Suma::PhoneNumber.format_e164(Suma::Message::Forwarder.phone_numbers.sample),
+      from: data[:from],
+      to: data[:to],
       data: data.to_json,
     }
     return r
@@ -36,6 +40,7 @@ RSpec.describe Suma::Message::Forwarder, :db, :no_transaction_check, reset_confi
         created_at: 1_749_921_156,
         type: "sms",
         metadata: {is_inbound: true, is_archived: false},
+        attachments: [],
       }.to_json).to_return(json_response({}))
 
     described_class.new(now: Time.now).run
@@ -50,6 +55,68 @@ RSpec.describe Suma::Message::Forwarder, :db, :no_transaction_check, reset_confi
     described_class.new(now: Time.now).run
     described_class.new(now: Time.now).run
     expect(req).to have_been_made.once
+  end
+
+  it "includes media" do
+    msg = insert_message(
+      "msg1",
+      body: "hello",
+      date_created: Time.at(1_749_921_156),
+      num_media: 3,
+      subresource_uris: {
+        media: "/api/laml/2010-04-01/Accounts/AC123/Messages/msg1/Media.json",
+      },
+    )
+
+    media_list_req = stub_request(:get, "https://sumafaketest.signalwire.com/api/laml/2010-04-01/Accounts/AC123/Messages/msg1/Media.json").
+      to_return(
+        json_response(
+          {
+            media_list: [
+              {
+                sid: "media1",
+                content_type: "image/jpeg",
+                uri: "/api/laml/2010-04-01/Accounts/AC123/Messages/SMabcxyz/Media/media1.json",
+              },
+              {
+                sid: "media2",
+                content_type: "video/mp4",
+                uri: "/api/laml/2010-04-01/Accounts/AC123/Messages/SMabcxyz/Media/media2.json",
+              },
+              {
+                sid: "media3",
+                # Unrecognized content type should have .unrek extension but octet-stream mimetype
+                content_type: "image/unrek",
+                uri: "/api/laml/2010-04-01/Accounts/AC123/Messages/SMabcxyz/Media/media3.json",
+              },
+            ],
+          },
+        ),
+      )
+    media1_req = stub_request(:get, "https://sumafaketest.signalwire.com/api/laml/2010-04-01/Accounts/AC123/Messages/SMabcxyz/Media/media1").
+      to_return(status: 200, body: "media1 body", headers: {"Content-Type" => "image/jpeg"})
+    media2_req = stub_request(:get, "https://sumafaketest.signalwire.com/api/laml/2010-04-01/Accounts/AC123/Messages/SMabcxyz/Media/media2").
+      to_return(status: 200, body: "media2 body", headers: {"Content-Type" => "video/mp4"})
+    media3_req = stub_request(:get, "https://sumafaketest.signalwire.com/api/laml/2010-04-01/Accounts/AC123/Messages/SMabcxyz/Media/media3").
+      to_return(status: 200, body: "media3 body", headers: {"Content-Type" => "image/unrek"})
+
+    # rubocop:disable Layout/LineLength
+    front_req = stub_request(:post, "https://api2.frontapp.com/inboxes/inb_ya/imported_messages").
+      with do |req|
+      expect(req.body).to include("Content-Disposition: form-data; name=\"external_id\"\r\n\r\nmsg1")
+      expect(req.body).to include("Content-Disposition: form-data; name=\"metadata[is_inbound]\"\r\n\r\ntrue")
+      expect(req.body).to include("Content-Disposition: form-data; name=\"attachments[0]\"; filename=\"20250614-attachment1.jpeg\"\r\nContent-Type: image/jpeg\r\n\r\nmedia1 body")
+      expect(req.body).to include("Content-Disposition: form-data; name=\"attachments[1]\"; filename=\"20250614-attachment2.mp4\"\r\nContent-Type: application/mp4\r\n\r\nmedia2 body")
+      expect(req.body).to include("Content-Disposition: form-data; name=\"attachments[2]\"; filename=\"20250614-attachment3.unrek\"\r\nContent-Type: application/octet-stream\r\n\r\nmedia3 body")
+    end.to_return(json_response({message_uid: "FMID2"}, status: 202))
+    # rubocop:enable Layout/LineLength
+
+    described_class.new(now: Time.now).run
+    expect(media_list_req).to have_been_made
+    expect(media1_req).to have_been_made
+    expect(media2_req).to have_been_made
+    expect(media3_req).to have_been_made
+    expect(front_req).to have_been_made
   end
 
   it "errors if the Front inbox is not set" do

--- a/spec/suma/organization/membership_spec.rb
+++ b/spec/suma/organization/membership_spec.rb
@@ -123,5 +123,21 @@ RSpec.describe "Suma::Organization::Membership", :db do
       )
       expect(m.member).to_not be_onboarding_verified
     end
+
+    it "creates a verification if unverified" do
+      created_unverified = Suma::Fixtures.organization_membership.unverified.create
+      expect(created_unverified.verification).to be_a(Suma::Organization::Membership::Verification)
+      became_unverified = Suma::Fixtures.organization_membership.verified.create
+      expect(became_unverified.verification).to be_nil
+      became_unverified.update(unverified_organization_name: "abc", verified_organization: nil)
+      expect(became_unverified.verification).to be_a(Suma::Organization::Membership::Verification)
+    end
+
+    it "does not create a verification if not unverified" do
+      m = Suma::Fixtures.organization_membership.verified.create
+      expect(m.verification).to be_nil
+      m = Suma::Fixtures.organization_membership.former.create
+      expect(m.verification).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Verification list button fixes

- Use loading buttons
- Fix failure to open the new Front convo

---

Create verifications for unverified memberships

When an unverified membership is created,
or more rarely, a verified membership is made to be unverified,
create a membership verification object automatically.

This required some mucking around to make sure we don't create
redundant memberships as we fixture verifications.

---

Message forwarder supports attachments

I was hoping we could avoid this but it's needed.
Add better multipart support into Suma::Http.

---

Verification: Fix headers not being passed to api method
