### PR TITLE
Automatically 'unenroll' users when they are no longer eligible in programs

### DIFF
--- a/adminapp/src/pages/ProgramEnrollmentDetailPage.jsx
+++ b/adminapp/src/pages/ProgramEnrollmentDetailPage.jsx
@@ -3,7 +3,6 @@ import AdminLink from "../components/AdminLink";
 import InlineEditField from "../components/InlineEditField";
 import ResourceDetail from "../components/ResourceDetail";
 import useErrorSnackbar from "../hooks/useErrorSnackbar";
-import { useUser } from "../hooks/user";
 import { dayjs } from "../modules/dayConfig";
 import formatDate from "../modules/formatDate";
 import { Switch } from "@mui/material";
@@ -11,7 +10,6 @@ import React from "react";
 
 export default function ProgramEnrollmentDetailPage() {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
-  const { user } = useUser();
   const handleUpdateProgramEnrollment = (enrollment, replaceState) => {
     return api
       .updateProgramEnrollment(enrollment)
@@ -53,7 +51,6 @@ export default function ProgramEnrollmentDetailPage() {
                       set({
                         ...st,
                         approved: e.target.checked,
-                        approvedBy: e.target.checked ? { id: user.id } : null,
                       })
                     }
                   ></Switch>
@@ -85,7 +82,6 @@ export default function ProgramEnrollmentDetailPage() {
                       set({
                         ...st,
                         unenrolled: e.target.checked,
-                        unenrolledBy: e.target.checked ? { id: user.id } : null,
                       })
                     }
                   ></Switch>

--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -39,10 +39,6 @@ export default function VendorAccountDetailPage() {
           label: "Latest Access Code Set At",
           value: formatDate(model.latestAccessCodeSetAt),
         },
-        {
-          label: "Registered with Vendor",
-          value: model.registeredWithVendor,
-        },
       ]}
     >
       {(model) => [
@@ -78,6 +74,18 @@ export default function VendorAccountDetailPage() {
             ]}
           />
         ),
+        <RelatedList
+          title="Registrations"
+          rows={model.registrations}
+          headers={["Id", "Created", "Program Id", "External Id"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            row.id,
+            formatDate(row.createdAt),
+            row.externalProgramId,
+            row.externalRegistrationId,
+          ]}
+        />,
         <RelatedList
           title="Messages"
           rows={model.messages}

--- a/db/migrations/079_unenrollment.rb
+++ b/db/migrations/079_unenrollment.rb
@@ -30,12 +30,14 @@ Sequel.migration do
 
     alter_table(:anon_proxy_vendor_accounts) do
       rename_column :registered_with_vendor, :legacy_registered_with_vendor
+      add_column :pending_closure, :boolean, default: false
     end
   end
   down do
     drop_table(:anon_proxy_vendor_account_registrations)
     alter_table(:anon_proxy_vendor_accounts) do
       rename_column :legacy_registered_with_vendor, :registered_with_vendor
+      drop_column :pending_closure
     end
   end
 end

--- a/db/migrations/079_unenrollment.rb
+++ b/db/migrations/079_unenrollment.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "sequel/null_or_present_constraint"
+
+Sequel.migration do
+  up do
+    create_table(:anon_proxy_vendor_account_registrations) do
+      primary_key :id
+      timestamptz :created_at, null: false, default: Sequel.function(:now)
+
+      foreign_key :account_id, :anon_proxy_vendor_accounts, null: false, on_delete: :cascade
+      text :external_program_id, null: false
+      text :external_registration_id
+      constraint(
+        :non_empty_external_registration_id,
+        Sequel.null_or_present_constraint(:external_registration_id),
+      )
+    end
+
+    from(:anon_proxy_vendor_accounts).exclude(registered_with_vendor: nil).each do |row|
+      r = JSON.parse(row.fetch(:registered_with_vendor))
+      r.each do |lyft_id, enrolled_at|
+        from(:anon_proxy_vendor_account_registrations).insert(
+          created_at: enrolled_at.present? ? Time.parse(enrolled_at) : Time.now,
+          account_id: row.fetch(:id),
+          external_program_id: lyft_id,
+        )
+      end
+    end
+
+    alter_table(:anon_proxy_vendor_accounts) do
+      rename_column :registered_with_vendor, :legacy_registered_with_vendor
+    end
+  end
+  down do
+    drop_table(:anon_proxy_vendor_account_registrations)
+    alter_table(:anon_proxy_vendor_accounts) do
+      rename_column :legacy_registered_with_vendor, :registered_with_vendor
+    end
+  end
+end

--- a/lib/suma/admin_api/anon_proxy_vendor_accounts.rb
+++ b/lib/suma/admin_api/anon_proxy_vendor_accounts.rb
@@ -6,6 +6,13 @@ class Suma::AdminAPI::AnonProxyVendorAccounts < Suma::AdminAPI::V1
   include Suma::Service::Types
   include Suma::AdminAPI::Entities
 
+  class VendorAccountRegistrationEntity < BaseEntity
+    include Suma::AdminAPI::Entities
+    include AutoExposeBase
+    expose :external_program_id
+    expose :external_registration_id
+  end
+
   class DetailedVendorAccountEntity < AnonProxyVendorAccountEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
@@ -13,8 +20,8 @@ class Suma::AdminAPI::AnonProxyVendorAccounts < Suma::AdminAPI::V1
     expose :latest_access_code_set_at
     expose :latest_access_code_requested_at
     expose :latest_access_code_magic_link
-    expose :registered_with_vendor
     expose :contact, with: AnonProxyMemberContactEntity
+    expose :registrations, with: VendorAccountRegistrationEntity
   end
 
   resource :anon_proxy_vendor_accounts do

--- a/lib/suma/admin_api/program_enrollments.rb
+++ b/lib/suma/admin_api/program_enrollments.rb
@@ -8,7 +8,8 @@ class Suma::AdminAPI::ProgramEnrollments < Suma::AdminAPI::V1
   class DetailedProgramEnrollmentEntity < ProgramEnrollmentEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
-    expose :approved?, as: :approved
+    expose :enrolled?, as: :enrolled
+    expose :ever_approved?, as: :approved
     expose :approved_by, with: MemberEntity
     expose :unenrolled?, as: :unenrolled
     expose :unenrolled_by, with: MemberEntity
@@ -45,12 +46,15 @@ class Suma::AdminAPI::ProgramEnrollments < Suma::AdminAPI::V1
       self,
       Suma::Program::Enrollment,
       DetailedProgramEnrollmentEntity,
+      around: lambda do |rt, m, &block|
+        m.approved_by = rt.admin_member if rt.params[:approved]
+        m.unenrolled_by = rt.admin_member if rt.params[:unenrolled]
+        block.call
+      end,
     ) do
       params do
         optional :approved, type: Boolean
-        optional(:approved_by, type: JSON) { use :model_with_id }
         optional :unenrolled, type: Boolean
-        optional(:unenrolled_by, type: JSON) { use :model_with_id }
       end
     end
   end

--- a/lib/suma/anon_proxy.rb
+++ b/lib/suma/anon_proxy.rb
@@ -4,7 +4,7 @@ module Suma::AnonProxy
   include Appydays::Configurable
 
   configurable(:anon_proxy) do
-    setting :postmark_email_template, "#{Suma::RACK_ENV}.m%{member_id}@in-dev.mysuma.org"
+    setting :postmark_email_domain, "in-dev.mysuma.org"
     setting :signalwire_relay_number, ""
     setting :email_relay, "fake-email-relay"
     setting :phone_relay, "fake-phone-relay"

--- a/lib/suma/anon_proxy/auth_to_vendor.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor.rb
@@ -27,12 +27,13 @@ class Suma::AnonProxy::AuthToVendor
   end
 
   # Run the auth in the vendor system (send magic link email, associate the Suma member with the vendor backend, etc.)
-  def auth = raise NotImplementedError
+  def auth(now:) = raise NotImplementedError
 
   # True if the client should poll for an access code set on the vendor account,
   # or false if the linking is immediate.
   # @return [true,false]
   def needs_polling? = raise NotImplementedError
+
   # True if the vendor account needs attention; like if it needs to be created
   # or relinked.
   def needs_attention?(now:) = raise NotImplementedError

--- a/lib/suma/anon_proxy/auth_to_vendor/fake.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/fake.rb
@@ -22,7 +22,7 @@ class Suma::AnonProxy::AuthToVendor::Fake < Suma::AnonProxy::AuthToVendor
     super
   end
 
-  def auth = self.class._auth
+  def auth(*) = self.class._auth
   def needs_polling? = self.class.needs_polling
   def needs_attention?(*) = self.class.needs_attention
 end

--- a/lib/suma/anon_proxy/auth_to_vendor/lime.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lime.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
-  AGREEMENT_PARAMS = "&user_agreement_version=5&user_agreement_country_code=US"
-  USER_AGENT = "Android Lime/3.179.1; (com.limebike; build:3.179.1; Android 33) 4.10.0"
-  APP_VERSION = "3.179.1"
+  AGREEMENT_PARAMS = {user_agreement_version: "5", user_agreement_country_code: "US"}.freeze
+  USER_AGENT = "Android Lime/3.219.0; (com.limebike; build:3.219.0; Android 33) 4.12.0"
+  APP_VERSION = "3.219.0"
 
   def request_headers
     return {
@@ -11,6 +11,11 @@ class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
       "Platform" => "Android",
       "User-Agent" => USER_AGENT,
       "App-Version" => APP_VERSION,
+      # Best we can tell, these do not matter/do not need to be valid.
+      # It's possible this will change in the future.
+      "X-Device-Token" => "e3001a2a-ef16-4201-a473-af7d9fd47735",
+      "X-Fingerprint" => "3820d768a6525588",
+      "X-Session-ID" => "1751641417301",
     }
   end
 
@@ -18,7 +23,7 @@ class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
     contact = self.vendor_account.ensure_anonymous_contact(:email)
     Suma::Http.post(
       "https://web-production.lime.bike/api/rider/v2/onboarding/magic-link",
-      "email=#{contact.email}#{AGREEMENT_PARAMS}",
+      AGREEMENT_PARAMS.merge(email: contact.email),
       headers: {
         "Content-Type" => "application/x-www-form-urlencoded",
         **self.request_headers,
@@ -31,7 +36,7 @@ class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
   def exchange_magic_link_token(magic_link_token)
     resp = Suma::Http.post(
       "https://web-production.lime.bike/api/rider/v2/onboarding/login",
-      "magic_link_token=#{magic_link_token}#{AGREEMENT_PARAMS}&has_virtual_card=false",
+      AGREEMENT_PARAMS.merge(magic_link_token: magic_link_token, has_virtual_card: false),
       headers: {
         "Content-Type" => "application/x-www-form-urlencoded",
         **self.request_headers,

--- a/lib/suma/anon_proxy/auth_to_vendor/lime.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lime.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
-  def auth
+  def auth(*)
     contact = self.vendor_account.ensure_anonymous_contact(:email)
     Suma::Http.post(
       "https://web-production.lime.bike/api/rider/v2/onboarding/magic-link",

--- a/lib/suma/anon_proxy/auth_to_vendor/lime.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lime.rb
@@ -1,17 +1,53 @@
 # frozen_string_literal: true
 
 class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
+  AGREEMENT_PARAMS = "&user_agreement_version=5&user_agreement_country_code=US"
+  USER_AGENT = "Android Lime/3.179.1; (com.limebike; build:3.179.1; Android 33) 4.10.0"
+  APP_VERSION = "3.179.1"
+
+  def request_headers
+    return {
+      "X-Suma" => "holá",
+      "Platform" => "Android",
+      "User-Agent" => USER_AGENT,
+      "App-Version" => APP_VERSION,
+    }
+  end
+
   def auth(*)
     contact = self.vendor_account.ensure_anonymous_contact(:email)
     Suma::Http.post(
       "https://web-production.lime.bike/api/rider/v2/onboarding/magic-link",
-      "email=#{contact.email}&user_agreement_version=5&user_agreement_country_code=US",
+      "email=#{contact.email}#{AGREEMENT_PARAMS}",
       headers: {
-        "X-Suma" => "holá",
-        "Platform" => "Android",
-        "User-Agent" => "Android Lime/3.179.1; (com.limebike; build:3.179.1; Android 33) 4.10.0",
-        "App-Version" => "3.179.1",
         "Content-Type" => "application/x-www-form-urlencoded",
+        **self.request_headers,
+      },
+      logger: self.vendor_account.logger,
+    )
+  end
+
+  # Given a magic link token, return an auth token.
+  def exchange_magic_link_token(magic_link_token)
+    resp = Suma::Http.post(
+      "https://web-production.lime.bike/api/rider/v2/onboarding/login",
+      "magic_link_token=#{magic_link_token}#{AGREEMENT_PARAMS}&has_virtual_card=false",
+      headers: {
+        "Content-Type" => "application/x-www-form-urlencoded",
+        **self.request_headers,
+      },
+      logger: self.vendor_account.logger,
+    )
+    return resp.parsed_response.fetch("token")
+  end
+
+  def log_out(auth_token)
+    Suma::Http.post(
+      "https://web-production.lime.bike/api/rider/v1/logout",
+      headers: {
+        "Authorization" => "Bearer #{auth_token}",
+        "Content-Type" => "application/x-www-form-urlencoded",
+        **self.request_headers,
       },
       logger: self.vendor_account.logger,
     )

--- a/lib/suma/anon_proxy/member_contact.rb
+++ b/lib/suma/anon_proxy/member_contact.rb
@@ -24,6 +24,11 @@ class Suma::AnonProxy::MemberContact < Suma::Postgres::Model(:anon_proxy_member_
     def ensure_anonymous_contact(member, type)
       contact = member.anon_proxy_contacts.find(&:"#{type}?")
       return [contact, false] if contact
+      contact = self.provision_anonymous_contact(member, type)
+      return [contact, true]
+    end
+
+    def provision_anonymous_contact(member, type)
       relay = Suma::AnonProxy::Relay.send(:"active_#{type}_relay")
       addr = relay.provision(member)
       contact = Suma::AnonProxy::MemberContact.create(
@@ -32,7 +37,7 @@ class Suma::AnonProxy::MemberContact < Suma::Postgres::Model(:anon_proxy_member_
         type => addr.address,
         external_relay_id: addr.external_id || "",
       )
-      return [contact, true]
+      return contact
     end
   end
 

--- a/lib/suma/anon_proxy/message_handler/lime.rb
+++ b/lib/suma/anon_proxy/message_handler/lime.rb
@@ -32,14 +32,22 @@ class Suma::AnonProxy::MessageHandler::Lime < Suma::AnonProxy::MessageHandler
       result.handled = false
       return result
     end
-    link_to_use = Suma::UrlShortener.enabled? ? Suma::UrlShortener.shortener.shorten(magic_link).url : magic_link
-    vendor_account_message.vendor_account.replace_access_code(token, link_to_use).save_changes
-    msg = Suma::Messages::SingleValue.new(
-      "anon_proxy",
-      "lime-deep-link-access-code",
-      link_to_use,
-    )
-    vendor_account_message.vendor_account.member.message_preferences!.dispatch(msg)
+    vendor_account = vendor_account_message.vendor_account
+    if vendor_account.pending_closure
+      lime_atv = Suma::AnonProxy::AuthToVendor::Lime.new(vendor_account)
+      # This will log the user out of their own device, which is good enough.
+      lime_atv.exchange_magic_link_token(token)
+      vendor_account.update(pending_closure: false)
+    else
+      link_to_use = Suma::UrlShortener.enabled? ? Suma::UrlShortener.shortener.shorten(magic_link).url : magic_link
+      vendor_account.replace_access_code(token, link_to_use).save_changes
+      msg = Suma::Messages::SingleValue.new(
+        "anon_proxy",
+        "lime-deep-link-access-code",
+        link_to_use,
+      )
+      vendor_account.member.message_preferences!.dispatch(msg)
+    end
     result.handled = true
     return result
   end

--- a/lib/suma/anon_proxy/relay/fake_email.rb
+++ b/lib/suma/anon_proxy/relay/fake_email.rb
@@ -8,7 +8,7 @@ class Suma::AnonProxy::Relay::FakeEmail < Suma::AnonProxy::Relay::FakeRelay
 
   def provision(member)
     ProvisionedAddress.new(
-      "u#{member.id}@example.com", external_id: self.class.provisioned_external_id,
+      "u#{member.id}.#{Time.now.to_i}@example.com", external_id: self.class.provisioned_external_id,
     )
   end
 end

--- a/lib/suma/anon_proxy/relay/postmark.rb
+++ b/lib/suma/anon_proxy/relay/postmark.rb
@@ -4,7 +4,13 @@ class Suma::AnonProxy::Relay::Postmark < Suma::AnonProxy::Relay
   def key = "postmark"
   def transport = :email
   def webhookdb_dataset = Suma::Webhookdb.postmark_inbound_messages_dataset
-  def provision(member) = ProvisionedAddress.new(Suma::AnonProxy.postmark_email_template % {member_id: member.id})
+
+  def provision(member)
+    email = "m#{member.id}.#{Time.now.to_i}@#{Suma::AnonProxy.postmark_email_domain}"
+    email = "#{Suma::RACK_ENV}.#{email}" if Suma::RACK_ENV != "production"
+    ProvisionedAddress.new(email)
+  end
+
   def deprovision(_addr) = nil
 
   def parse_message(row)

--- a/lib/suma/anon_proxy/vendor_account.rb
+++ b/lib/suma/anon_proxy/vendor_account.rb
@@ -26,6 +26,7 @@ class Suma::AnonProxy::VendorAccount < Suma::Postgres::Model(:anon_proxy_vendor_
   many_to_one :configuration, class: "Suma::AnonProxy::VendorConfiguration"
   many_to_one :contact, class: "Suma::AnonProxy::MemberContact"
   one_to_many :messages, class: "Suma::AnonProxy::VendorAccountMessage"
+  one_to_many :registrations, class: "Suma::AnonProxy::VendorAccountRegistration", key: :account_id
 
   class << self
     # Return existing or newly created vendor accounts for the member,
@@ -58,7 +59,7 @@ class Suma::AnonProxy::VendorAccount < Suma::Postgres::Model(:anon_proxy_vendor_
     return Suma::AnonProxy::AuthToVendor.create!(self.configuration.auth_to_vendor_key, vendor_account: self)
   end
 
-  def registered_with_vendor? = self.registered_with_vendor.present?
+  def needs_attention?(now:) = self.auth_to_vendor.needs_attention?(now:)
 
   # Ensure an anonymous email or phone number is provisioned.
   # Note that this takes a lock on the vendor account to avoid potential duplicate provisioning.

--- a/lib/suma/anon_proxy/vendor_account_registration.rb
+++ b/lib/suma/anon_proxy/vendor_account_registration.rb
@@ -3,8 +3,25 @@
 require "suma/postgres"
 require "suma/anon_proxy"
 
+# Registrations represent a vendor account's being registered or enrolled with specific programs
+# within a vendor. This model is similar in concept for a program enrollment,
+# except the 'program' concept is an external concept (the +external_program_id+).
 class Suma::AnonProxy::VendorAccountRegistration < Suma::Postgres::Model(:anon_proxy_vendor_account_registrations)
   plugin :timestamps
 
   many_to_one :account, class: "Suma::AnonProxy::VendorAccount"
+
+  # The account this registration belongs to.
+  # @!attribute account
+  # @return [Suma::AnonProxy::VendorAccount]
+
+  # The ID this registration is associated with, like a Lyft Pass program ID.
+  # @!attribute external_program_id
+  # @return [String]
+
+  # The ID in the vendor's system of this registration.
+  # Usually used to remove the member from the vendor's program,
+  # when the removal requires knowing something about the registration into the vendor's program.
+  # @!attribute external_registration_id
+  # @return [String]
 end

--- a/lib/suma/anon_proxy/vendor_account_registration.rb
+++ b/lib/suma/anon_proxy/vendor_account_registration.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "suma/postgres"
+require "suma/anon_proxy"
+
+class Suma::AnonProxy::VendorAccountRegistration < Suma::Postgres::Model(:anon_proxy_vendor_account_registrations)
+  plugin :timestamps
+
+  many_to_one :vendor_account, class: "Suma::AnonProxy::VendorAccount"
+end

--- a/lib/suma/anon_proxy/vendor_account_registration.rb
+++ b/lib/suma/anon_proxy/vendor_account_registration.rb
@@ -6,5 +6,5 @@ require "suma/anon_proxy"
 class Suma::AnonProxy::VendorAccountRegistration < Suma::Postgres::Model(:anon_proxy_vendor_account_registrations)
   plugin :timestamps
 
-  many_to_one :vendor_account, class: "Suma::AnonProxy::VendorAccount"
+  many_to_one :account, class: "Suma::AnonProxy::VendorAccount"
 end

--- a/lib/suma/api/anon_proxy.rb
+++ b/lib/suma/api/anon_proxy.rb
@@ -141,7 +141,9 @@ class Suma::API::AnonProxy < Suma::API::V1
     expose :magic_link do |instance|
       instance.latest_access_code_is_recent? ? instance.latest_access_code_magic_link : nil
     end
-    expose :registered_with_vendor?, as: :registered_with_vendor
+    expose :needs_attention do |instance|
+      instance.needs_attention?(now: self.current_time)
+    end
     expose :vendor_name, &self.delegate_to(:configuration, :vendor, :name)
     expose :vendor_slug, &self.delegate_to(:configuration, :vendor, :slug)
     expose :vendor_image, with: ImageEntity, &self.delegate_to(:configuration, :vendor, :images, :first)

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -101,7 +101,7 @@ class Suma::API::Mobility < Suma::API::V1
       else
         vehicle = matches[0]
       end
-      present vehicle, with: MobilityVehicleEntity, member:, request:, current_time:
+      present vehicle, with: MobilityVehicleEntity, member:, request:
     end
 
     params do

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -222,9 +222,9 @@ class Suma::API::Mobility < Suma::API::V1
     expose :deeplink do |vehicle, options|
       vehicle.deep_link_for_user_agent(options.fetch(:request).user_agent)
     end
-    expose :goto_private_account do |vehicle, options|
+    expose :goto_private_account do |vehicle|
       member = options.fetch(:member)
-      now = options.fetch(:current_time)
+      now = self.current_time
       vehicle.vendor_service.mobility_adapter.anon_proxy_vendor_account_requires_attention?(member, now:)
     end
   end

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -26,6 +26,7 @@ module Suma::Async
     "suma/async/anon_proxy_destroyed_member_contact_cleanup",
     "suma/async/deprecated_jobs",
     "suma/async/emailer",
+    "suma/async/enrollment_removal_runner",
     "suma/async/forward_messages",
     "suma/async/frontapp_upsert_contact",
     "suma/async/funding_transaction_processor",

--- a/lib/suma/async/enrollment_removal_runner.rb
+++ b/lib/suma/async/enrollment_removal_runner.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "amigo/job"
+
+class Suma::Async::EnrollmentRemovalRunner
+  extend Amigo::Job
+
+  on(/^suma\.((program\.enrollment\.updated)|(organization\.membership\.updated))$/)
+
+  class << self
+    attr_accessor :testing_last_ran_removers
+  end
+
+  def _perform(event)
+    case event.name
+      when "suma.program.enrollment.updated"
+        enrollment = self.lookup_model(Suma::Program::Enrollment, event)
+        case event.payload[1]
+          when changed(:unenrolled_at, from: nil)
+            removers = self.handle_direct_enrollment_unenrolled(enrollment)
+          else
+            return
+        end
+      when "suma.organization.membership.updated"
+        membership = self.lookup_model(Suma::Organization::Membership, event)
+        case event.payload[1]
+          when changed(:verified_organization_id, to: nil)
+            removers = [
+              Suma::Program::EnrollmentRemover.new(membership.member).reenroll do
+                membership.this.update(
+                  unverified_organization_name: nil,
+                  verified_organization_id: membership.former_organization_id,
+                  former_organization_id: nil,
+                  formerly_in_organization_at: nil,
+                )
+              end,
+            ]
+          else
+            return
+        end
+      else
+        raise NotImplementedError, "unhandled event: #{event.name}"
+    end
+    self.class.testing_last_ran_removers = removers if Suma::RACK_ENV == "test"
+    return if removers.nil?
+    removers.each(&:process)
+  end
+
+  def handle_direct_enrollment_unenrolled(enrollment)
+    reenroll = ->(*) { enrollment.update(unenrolled_at: nil) }
+    members = if enrollment.member
+                [enrollment.member]
+    elsif enrollment.organization
+      enrollment.organization.memberships.map(&:member)
+    else
+      enrollment.role.members + enrollment.role.organizations.flat_map(&:memberships).map(&:member)
+    end
+    removers = members.uniq.map { |m| Suma::Program::EnrollmentRemover.new(m) }
+    removers.each { |r| r.reenroll(&reenroll) }
+    return removers
+  end
+end

--- a/lib/suma/fixtures/roles.rb
+++ b/lib/suma/fixtures/roles.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "suma/fixtures"
+require "suma/role"
+
+module Suma::Fixtures::Roles
+  extend Suma::Fixtures
+
+  fixtured_class Suma::Role
+
+  base :role do
+    self.name ||= "#{Faker::Name.name}-#{SecureRandom.hex(2)}"
+  end
+end

--- a/lib/suma/lyft/pass.rb
+++ b/lib/suma/lyft/pass.rb
@@ -393,10 +393,27 @@ class Suma::Lyft::Pass
         enrollment_users: [
           {
             custom_field_value_key_value_pairs: [],
-            user_identifier: {phone_number: "+#{member.phone}"},
+            user_identifier: {
+              phone_number: Suma::PhoneNumber.format_e164(member.phone),
+            },
           },
         ],
         ride_program_id: program_id,
+      },
+      headers: self.auth_headers,
+      logger: self.logger,
+    )
+  end
+
+  def revoke_member(member, program_id:)
+    self.logger.info "revoking_lyft_pass", member_id: member.id, lyft_program_id: program_id, phone: member.phone
+    Suma::Http.post(
+      "https://www.lyft.com/api/rideprograms/enrollment/revoke",
+      {
+        ride_program_id: program_id,
+        user_identifier: {
+          phone_number: Suma::PhoneNumber.format_e164(member.phone),
+        },
       },
       headers: self.auth_headers,
       logger: self.logger,

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -8,6 +8,7 @@ require "suma/admin_linked"
 require "suma/has_activity_audit"
 require "suma/payment/has_account"
 require "suma/postgres/model"
+require "suma/role"
 require "suma/secureid"
 
 class Suma::Member < Suma::Postgres::Model(:members)
@@ -99,7 +100,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
               order: Sequel.desc([:created_at]),
               # Use ResetCode.replace_active instead, add_reset_code is unsafe since it can keep multiple active.
               adder: nil
-  many_to_many :roles, class: "Suma::Role", join_table: :roles_members
+  many_to_many :roles, class: "Suma::Role", join_table: :roles_members, **Suma::Role.association_options
   one_to_many :sessions, class: "Suma::Member::Session", order: Sequel.desc([:created_at, :id])
   one_to_many :commerce_carts, class: "Suma::Commerce::Cart"
   one_to_many :anon_proxy_contacts, class: "Suma::AnonProxy::MemberContact"

--- a/lib/suma/organization.rb
+++ b/lib/suma/organization.rb
@@ -2,6 +2,7 @@
 
 require "suma/postgres/model"
 require "suma/admin_linked"
+require "suma/role"
 
 class Suma::Organization < Suma::Postgres::Model(:organizations)
   include Suma::Postgres::HybridSearch
@@ -17,7 +18,7 @@ class Suma::Organization < Suma::Postgres::Model(:organizations)
   one_to_many :memberships, class: "Suma::Organization::Membership", key: :verified_organization_id
   one_to_many :former_memberships, class: "Suma::Organization::Membership", key: :former_organization_id
   one_to_many :program_enrollments, class: "Suma::Program::Enrollment"
-  many_to_many :roles, class: "Suma::Role", join_table: :roles_organizations
+  many_to_many :roles, class: "Suma::Role", join_table: :roles_organizations, **Suma::Role.association_options
 
   plugin :association_array_replacer, :roles
 

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -52,6 +52,7 @@ module Suma::Postgres
     "suma/anon_proxy/member_contact",
     "suma/anon_proxy/vendor_account",
     "suma/anon_proxy/vendor_account_message",
+    "suma/anon_proxy/vendor_account_registration",
     "suma/anon_proxy/vendor_configuration",
     "suma/charge",
     "suma/charge/line_item",

--- a/lib/suma/program.rb
+++ b/lib/suma/program.rb
@@ -106,6 +106,7 @@ class Suma::Program < Suma::Postgres::Model(:programs)
   # @return [String]
 end
 
+require "suma/program/enrollment_remover"
 require "suma/program/has"
 
 # Table: programs

--- a/lib/suma/program/enrollment.rb
+++ b/lib/suma/program/enrollment.rb
@@ -107,6 +107,12 @@ class Suma::Program::Enrollment < Suma::Postgres::Model(:program_enrollments)
   # @return ["Member","Organization","Role","NilClass"]
   def enrollee_type = self.enrollee.class.name.demodulize
 
+  def enrollment_status
+    return :enrolled if self.enrolled?
+    return :unenrolled if self.unenrolled?
+    return :pending
+  end
+
   def rel_admin_link = "/program-enrollment/#{self.id}"
 
   def hybrid_search_fields
@@ -114,15 +120,7 @@ class Suma::Program::Enrollment < Suma::Postgres::Model(:program_enrollments)
       :program,
       :enrollee,
       :enrollee_type,
-    ]
-  end
-
-  def hybrid_search_facts
-    return [
-      self.approved? && "I have been approved.",
-      !self.approved? && "I have not been approved.",
-      !self.unenrolled? && "I am enrolled.",
-      self.unenrolled? && "I have been unenrolled.",
+      :enrollment_status,
     ]
   end
 end

--- a/lib/suma/program/enrollment.rb
+++ b/lib/suma/program/enrollment.rb
@@ -75,20 +75,28 @@ class Suma::Program::Enrollment < Suma::Postgres::Model(:program_enrollments)
     end
   end
 
+  # Return true if the given time is within the program's period.
   def program_active_at?(t)
     return self.program.period.cover?(t)
   end
 
-  def approved? = Suma::MethodUtilities.timestamp_set?(self, :approved_at)
+  # Return true if this enrollment has ever been approved (approved_at is set).
+  def ever_approved? = Suma::MethodUtilities.timestamp_set?(self, :approved_at)
 
+  # Return true if the enrollment is approved and not unenrolled.
+  def enrolled? = self.ever_approved? && !self.unenrolled?
+
+  # Set approved_at.
   def approved=(v)
     Suma::MethodUtilities.timestamp_set(self, :approved_at, v)
   end
 
+  # Return true if unenrolled_at is set.
   def unenrolled?
     Suma::MethodUtilities.timestamp_set?(self, :unenrolled_at)
   end
 
+  # Set unenrolled_at.
   def unenrolled=(v)
     Suma::MethodUtilities.timestamp_set(self, :unenrolled_at, v)
   end
@@ -96,6 +104,7 @@ class Suma::Program::Enrollment < Suma::Postgres::Model(:program_enrollments)
   # @return [Suma::Member,Suma::Organization,Suma::Role]
   def enrollee = self.member || self.organization || self.role
 
+  # @return ["Member","Organization","Role","NilClass"]
   def enrollee_type = self.enrollee.class.name.demodulize
 
   def rel_admin_link = "/program-enrollment/#{self.id}"

--- a/lib/suma/program/enrollment_remover.rb
+++ b/lib/suma/program/enrollment_remover.rb
@@ -26,6 +26,7 @@ class Suma::Program::EnrollmentRemover
 
   def reenroll(&block)
     @reenroll_block = block
+    return self
   end
 
   def process
@@ -33,9 +34,9 @@ class Suma::Program::EnrollmentRemover
     @member.db.transaction(rollback: :always) do
       m2 = Suma::Member[@member.id]
       @reenroll_block.call(m2)
-      @before_enrollments = m2.combined_program_enrollments
+      @before_enrollments = m2.combined_program_enrollments.select(&:enrolled?)
     end
-    @after_enrollments = @member.combined_program_enrollments
+    @after_enrollments = @member.combined_program_enrollments.select(&:enrolled?)
     @removed_enrollments = @before_enrollments - @after_enrollments
 
     @before_configs = @before_enrollments.map(&:program).flat_map(&:anon_proxy_vendor_configurations).uniq

--- a/lib/suma/program/enrollment_remover.rb
+++ b/lib/suma/program/enrollment_remover.rb
@@ -50,7 +50,13 @@ class Suma::Program::EnrollmentRemover
     was_in_lime = @before_configs.any? { |vc| vc.auth_to_vendor_key == "lime" }
     still_in_lime = @after_configs.any? { |vc| vc.auth_to_vendor_key == "lime" }
     return unless was_in_lime && !still_in_lime
-    raise NotImplementedError, "TODO: Not sure how to handle this yet, ask devs for help"
+    lime_config = @before_configs.find { |vc| vc.auth_to_vendor_key == "lime" }
+    vas = @member.anon_proxy_vendor_accounts_dataset.where(configuration: lime_config).all
+    return if vas.empty?
+    new_contact = Suma::AnonProxy::MemberContact.provision_anonymous_contact(@member, :email)
+    vas.each do |va|
+      va.update(contact: new_contact)
+    end
   end
 
   # Revoking lyft pass is complex for a couple reasons:

--- a/lib/suma/program/enrollment_remover.rb
+++ b/lib/suma/program/enrollment_remover.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Logic that runs when a member sees reduction in program access;
+# for example, losing a role, getting an expired organization membership,
+# having a direct enrollment removed, etc.
+#
+# Each removal calculation can be somewhat slow, so the removal is done asynchronously-
+# users will lose the ability to see a program immediately, but secondary effects
+# like closing a vendor account will happen afterwards.
+#
+# We haven't figured out a generic way to process un-enrollments,
+# since there is a lot of nuance with how resources can be shared.
+#
+# For example, we don't want to remove someone from a Lyft Pass program
+# if they have access to any program using it; we don't want to close
+# someone's Lime account if any program gives them access to a Lime vendor service.
+#
+# So this logic is closely coupled to knowing about what external resources
+# may need revocation.
+class Suma::Program::EnrollmentRemover
+  attr_accessor :before_enrollments, :after_enrollments, :removed_enrollments
+
+  def initialize(member)
+    @member = member
+  end
+
+  def reenroll(&block)
+    @reenroll_block = block
+  end
+
+  def process
+    raise LocalJumpError, "must first call reenroll with a block" unless @reenroll_block
+    @member.db.transaction(rollback: :always) do
+      m2 = Suma::Member[@member.id]
+      @reenroll_block.call(m2)
+      @before_enrollments = m2.combined_program_enrollments
+    end
+    @after_enrollments = @member.combined_program_enrollments
+    @removed_enrollments = @before_enrollments - @after_enrollments
+
+    @before_configs = @before_enrollments.map(&:program).flat_map(&:anon_proxy_vendor_configurations).uniq
+    @after_configs = @after_enrollments.map(&:program).flat_map(&:anon_proxy_vendor_configurations).uniq
+    @removed_configs = @before_configs - @after_configs
+    self._close_lime_account
+    self._revoke_lyft_pass
+  end
+
+  protected def _close_lime_account
+    was_in_lime = @before_configs.any? { |vc| vc.auth_to_vendor_key == "lime" }
+    still_in_lime = @after_configs.any? { |vc| vc.auth_to_vendor_key == "lime" }
+    return unless was_in_lime && !still_in_lime
+    raise NotImplementedError, "TODO: Not sure how to handle this yet, ask devs for help"
+  end
+
+  # Revoking lyft pass is complex for a couple reasons:
+  #
+  # First, we can't just revoke access to any unenrolled programs;
+  # we need to make sure the member cannot still access that lyft pass program from a different suma program.
+  # We only revoke access to lyft passes the member can no longer access at all.
+  #
+  # Second, and more confusingly, we need to update the VendorAccount tied to the LyftPass vendor configuration,
+  # to un-mark the member as registered in that lyft pass program. This way, if the member gains new access
+  # to this lyft pass program id, the correct code paths (prompting them to 'link' their account,
+  # and thus regain access to Lyft Pass) will run.
+  def _revoke_lyft_pass
+    previous_pass_ids = @before_enrollments.map { |e| e.program.lyft_pass_program_id }.select(&:present?)
+    current_pass_ids = @after_enrollments.map { |e| e.program.lyft_pass_program_id }.select(&:present?)
+    removed_pass_ids = previous_pass_ids - current_pass_ids
+    return if removed_pass_ids.empty?
+    registrations = Suma::AnonProxy::VendorAccountRegistration.where(
+      external_program_id: removed_pass_ids,
+      account: @member.anon_proxy_vendor_accounts_dataset.where(
+        configuration: Suma::AnonProxy::VendorConfiguration.where(auth_to_vendor_key: "lyft_pass"),
+      ),
+    ).all
+    lp = Suma::Lyft::Pass.from_config
+    lp.authenticate
+    registrations.each do |r|
+      lp.revoke_member(r.account.member, program_id: r.external_program_id)
+      r.destroy
+    end
+  end
+end

--- a/lib/suma/role.rb
+++ b/lib/suma/role.rb
@@ -47,6 +47,17 @@ class Suma::Role < Suma::Postgres::Model(:roles)
     # Return a cache of roles lookups.
     # Generally callers should use +Suma::Member::RoleAccess+ rather than look at roles directly.
     def cache = @cache ||= Cache.new
+
+    def association_options
+      return {
+        after_add: lambda do |receiver, role|
+          receiver.publish_deferred("role.added", receiver.pk, role.pk)
+        end,
+        after_remove: lambda do |receiver, role|
+          receiver.publish_deferred("role.removed", receiver.pk, role.pk)
+        end,
+      }
+    end
   end
 
   many_to_many :members,

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -17,7 +17,7 @@ module Suma::Service::Entities
   end
 
   class Base < Grape::Entity
-    extend Suma::MethodUtilities
+    def current_time = self.options.fetch(:env).fetch("now")
 
     def self.timezone(*lookup_path, field: nil)
       return lambda do |instance, opts|

--- a/lib/suma/spec_helpers/postgres.rb
+++ b/lib/suma/spec_helpers/postgres.rb
@@ -26,6 +26,7 @@ module Suma::SpecHelpers::Postgres
   SNIFF_LEAKY_TESTS = false
 
   Suma::Postgres.register_model("suma/postgres/testing_pixie")
+  SequelHybridSearch.indexing_mode = :off
 
   ### Inclusion callback -- install some hooks
   def self.included(context)

--- a/spec/data/lime/app_post_magic_link.json
+++ b/spec/data/lime/app_post_magic_link.json
@@ -1,0 +1,91 @@
+{
+  "token": "ey123.ey456.789",
+  "user": {
+    "id": "BBBB",
+    "type": "users",
+    "attributes": {
+      "token": "BBBB",
+      "phone_number": null,
+      "email_address": "m1@in.mysuma.org",
+      "has_verified_email_address": true,
+      "name": null,
+      "given_name": null,
+      "surname": null,
+      "default_payment_method": null,
+      "referral_code": "AAAA",
+      "num_trips": 1,
+      "edu": false,
+      "enable_instabug": false,
+      "enable_instabug_screenshot": false,
+      "subscription_item_states": [],
+      "promotion_notification": false,
+      "enable_email_receipt": true,
+      "donation_profile": {
+        "id": "CCCC",
+        "type": "donation_profiles",
+        "attributes": {
+          "donation_type": "none",
+          "donation_organizations": [],
+          "total_donation_amount": {
+            "currency_code": "USD",
+            "amount": 0,
+            "amount_str": "0.0",
+            "currency_symbol": "$",
+            "display_string": "$0"
+          },
+          "total_donation_amount_cents": null,
+          "currency": null
+        }
+      },
+      "trusted_tester": false,
+      "accepted_user_agreement_version": 5,
+      "accepted_compliance_version": null,
+      "balance": {
+        "currency_code": "USD",
+        "amount": 0,
+        "amount_str": "0.0",
+        "currency_symbol": "$",
+        "display_string": "$0"
+      },
+      "pending_balance": {
+        "currency_code": "USD",
+        "amount": 0,
+        "amount_str": "0.0",
+        "currency_symbol": "$",
+        "display_string": "$0"
+      },
+      "balance_cents": 0,
+      "pending_balance_cents": 0,
+      "currency": "USD",
+      "show_group_ride": false,
+      "id_verification_pending": false
+    }
+  },
+  "meta": {
+    "latest_user_agreement_version": "-1",
+    "min_ios_version": "3.113.00",
+    "min_android_code": 311300,
+    "flags": "IOS_VERSION_V1.0,ANDROID_VERSION_V1.0",
+    "groups": {
+      "apple_pay": true,
+      "apple_pay_address_ui": true,
+      "card_scanner": "use_stripe_scanner",
+      "enable_google_pay": true,
+      "enable_new_payment_blocker": true,
+      "enable_stripe_sca_flow": true,
+      "full_screen_payment_prompt": false,
+      "request_payment_method_after_location_permission_killswitch": true,
+      "klarna_payment_method": false,
+      "require_email_after_signup": false,
+      "paypal_payment_method": true,
+      "payment_zip_code": true,
+      "onboarding_payment_ui_v2": false,
+      "zip_code_country_selector": true,
+      "zip_code_required_countries": [
+        "US"
+      ],
+      "enable_early_bootstrap": false,
+      "enable_api_authorization_via_access_token": false
+    }
+  }
+}

--- a/spec/suma/admin_api/anon_proxy_member_contacts_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_member_contacts_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Suma::AdminAPI::AnonProxyMemberContacts, :db do
       post "/v1/anon_proxy_member_contacts/provision", member: {id: member.id}, type: :email
 
       expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(email: "u#{member.id}@example.com")
+      expect(last_response).to have_json_body.that_includes(email: /u#{member.id}\.\d+@example.com/)
       expect(member.anon_proxy_contacts).to have_length(1)
     end
 

--- a/spec/suma/admin_api/program_enrollments_spec.rb
+++ b/spec/suma/admin_api/program_enrollments_spec.rb
@@ -98,10 +98,10 @@ RSpec.describe Suma::AdminAPI::ProgramEnrollments, :db do
   end
 
   describe "POST /v1/program_enrollments/:id" do
-    it "updates a program enrollment" do
+    it "sets approved_at and approved_by if approved is true" do
       enrollment = Suma::Fixtures.program_enrollment.unapproved.create
 
-      post "/v1/program_enrollments/#{enrollment.id}", approved: true, approved_by: {id: admin.id}
+      post "/v1/program_enrollments/#{enrollment.id}", approved: true
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
@@ -109,6 +109,22 @@ RSpec.describe Suma::AdminAPI::ProgramEnrollments, :db do
         approved_by: include(id: admin.id),
         unenrolled: false,
         unenrolled_by: be_nil,
+        enrolled: true,
+      )
+    end
+
+    it "sets unenrolled_at and unenrolled_by if unenrolled is true" do
+      enrollment = Suma::Fixtures.program_enrollment.create
+
+      post "/v1/program_enrollments/#{enrollment.id}", unenrolled: true
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        approved: true,
+        approved_by: nil,
+        unenrolled: true,
+        unenrolled_by: include(id: admin.id),
+        enrolled: false,
       )
     end
   end

--- a/spec/suma/anon_proxy/auth_to_vendor_spec.rb
+++ b/spec/suma/anon_proxy/auth_to_vendor_spec.rb
@@ -67,9 +67,6 @@ RSpec.describe Suma::AnonProxy::AuthToVendor, :db do
     end
 
     describe "exchange_magic_link_token" do
-      let(:response_cookie) do
-        "_limebike-web_session=%2FeiRHNDbZElUfsNoabEDvl0lEoFlXSllTKHVcwDCHR50fqAf86rmSklHdZAziFkaH8kPkKuufiBq%2B4U9U%2BmnrDfbvtqA3yTmO00inhUlwHZ18TTqULKWwI3CbYYIDVWXDdN3nSHY8Q8uUhPflrTYiy6yJ4B3Au5hdwL3Pc5GSvKi%2Bwal%2BdWQfXirGjMSD86Lm3rA%2FbLE8kSqqDW1%2BnxkyMLJuwU5y1KfLJz%2F1rxB6IRD5MHd01a6duQbbrXj1qTeh5KcIT%2FUl3tIkEAD9sYidpOhs9aPIT2AsuPqliVmNxzN5zjsHlQOoecSMmxt4ucYiK7u2gf05TFkLn%2FOiXPx%2FZSQygM1Dk3XgxNF8JRaARJDou0j8MhAKPH6DPALGwT3DYWOe9AgdXsV%2BjqDmz%2B8E6AR7W1ZThm9c1%2Ba8oqQOqlR1evW33ntUyFiW%2Fuxu4utlQxYD7JSWwtmlNzCbASSE1CszculuT%2FAdziThdYtlPmYNDQY43O70Yu9QtIP7anjHSozf6rocbOwmRyD5y78ck1vyqFFv2OVF02XW1NKxX41qfv%2BuzAeow6G63sCQjNaonRahki0Fvov%2FqptF1OT1vamHe%2BFX85bw4ihfFv59U0fSK1UO%2FsYYiWROx0%2FoJRIFC10nFbtSo%2Ba%2FKfR4jcy6Nn7RPAQLP1%2F6BWKBr4mqZpvdrfojHiFc8YzRh28EGCOlRV3ooS1RplXZ4VqlxcXoOI%3D--Csc2k5BnVVMnsOAW--%2F%2BsQRcUVibT%2B2d34Ncd9ww%3D%3D; path=/; secure; HttpOnly; SameSite=Lax"
-      end
       it "exchanges the link token for an auth token" do
         req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
           with(

--- a/spec/suma/anon_proxy/auth_to_vendor_spec.rb
+++ b/spec/suma/anon_proxy/auth_to_vendor_spec.rb
@@ -65,6 +65,48 @@ RSpec.describe Suma::AnonProxy::AuthToVendor, :db do
       va.ensure_anonymous_contact(:email)
       expect(va.auth_to_vendor).to_not be_needs_attention(now: Time.now)
     end
+
+    describe "exchange_magic_link_token" do
+      let(:response_cookie) do
+        "_limebike-web_session=%2FeiRHNDbZElUfsNoabEDvl0lEoFlXSllTKHVcwDCHR50fqAf86rmSklHdZAziFkaH8kPkKuufiBq%2B4U9U%2BmnrDfbvtqA3yTmO00inhUlwHZ18TTqULKWwI3CbYYIDVWXDdN3nSHY8Q8uUhPflrTYiy6yJ4B3Au5hdwL3Pc5GSvKi%2Bwal%2BdWQfXirGjMSD86Lm3rA%2FbLE8kSqqDW1%2BnxkyMLJuwU5y1KfLJz%2F1rxB6IRD5MHd01a6duQbbrXj1qTeh5KcIT%2FUl3tIkEAD9sYidpOhs9aPIT2AsuPqliVmNxzN5zjsHlQOoecSMmxt4ucYiK7u2gf05TFkLn%2FOiXPx%2FZSQygM1Dk3XgxNF8JRaARJDou0j8MhAKPH6DPALGwT3DYWOe9AgdXsV%2BjqDmz%2B8E6AR7W1ZThm9c1%2Ba8oqQOqlR1evW33ntUyFiW%2Fuxu4utlQxYD7JSWwtmlNzCbASSE1CszculuT%2FAdziThdYtlPmYNDQY43O70Yu9QtIP7anjHSozf6rocbOwmRyD5y78ck1vyqFFv2OVF02XW1NKxX41qfv%2BuzAeow6G63sCQjNaonRahki0Fvov%2FqptF1OT1vamHe%2BFX85bw4ihfFv59U0fSK1UO%2FsYYiWROx0%2FoJRIFC10nFbtSo%2Ba%2FKfR4jcy6Nn7RPAQLP1%2F6BWKBr4mqZpvdrfojHiFc8YzRh28EGCOlRV3ooS1RplXZ4VqlxcXoOI%3D--Csc2k5BnVVMnsOAW--%2F%2BsQRcUVibT%2B2d34Ncd9ww%3D%3D; path=/; secure; HttpOnly; SameSite=Lax"
+      end
+      it "exchanges the link token for an auth token" do
+        req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
+          with(
+            body: {
+              "has_virtual_card" => "false",
+              "magic_link_token" => "mytoken",
+              "user_agreement_country_code" => "US",
+              "user_agreement_version" => "5",
+            },
+            headers: {
+              "Content-Type" => "application/x-www-form-urlencoded",
+              "X-Suma" => "holá",
+            },
+          ).
+          to_return(fixture_response("lime/app_post_magic_link"))
+
+        token = va.auth_to_vendor.exchange_magic_link_token("mytoken")
+        expect(req).to have_been_made
+        expect(token).to eq("ey123.ey456.789")
+      end
+    end
+
+    describe "log_out" do
+      it "calls Lime" do
+        req = stub_request(:post, "https://web-production.lime.bike/api/rider/v1/logout").
+          with(
+            headers: {
+              "Authorization" => "Bearer ey123.ey456.789",
+              "Content-Type" => "application/x-www-form-urlencoded",
+              "X-Suma" => "holá",
+            },
+          ).
+          to_return(status: 200, body: "", headers: {})
+        va.auth_to_vendor.log_out("ey123.ey456.789")
+        expect(req).to have_been_made
+      end
+    end
   end
 
   describe "LyftPass" do

--- a/spec/suma/anon_proxy/message_handler_spec.rb
+++ b/spec/suma/anon_proxy/message_handler_spec.rb
@@ -188,5 +188,26 @@ RSpec.describe Suma::AnonProxy::MessageHandler, :db do
       expect(got).to be_nil
       expect(vendor_account.contact.member.message_deliveries).to be_empty
     end
+
+    it "logs in the user if the vendor account has a pending closure" do
+      vendor_account.update(pending_closure: true)
+      req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
+        with(
+          body: {
+            "has_virtual_card" => "false",
+            "magic_link_token" => "M1ZgpMepjL5kW9XgzCmnsBKQ",
+            "user_agreement_country_code" => "US", "user_agreement_version" => "5",
+          },
+        ).to_return(fixture_response("lime/app_post_magic_link"))
+
+      got = Suma::AnonProxy::MessageHandler.handle(
+        Suma::AnonProxy::Relay.create!("fake-email-relay"),
+        signin_message,
+      )
+
+      expect(req).to have_been_made
+      expect(got).to have_attributes(vendor_account:, outbound_delivery: nil)
+      expect(vendor_account.refresh).to have_attributes(latest_access_code: nil, pending_closure: false)
+    end
   end
 end

--- a/spec/suma/anon_proxy/relay_spec.rb
+++ b/spec/suma/anon_proxy/relay_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe Suma::AnonProxy::Relay, :db do
 
     it "can provision" do
       m = Suma::Fixtures.member.create
-      expect(relay.provision(m)).to have_attributes(address: "u#{m.id}@example.com")
+      Timecop.travel("2025-06-20T12:00:00-0700") do
+        expect(relay.provision(m)).to have_attributes(address: "u#{m.id}.1750446000@example.com")
+      end
     end
   end
 
@@ -41,7 +43,17 @@ RSpec.describe Suma::AnonProxy::Relay, :db do
 
     it "can provision" do
       m = Suma::Fixtures.member.create
-      expect(relay.provision(m)).to have_attributes(address: "test.m#{m.id}@in-dev.mysuma.org")
+      Timecop.travel("2025-06-20T12:00:00-0700") do
+        expect(relay.provision(m)).to have_attributes(address: "test.m#{m.id}.1750446000@in-dev.mysuma.org")
+      end
+    end
+
+    it "can provision in production, so there is no prefix" do
+      stub_const("Suma::RACK_ENV", "production")
+      m = Suma::Fixtures.member.create
+      Timecop.travel("2025-06-20T12:00:00-0700") do
+        expect(relay.provision(m)).to have_attributes(address: "m#{m.id}.1750446000@in-dev.mysuma.org")
+      end
     end
 
     it "can deprovision" do

--- a/spec/suma/anon_proxy/vendor_account_spec.rb
+++ b/spec/suma/anon_proxy/vendor_account_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Suma::AnonProxy::VendorAccount", :db do
       Suma::AnonProxy::Relay::FakeEmail.provisioned_external_id = "xyz"
       va.ensure_anonymous_contact(:email)
       expect(va.contact).to have_attributes(
-        email: "u#{va.member.id}@example.com",
+        email: /u#{va.member.id}\.\d+@example.com/,
         relay_key: "fake-email-relay",
         external_relay_id: "xyz",
       )

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -78,6 +78,126 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
     end
   end
 
+  describe "EnrollmentRemovalRunner" do
+    let(:jobclass) { Suma::Async::EnrollmentRemovalRunner }
+    let(:member) { Suma::Fixtures.member.create }
+
+    before(:each) do
+      jobclass.testing_last_ran_removers = []
+    end
+
+    context "runs the enrollment remover when" do
+      specify "a direct program enrollment is unenrolled" do
+        e = Suma::Fixtures.program_enrollment.create(member:)
+        expect do
+          e.update(unenrolled: true)
+        end.to perform_async_job(jobclass)
+        expect(jobclass.testing_last_ran_removers).to contain_exactly(
+          have_attributes(
+            before_enrollments: have_length(1),
+            after_enrollments: be_empty,
+          ),
+        )
+      end
+
+      specify "an organization program enrollment is unenrolled" do
+        organization = Suma::Fixtures.organization.create
+        Suma::Fixtures.organization_membership.verified(organization).create(member:)
+        Suma::Fixtures.organization_membership.former(organization).create
+        e = Suma::Fixtures.program_enrollment.create(organization:)
+        expect do
+          e.update(unenrolled: true)
+        end.to perform_async_job(jobclass)
+        expect(jobclass.testing_last_ran_removers).to contain_exactly(
+          have_attributes(
+            before_enrollments: have_length(1),
+            after_enrollments: be_empty,
+          ),
+        )
+      end
+
+      specify "an organization role program enrollment is unenrolled" do
+        role = Suma::Fixtures.role.create
+        organization = Suma::Fixtures.organization.create
+        organization.add_role(role)
+        Suma::Fixtures.organization_membership.verified(organization).create(member:)
+        e = Suma::Fixtures.program_enrollment.create(role:)
+        expect do
+          e.update(unenrolled: true)
+        end.to perform_async_job(jobclass)
+        expect(jobclass.testing_last_ran_removers).to contain_exactly(
+          have_attributes(
+            before_enrollments: have_length(1),
+            after_enrollments: be_empty,
+          ),
+        )
+      end
+
+      specify "a member role program enrollment is unenrolled" do
+        role = Suma::Fixtures.role.create
+        member.add_role(role)
+        e = Suma::Fixtures.program_enrollment.create(role:)
+        expect do
+          e.update(unenrolled: true)
+        end.to perform_async_job(jobclass)
+        expect(jobclass.testing_last_ran_removers).to contain_exactly(
+          have_attributes(
+            before_enrollments: have_length(1),
+            after_enrollments: be_empty,
+          ),
+        )
+      end
+
+      specify "a member is removed from an organization" do
+        organization = Suma::Fixtures.organization.create
+        m = Suma::Fixtures.organization_membership.verified(organization).create(member:)
+        Suma::Fixtures.program_enrollment.create(organization:)
+        expect do
+          m.remove_from_organization
+          m.save_changes
+        end.to perform_async_job(jobclass)
+        expect(jobclass.testing_last_ran_removers).to contain_exactly(
+          have_attributes(
+            before_enrollments: have_length(1),
+            after_enrollments: be_empty,
+          ),
+        )
+      end
+
+      specify "a role is removed from a member" do
+        role = Suma::Fixtures.role.create
+        member.add_role(role)
+        Suma::Fixtures.program_enrollment.create(role:)
+        expect do
+          member.remove_role(role)
+        end.to perform_async_job(jobclass)
+        expect(jobclass.testing_last_ran_removers).to contain_exactly(
+          have_attributes(
+            before_enrollments: have_length(1),
+            after_enrollments: be_empty,
+          ),
+        )
+      end
+
+      specify "a role is removed from an organization" do
+        role = Suma::Fixtures.role.create
+        organization = Suma::Fixtures.organization.create
+        organization.add_role(role)
+        Suma::Fixtures.organization_membership.verified(organization).create(member:)
+        Suma::Fixtures.program_enrollment.create(role:)
+        expect do
+          organization.remove_role(role)
+        end.to perform_async_job(jobclass)
+        expect(jobclass.testing_last_ran_removers).to contain_exactly(
+          have_attributes(
+            before_enrollments: have_length(1),
+            after_enrollments: be_empty,
+          ),
+        )
+      end
+    end
+  end
+
   describe "ForwardMessages" do
     before(:each) do
       Suma::Message::Forwarder.reset_configuration

--- a/spec/suma/behaviors.rb
+++ b/spec/suma/behaviors.rb
@@ -18,21 +18,21 @@ RSpec.shared_examples "a hybrid searchable object" do
   end
 end
 
-RSpec.shared_examples "has a timestamp predicate" do |tsattr, boolattr|
+RSpec.shared_examples "has a timestamp predicate" do |tsattr, boolattr, setter=:"#{boolattr}="|
   let(:instance) { raise "must be defined in block" }
 
   it "adheres to MethodUtilities.timestamp_set" do
     m = instance
-    m.send(:"#{boolattr}=", false)
+    m.send(setter, false)
     expect(m.send(tsattr)).to be_nil
     expect(m.send(:"#{boolattr}?")).to be(false)
 
-    m.send(:"#{boolattr}=", true)
+    m.send(setter, true)
     expect(m.send(tsattr)).to match_time(:now)
     expect(m.send(:"#{boolattr}?")).to be(true)
 
     t = 4.hours.ago
-    m.send(:"#{boolattr}=", t)
+    m.send(setter, t)
     expect(m.send(tsattr)).to match_time(t)
   end
 end

--- a/spec/suma/lyft/pass_spec.rb
+++ b/spec/suma/lyft/pass_spec.rb
@@ -609,5 +609,21 @@ RSpec.describe Suma::Lyft::Pass, :db, reset_configuration: Suma::Lyft do
       expect(req).to have_been_made
     end
   end
+
+  describe "revoke_member" do
+    let(:member) { Suma::Fixtures.member.create(phone: "15552223333") }
+
+    it "revokes access" do
+      insert_valid_credential
+      req = stub_request(:post, "https://www.lyft.com/api/rideprograms/enrollment/revoke").
+        with(
+          body: {ride_program_id: "5678", user_identifier: {phone_number: "+15552223333"}}.to_json,
+        ).to_return(status: 200, body: {}.to_json, headers: {"Content-Type" => "application/json"})
+
+      instance.authenticate
+      instance.revoke_member(member, program_id: "5678")
+      expect(req).to have_been_made
+    end
+  end
 end
 # rubocop:enable Layout/LineLength

--- a/spec/suma/program/enrollment_remover_spec.rb
+++ b/spec/suma/program/enrollment_remover_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe Suma::Program::EnrollmentRemover, :db do
     expect(Suma::Program::Enrollment.all).to have_same_ids_as(p1enroll)
   end
 
+  it "excludes not-currently-enrolled enrollments from all calculations" do
+    e1 = Suma::Fixtures.program_enrollment(member:).create
+    e2 = Suma::Fixtures.program_enrollment(member:).unenrolled.create
+    e3 = Suma::Fixtures.program_enrollment(member:).unenrolled.create
+    e4 = Suma::Fixtures.program_enrollment(member:).unapproved.create
+    instance.reenroll do
+      e2.update(unenrolled: false)
+    end
+    instance.process
+    expect(instance.before_enrollments).to have_same_ids_as(e1, e2)
+    expect(instance.after_enrollments).to have_same_ids_as(e1)
+  end
+
   describe "lyft pass" do
     before(:each) do
       Suma::Lyft.reset_configuration

--- a/spec/suma/program/enrollment_remover_spec.rb
+++ b/spec/suma/program/enrollment_remover_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.describe Suma::Program::EnrollmentRemover, :db do
+  let(:member) { Suma::Fixtures.member.create }
+  let(:instance) { described_class.new(member) }
+
+  it "runs the preprocess block to capture before and after enrollments on the member and rolls back changes" do
+    p1 = Suma::Fixtures.program.create
+    p2 = Suma::Fixtures.program.create
+    p1enroll = Suma::Fixtures.program_enrollment(member:).in(p1).create
+    instance.reenroll do |m|
+      # Refer to the same row, but NOT the same object in memory
+      expect(m).to be === member
+      expect(m.object_id).to_not eql(member.object_id)
+      role = Suma::Role.create(name: "enrollmenttestrole")
+      m.add_role(role)
+      Suma::Fixtures.program_enrollment(role:).in(p2).create
+    end
+    instance.process
+    # We added the 'removed' enrollment
+    expect(instance.before_enrollments).to contain_exactly(
+      have_attributes(program: p1), have_attributes(program: p2),
+    )
+    # We found only the existing enrollment
+    expect(instance.after_enrollments).to contain_exactly(have_attributes(program: p1))
+    # We calculated the removed enrollments correctly
+    expect(instance.removed_enrollments).to contain_exactly(have_attributes(program: p2))
+    # We rolled back any database changes
+    expect(Suma::Program::Enrollment.all).to have_same_ids_as(p1enroll)
+  end
+
+  describe "lyft pass" do
+    before(:each) do
+      Suma::Lyft.reset_configuration
+
+      Suma::ExternalCredential.create(
+        service: "lyft-pass-access-token",
+        expires_at: 5.hours.from_now,
+        data: {body: {}, cookies: {}}.to_json,
+      )
+
+      Suma::Lyft.pass_authorization = "Basic xyz"
+      Suma::Lyft.pass_email = "a@b.c"
+      Suma::Lyft.pass_org_id = "1234"
+    end
+
+    it "revokes lyft pass and destroys registrations for lyft pass program ids the member no longer can access" do
+      lyft_pass_config = Suma::Fixtures.anon_proxy_vendor_configuration.create(auth_to_vendor_key: "lyft_pass")
+      lyft_pass_vendor_acct = Suma::Fixtures.anon_proxy_vendor_account.
+        create(configuration: lyft_pass_config, member: member)
+      reg1 = lyft_pass_vendor_acct.add_registration(external_program_id: "111")
+      reg2 = lyft_pass_vendor_acct.add_registration(external_program_id: "222")
+
+      p1_lp1 = Suma::Fixtures.program.create(lyft_pass_program_id: "111")
+      p2_lp1 = Suma::Fixtures.program.create(lyft_pass_program_id: "111")
+      p3_lp2 = Suma::Fixtures.program.create(lyft_pass_program_id: "222")
+
+      p1enroll = Suma::Fixtures.program_enrollment(member:).in(p1_lp1).create
+      instance.reenroll do
+        Suma::Fixtures.program_enrollment(member:).in(p2_lp1).create
+        Suma::Fixtures.program_enrollment(member:).in(p3_lp2).create
+      end
+
+      stub_request(:post, "https://www.lyft.com/api/rideprograms/enrollment/revoke").
+        with(body: hash_including("ride_program_id" => "222")).to_return(status: 200)
+
+      instance.process
+      expect(reg1).to_not be_destroyed
+      expect(reg2).to be_destroyed
+    end
+  end
+
+  describe "lime" do
+    it "only processes removal if there are no enrollments in any lime programs" do
+      p1 = Suma::Fixtures.program.create
+      p2 = Suma::Fixtures.program.create
+      vc = Suma::Fixtures.anon_proxy_vendor_configuration.create(auth_to_vendor_key: "lime")
+      p1.add_anon_proxy_vendor_configuration(vc)
+      p2.add_anon_proxy_vendor_configuration(vc)
+      Suma::Fixtures.program_enrollment(member:, program: p1).create
+      instance.reenroll do
+        Suma::Fixtures.program_enrollment(member:, program: p2).create
+      end
+      expect { instance.process }.to_not raise_error
+    end
+
+    it "errors if they have lost access to any Lime program" do
+      program = Suma::Fixtures.program.create
+      vc = Suma::Fixtures.anon_proxy_vendor_configuration.create(auth_to_vendor_key: "lime")
+      program.add_anon_proxy_vendor_configuration(vc)
+      instance.reenroll do
+        Suma::Fixtures.program_enrollment(member:, program:).create
+      end
+      expect { instance.process }.to raise_error(/TODO: Not sure how to handle this yet/)
+    end
+  end
+end

--- a/spec/suma/program/enrollment_remover_spec.rb
+++ b/spec/suma/program/enrollment_remover_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Suma::Program::EnrollmentRemover, :db do
+RSpec.describe Suma::Program::EnrollmentRemover, :db, :no_transaction_check do
   let(:member) { Suma::Fixtures.member.create }
   let(:instance) { described_class.new(member) }
 
@@ -40,6 +40,11 @@ RSpec.describe Suma::Program::EnrollmentRemover, :db do
     instance.process
     expect(instance.before_enrollments).to have_same_ids_as(e1, e2)
     expect(instance.after_enrollments).to have_same_ids_as(e1)
+  end
+
+  it "errors if in a transaction", no_transaction_check: false do
+    instance.reenroll {}
+    expect { instance.process }.to raise_error(Suma::Postgres::InTransaction)
   end
 
   describe "lyft pass" do

--- a/spec/suma/program/enrollment_spec.rb
+++ b/spec/suma/program/enrollment_spec.rb
@@ -96,11 +96,32 @@ RSpec.describe "Suma::Program::Enrollment", :db do
     expect(pe).to have_attributes(enrollee_type: "NilClass", enrollee: nil)
   end
 
-  it_behaves_like "has a timestamp predicate", "approved_at", "approved" do
+  it_behaves_like "has a timestamp predicate", "approved_at", "ever_approved", :"approved=" do
     let(:instance) { Suma::Fixtures.program_enrollment.instance }
   end
 
   it_behaves_like "has a timestamp predicate", "unenrolled_at", "unenrolled" do
     let(:instance) { Suma::Fixtures.program_enrollment.instance }
+  end
+
+  it "has accessors describing its enrollment condition" do
+    pe = Suma::Fixtures.program_enrollment.unapproved.instance
+    expect(pe).to have_attributes(
+      ever_approved?: false,
+      enrolled?: false,
+      unenrolled?: false,
+    )
+    pe.approved = true
+    expect(pe).to have_attributes(
+      ever_approved?: true,
+      enrolled?: true,
+      unenrolled?: false,
+    )
+    pe.unenrolled = true
+    expect(pe).to have_attributes(
+      ever_approved?: true,
+      enrolled?: false,
+      unenrolled?: true,
+    )
   end
 end

--- a/spec/suma/program/enrollment_spec.rb
+++ b/spec/suma/program/enrollment_spec.rb
@@ -110,18 +110,21 @@ RSpec.describe "Suma::Program::Enrollment", :db do
       ever_approved?: false,
       enrolled?: false,
       unenrolled?: false,
+      enrollment_status: :pending,
     )
     pe.approved = true
     expect(pe).to have_attributes(
       ever_approved?: true,
       enrolled?: true,
       unenrolled?: false,
+      enrollment_status: :enrolled,
     )
     pe.unenrolled = true
     expect(pe).to have_attributes(
       ever_approved?: true,
       enrolled?: false,
       unenrolled?: true,
+      enrollment_status: :unenrolled,
     )
   end
 end

--- a/spec/suma/role_spec.rb
+++ b/spec/suma/role_spec.rb
@@ -26,4 +26,21 @@ RSpec.describe "Suma::Role", :db do
       expect(has_role.refresh.roles).to contain_exactly(role)
     end
   end
+
+  describe "association options", :async, :do_not_defer_events do
+    let(:member) { Suma::Fixtures.member.create }
+    let(:role) { Suma::Fixtures.role.create }
+
+    it "publishes an event when adding a role" do
+      expect do
+        member.add_role(role)
+      end.to publish("suma.member.role.added").with_payload([member.id, role.id])
+    end
+
+    it "publishes an event when removing a role" do
+      expect do
+        member.remove_role(role)
+      end.to publish("suma.member.role.removed").with_payload([member.id, role.id])
+    end
+  end
 end

--- a/webapp/src/pages/PrivateAccountsList.jsx
+++ b/webapp/src/pages/PrivateAccountsList.jsx
@@ -109,12 +109,12 @@ export default function PrivateAccountsList() {
 }
 
 function PrivateAccount({ account, onHelp }) {
-  const { registeredWithVendor, vendorImage } = account;
+  const { needsAttention, vendorImage } = account;
   const [buttonStatus, setButtonStatus] = React.useState(INITIAL);
   const pollingController = React.useRef(new AbortController());
   const [error, setError] = useError(null);
   const [pollingSuccess, setPollingSuccess] = React.useState(null);
-  const isLinked = pollingSuccess || registeredWithVendor;
+  const isLinked = pollingSuccess || !needsAttention;
 
   useUnmountEffect(() => {
     pollingController.current.abort();


### PR DESCRIPTION
Add `EnrollmentRemover`, which contains logic for unenrolling members from programs they can no longer access. The main things are adding Lime logout, and Lyft Pass removal.

Add `EnrollmentRemoverRunner`, which figures out what members need to have their enrollments processed when enrollment, membership, or roles change.

Add a helper to Role to add added/removed publish events.

Add VendorAccountRegistration to keep track of Lyft Pass registrations, rather than the unstructured way it was done.

There were a number of other small improvements to facilitate these changes as well.

- Enrollment status is now unambiguous. `approved?` was true when unenrolled, which is confusing. It's now `ever_approved?`, an `enrolled?` predicate, and there is an `enrollment_status` accessor.
- Set model indexing to off by default. It was running in the background and slowing down tests.