### PR TITLE
Fix db issues in cluster mode

### DIFF
--- a/lib/suma/postgres/model_utilities.rb
+++ b/lib/suma/postgres/model_utilities.rb
@@ -26,14 +26,6 @@ module Suma::Postgres::ModelUtilities
   module ClassMethods
     def anonymous? = self.name.blank? || self.name.start_with?("Sequel::_Model")
 
-    # Set up some things on new database connections.
-    def db=(newdb)
-      super
-      self.descendents.each do |subclass|
-        subclass.db = newdb
-      end
-    end
-
     # The application name, set on database connections.
     attr_reader :appname
 


### PR DESCRIPTION
- Recreate databases after forking
- We don't need the db= override anymore. This has been around 10+ years from other projects but isn't serving a purpose (and breaks the db= we use after fork).