### PR TITLE
Admin: BackToList, DetailGrid actions

### DIFF
--- a/adminapp/src/components/BackToList.jsx
+++ b/adminapp/src/components/BackToList.jsx
@@ -1,0 +1,11 @@
+import Link from "./Link";
+import LeftIcon from "@mui/icons-material/ChevronLeft";
+import React from "react";
+
+export default function BackToList({ to }) {
+  return (
+    <Link to={to} sx={{ verticalAlign: "bottom" }}>
+      <LeftIcon />
+    </Link>
+  );
+}

--- a/adminapp/src/components/DetailGrid.jsx
+++ b/adminapp/src/components/DetailGrid.jsx
@@ -36,14 +36,20 @@ export default function DetailGrid({ title, properties }) {
         )}
         <Table size="small">
           <TableBody>
-            {usedProperties.map(({ label, value, children }, index) => (
+            {usedProperties.map(({ label, value, tableCells, children }, index) => (
               <TableRow key={index}>
-                <TableCell sx={{ padding: 0.25, paddingRight: 1, border: "none" }}>
-                  <Label>{label}</Label>
-                </TableCell>
-                <TableCell sx={{ padding: 0.25, border: "none" }}>
-                  <Value value={value}>{children}</Value>
-                </TableCell>
+                {tableCells ? (
+                  tableCells({ sx: { padding: 0.25, border: "none" } })
+                ) : (
+                  <>
+                    <TableCell sx={{ padding: 0.25, paddingRight: 1, border: "none" }}>
+                      <Label>{label}</Label>
+                    </TableCell>
+                    <TableCell sx={{ padding: 0.25, border: "none" }}>
+                      <Value value={value}>{children}</Value>
+                    </TableCell>
+                  </>
+                )}
               </TableRow>
             ))}
           </TableBody>

--- a/adminapp/src/components/ResourceDetail.jsx
+++ b/adminapp/src/components/ResourceDetail.jsx
@@ -4,6 +4,7 @@ import invokeIfFunc from "../modules/invokeIfFunc";
 import { resourceEditRoute, resourceListRoute } from "../modules/resourceRoutes";
 import useAsyncFetch from "../shared/react/useAsyncFetch";
 import useToggle from "../shared/react/useToggle";
+import BackToList from "./BackToList";
 import DetailGrid from "./DetailGrid";
 import Link from "./Link";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -74,6 +75,7 @@ export default function ResourceDetail({
             resourceEditRoute(resource, state)
           }
         >
+          <BackToList to={resourceListRoute(resource)} />
           {title(state)}
         </Title>
       }

--- a/adminapp/src/components/ResponsiveStack.jsx
+++ b/adminapp/src/components/ResponsiveStack.jsx
@@ -1,6 +1,12 @@
 import { Stack } from "@mui/material";
 import React from "react";
 
-export default function ResponsiveStack({ ...rest }) {
-  return <Stack direction={{ xs: "column", sm: "row" }} spacing={2} {...rest} />;
+/**
+ * Stack that is a column at xs and a row at larger sizes.
+ * @param {'sm'|'md'|'lg'} rowAt= Use a row stack at this size and larger. Default to 'sm'.
+ * @param rest Passed to Stack.
+ */
+export default function ResponsiveStack({ rowAt, ...rest }) {
+  rowAt = rowAt || "sm";
+  return <Stack direction={{ xs: "column", [rowAt]: "row" }} spacing={2} {...rest} />;
 }

--- a/adminapp/src/hooks/useErrorSnackbar.jsx
+++ b/adminapp/src/hooks/useErrorSnackbar.jsx
@@ -5,8 +5,9 @@ import React from "react";
 export default function useErrorSnackbar() {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const enqueueErrorSnackbar = React.useCallback(
-    (e, options) => {
-      options = options || { variant: "error" };
+    (e, options = {}) => {
+      options = options || {};
+      options.variant = options.variant || "error";
       enqueueSnackbar(extractErrorMessage(e), options);
     },
     [enqueueSnackbar]

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -31,16 +31,14 @@ import {
   DialogActions,
 } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
+import TableCell from "@mui/material/TableCell";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 import { formatPhoneNumber, formatPhoneNumberIntl } from "react-phone-number-input";
-import { useParams } from "react-router-dom";
 
 export default function MemberDetailPage() {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
-  let { id } = useParams();
-  id = Number(id);
   const handleUpdateMember = (member, replaceState) => {
     return api
       .updateMember(member)
@@ -49,14 +47,18 @@ export default function MemberDetailPage() {
   };
   return (
     <>
-      <Typography variant="h5" gutterBottom>
-        Member Details <ImpersonateButton id={id} />
-      </Typography>
       <ResourceDetail
         resource="member"
         apiGet={api.getMember}
         canEdit
         properties={(model, replaceState) => [
+          {
+            tableCells: (props) => (
+              <TableCell colSpan={2} {...props}>
+                <ImpersonateButton id={model.id} sx={{ mb: 1 }} />
+              </TableCell>
+            ),
+          },
           { label: "ID", value: model.id },
           { label: "Name", value: model.name },
           { label: "Email", value: model.email },
@@ -420,7 +422,7 @@ function MemberContacts({ memberContacts }) {
   );
 }
 
-function ImpersonateButton({ id }) {
+function ImpersonateButton({ id, ...rest }) {
   const { enqueueErrorSnackbar } = useErrorSnackbar();
   const { user, setUser } = useUser();
   const { canWrite } = useRoleAccess();
@@ -451,6 +453,7 @@ function ImpersonateButton({ id }) {
         variant="contained"
         color="warning"
         size="small"
+        {...rest}
       >
         Unimpersonate {user.impersonating.name || user.impersonating.phone}
       </Button>
@@ -466,6 +469,7 @@ function ImpersonateButton({ id }) {
       variant="outlined"
       color="warning"
       size="small"
+      {...rest}
     >
       Impersonate
     </Button>

--- a/adminapp/src/pages/OfferingDetailPage.jsx
+++ b/adminapp/src/pages/OfferingDetailPage.jsx
@@ -31,6 +31,7 @@ export default function OfferingDetailPage() {
         { label: "Description (Es)", value: model.description.es },
         { label: "Opening Date", value: dayjs(model.periodBegin) },
         { label: "Closing Date", value: dayjs(model.periodEnd) },
+        { label: "Confirmation Message", value: model.confirmationTemplate },
         {
           label: "Begin Fulfillment At",
           value: model.beginFulfillmentAt && dayjs(model.beginFulfillmentAt),

--- a/adminapp/src/pages/OfferingForm.jsx
+++ b/adminapp/src/pages/OfferingForm.jsx
@@ -111,6 +111,13 @@ export default function OfferingForm({
           />
         </ResponsiveStack>
         <Divider />
+        <TextField
+          name="confirmationTemplate"
+          value={resource.confirmationTemplate || ""}
+          label="Confirmation template"
+          helperText="They key of the static string in the 'messages' namespace that is sent after the order is placed. If empty, do not send a message."
+          onChange={setFieldFromInput}
+        />
         <FormLabel>Fulfillment Prompt ("how do you want to get your stuff?")</FormLabel>
         <ResponsiveStack>
           <MultiLingualText

--- a/lib/suma/admin_api/commerce_offerings.rb
+++ b/lib/suma/admin_api/commerce_offerings.rb
@@ -20,6 +20,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
     expose :audit_activities, with: ActivityEntity
+    expose :confirmation_template
     expose :description, with: TranslatedTextEntity
     expose :fulfillment_prompt, with: TranslatedTextEntity
     expose :fulfillment_instructions, with: TranslatedTextEntity
@@ -101,6 +102,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
         requires :period_begin, type: Time
         requires :period_end, type: Time
         optional :begin_fulfillment_at, type: Time
+        optional :confirmation_template, type: String
         optional :max_ordered_items_cumulative, type: Integer
         optional :max_ordered_items_per_member, type: Integer
       end
@@ -136,6 +138,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
         optional :period_begin, type: Time
         optional :period_end, type: Time
         optional :begin_fulfillment_at, type: Time
+        optional :confirmation_template, type: String
         optional :max_ordered_items_cumulative, type: Integer
         optional :max_ordered_items_per_member, type: Integer
       end


### PR DESCRIPTION
- Add BackToList component for going back to a resource list
- Add DetailGrids now point back to the main list
- DetailGrid can now take a tableCells callback to render the cells in a row.
- Use this to move the member detail page impersonate button to the grid, so we don't need the redundant title (it looks very bad with the 'backt o list' chevron)
- enqueueErrorSnackbar interface improved: variant should default to 'alert' if not spefified, and indicate the options are optional.
- Offering confirmation template can be edited, and shows on the detail page.