### PR TITLE
Fix Rake task tests state leaking, add concurrency atomic_write

### DIFF
--- a/lib/suma/concurrency.rb
+++ b/lib/suma/concurrency.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Suma::Concurrency
+  # Write to a temp file and then move it to target_path.
+  # This allows existing file handles to operate on the old version
+  # and avoid any inconsistency or corruption.
+  module_function def atomic_write(target_path, mode: "w")
+    dir = File.dirname(target_path)
+    Tempfile.create(File.basename(target_path), dir) do |tempfile|
+      tempfile.binmode if mode.include?("b")
+      tempfile.sync = true
+      tempfile.set_encoding(Encoding::BINARY) if mode.include?("b")
+      yield tempfile
+      # Explicit close means the file won't be unlinked on GC
+      tempfile.close
+      FileUtils.mv(tempfile.path, target_path)
+    end
+  end
+end

--- a/lib/suma/spec_helpers.rb
+++ b/lib/suma/spec_helpers.rb
@@ -24,12 +24,6 @@ module Suma::SpecHelpers
     super
   end
 
-  module_function def invoke_rake_task(name)
-    Rake::Task[name].invoke
-  ensure
-    Rake::Task[name].reenable
-  end
-
   ### Load data from the spec/data directory with the specified +name+,
   ### deserializing it if it's YAML or JSON, and returning it.
   module_function def load_fixture_data(name, raw: false)

--- a/lib/suma/spec_helpers/rake.rb
+++ b/lib/suma/spec_helpers/rake.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "suma/tasks"
+require "suma/spec_helpers"
+
+module Suma::SpecHelpers::Rake
+  def self.included(context)
+    context.before(:all) do
+      Suma::Tasks.load_all
+    end
+  end
+
+  module_function def invoke_rake_task(name, *)
+    Rake::Task.tasks.each(&:reenable)
+    Rake::Task[name].invoke(*)
+  ensure
+    # If the task itself calls Rake[task].invoke, we need to make sure it gets reset.
+    Rake::Task.tasks.each(&:reenable)
+  end
+end

--- a/lib/suma/tasks.rb
+++ b/lib/suma/tasks.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
+require "rake/tasklib"
+
 require "suma"
 
 module Suma::Tasks
+  class << self
+    def load_all
+      return if @loaded
+      pattern = File.join(Pathname(__FILE__).dirname, "tasks", "*.rb")
+      Gem.find_files(pattern).each do |path|
+        require path
+      end
+      Rake::TaskLib.descendants.each do |task|
+        next unless task.name.start_with?("Suma::Tasks")
+        task.new
+      end
+      @loaded = true
+    end
+  end
 end

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -14,13 +14,14 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
       ENV["SUMA_DB_SLOW_QUERY_SECONDS"] = "1"
       Suma.load_app?
       raise "only run with a fresh database" unless Suma::Member.dataset.empty?
-      SequelTranslatedText.language = :en
-      Suma::Member.db.transaction do
-        Meta.new.fixture
-        Mobility.new.fixture
-        AnonProxy.new.fixture
-        Commerce.new.fixture
-        Programs.new.fixture
+      SequelTranslatedText.language(:en) do
+        Suma::Member.db.transaction do
+          Meta.new.fixture
+          Mobility.new.fixture
+          AnonProxy.new.fixture
+          Commerce.new.fixture
+          Programs.new.fixture
+        end
       end
     end
   end

--- a/lib/suma/tasks/db.rb
+++ b/lib/suma/tasks/db.rb
@@ -19,7 +19,7 @@ class Suma::Tasks::DB < Rake::TaskLib
           next if sc == Suma::Webhookdb::Model && Suma::RACK_ENV != "test"
           schemas.each do |schemaname|
             sc.db[:pg_tables].where(schemaname:).each do |tbl|
-              self.exec(sc.db, "DROP TABLE #{schemaname}.#{tbl[:tablename]} CASCADE")
+              Suma::Tasks::DB.exec(sc.db, "DROP TABLE #{schemaname}.#{tbl[:tablename]} CASCADE")
             end
           end
         end
@@ -46,13 +46,13 @@ class Suma::Tasks::DB < Rake::TaskLib
     end
   end
 
-  def exec(db, cmd)
-    print cmd
+  def self.exec(db, cmd)
+    Kernel.print cmd
     begin
       db.execute(cmd)
-      print "\n"
+      Kernel.print "\n"
     rescue StandardError
-      print " (error)\n"
+      Kernel.print " (error)\n"
       raise
     end
   end

--- a/spec/suma/concurrency_spec.rb
+++ b/spec/suma/concurrency_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "suma/concurrency"
+
+RSpec.describe Suma::Concurrency do
+  describe "atomic_write" do
+    include_context "uses temp dir"
+    let(:path) { temp_dir_path + "testfile" }
+
+    it "writes to the target" do
+      described_class.atomic_write(path) do |f|
+        f << "hi"
+      end
+      expect(File.read(path)).to eq("hi")
+    end
+
+    it "does not cause an issue with existing open handles" do
+      File.write(path, "orig")
+      h = File.open(path)
+      described_class.atomic_write(path) do |f|
+        f << "newdata"
+      end
+      expect(h.read).to eq("orig")
+      expect(File.read(path)).to eq("newdata")
+    end
+
+    it "handles binary data" do
+      # Cannot get this test to fail with any combination of bytes,
+      # but we want to exercise the code paths anyway.
+      b = "\u0000"
+      described_class.atomic_write(path, mode: "wb") do |f|
+        f << b
+      end
+      expect(File.binread(path)).to eq(b)
+    end
+
+    it "does not delete the new file" do
+      described_class.atomic_write(path) do |f|
+        f << "hi"
+      end
+      GC.start
+      expect(File.read(path)).to eq("hi")
+    end
+  end
+end

--- a/spec/tasks/analytics_spec.rb
+++ b/spec/tasks/analytics_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "suma/spec_helpers/rake"
+require "suma/tasks/analytics"
+
+RSpec.describe Suma::Tasks::Analytics, :db do
+  include Suma::SpecHelpers::Rake
+
+  describe "truncate" do
+    it "deletes analytics tables" do
+      Suma::Analytics::Member.create(member_id: 1)
+      invoke_rake_task("analytics:truncate")
+      expect(Suma::Analytics::Member.all).to be_empty
+    end
+  end
+
+  describe "import" do
+    it "imports tables" do
+      expect(Suma::Analytics::Member.all).to be_empty
+      Suma::Fixtures.member.create
+      invoke_rake_task("analytics:import")
+      expect(Suma::Analytics::Member.all).to have_length(1)
+    end
+  end
+end

--- a/spec/tasks/bootstrap_spec.rb
+++ b/spec/tasks/bootstrap_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
+require "suma/spec_helpers/rake"
 require "suma/tasks/bootstrap"
 
 RSpec.describe Suma::Tasks::Bootstrap, :db do
-  before(:all) do
-    described_class.new
-  end
+  include Suma::SpecHelpers::Rake
 
   it "runs successfully" do
     stub_const("Suma::RACK_ENV", "development")

--- a/spec/tasks/db_spec.rb
+++ b/spec/tasks/db_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "suma/spec_helpers/rake"
+require "suma/tasks/db"
+
+RSpec.describe Suma::Tasks::DB do
+  include Suma::SpecHelpers::Rake
+
+  describe "drop_tables" do
+    it "drops all tables" do
+      expect(described_class).to receive(:exec).
+        with(be_a(Sequel::Database), match(/DROP TABLE [\w.]+ CASCADE/)).
+        at_least(10).times
+      invoke_rake_task("db:drop_tables")
+    end
+  end
+
+  describe "wipe" do
+    it "truncates tables", db: :no_transaction do
+      Suma::Fixtures.member.create
+      # Speed this up since truncate cascade on many tables is slow
+      expect(Suma::Postgres).to receive(:each_model_class) do |&b|
+        b.call Suma::Member
+      end
+      invoke_rake_task("db:wipe")
+      expect(Suma::Member.all).to be_empty
+    end
+  end
+
+  describe "migrate" do
+    it "runs the migrator" do
+      expect(Suma::Postgres).to receive(:run_all_migrations).with(target: nil)
+      invoke_rake_task("db:migrate")
+    end
+
+    it "can set a version" do
+      expect(Suma::Postgres).to receive(:run_all_migrations).with(target: 5)
+      invoke_rake_task("db:migrate", "5")
+    end
+  end
+
+  describe "exec" do
+    it "prints and runs" do
+      cls = Class.new do
+        attr_accessor :executed
+
+        def execute(cmd) = @executed = cmd
+      end
+      db = cls.new
+      expect(Kernel).to receive(:print).with("SELECT 1")
+      expect(Kernel).to receive(:print).with("\n")
+      described_class.exec(db, "SELECT 1")
+      expect(db.executed).to eq("SELECT 1")
+    end
+
+    it "prints an error" do
+      cls = Class.new do
+        def execute(*) = raise "hi"
+      end
+      db = cls.new
+      expect(Kernel).to receive(:print).with("SELECT 1")
+      expect(Kernel).to receive(:print).with(" (error)\n")
+      expect { described_class.exec(db, "SELECT 1") }.to raise_error("hi")
+    end
+  end
+end

--- a/spec/tasks/release_spec.rb
+++ b/spec/tasks/release_spec.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
+require "suma/spec_helpers/rake"
 require "suma/tasks/release"
 
 RSpec.describe Suma::Tasks::Release, :db do
-  before(:all) do
-    Suma::Tasks::DB.new
-    Suma::Tasks::Sidekiq.new
-    described_class.new
-  end
+  include Suma::SpecHelpers::Rake
 
   describe "release" do
     it "migrates the database, marks the Sidekiq deployment, imports static strings" do

--- a/spec/tasks/sidekiq_spec.rb
+++ b/spec/tasks/sidekiq_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
+require "suma/spec_helpers/rake"
 require "suma/tasks/sidekiq"
 
 RSpec.describe Suma::Tasks::Sidekiq, sidekiq: :disable do
-  before(:all) do
-    described_class.new
-  end
+  include Suma::SpecHelpers::Rake
 
   describe "reset" do
     it "clears the redis DB" do


### PR DESCRIPTION
Add Concurrency.atomic_write helper

---

Fix Rake tests again

We cannot call Task.new multiple times.
Instead, dynamically require tasks just once in the process.

Move helper code to a separate spec helper file.

Also fix a flaky test in bootstrap
