### PR TITLE
Improve static string performance, fix camelize issues, add missing localization Sentry logging

### DIFF
--- a/db/migrations/082_static_strings_perf.rb
+++ b/db/migrations/082_static_strings_perf.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:i18n_static_strings) do
+      add_index :modified_at
+      add_index :text_id, unique: true # Should never be shared
+    end
+  end
+end

--- a/lib/suma/spec_helpers/i18n.rb
+++ b/lib/suma/spec_helpers/i18n.rb
@@ -18,6 +18,19 @@ module Suma::SpecHelpers::I18n
         example.run
       end
     end
+
+    context.around(:each) do |example|
+      if example.metadata[:static_strings]
+        Suma::I18n::StaticStringRebuilder.instance = nil
+        begin
+          example.run
+        ensure
+          Suma::I18n::StaticStringRebuilder.instance = nil
+        end
+      else
+        example.run
+      end
+    end
     super
   end
 

--- a/spec/suma/i18n/static_string_rebuilder_spec.rb
+++ b/spec/suma/i18n/static_string_rebuilder_spec.rb
@@ -69,6 +69,22 @@ RSpec.describe Suma::I18n::StaticStringRebuilder, :db do
       expect(Pathname(temp_dir_path + "en_n2.json")).to be_exist
       expect(Pathname(temp_dir_path + "en_n3.json")).to_not be_exist
     end
+
+    it "writes an empty file if there are no strings" do
+      described_class.new(temp_dir_path).write_namespaces(["n"])
+      expect(File.read(temp_dir_path + "en_n.json")).to eq("{}")
+    end
+
+    it "sets the file modtime to the max namespace string modified_at" do
+      t1 = 1.year.ago
+      Suma::Fixtures.static_string.create(namespace: "n1", modified_at: t1)
+      t2 = 2.years.ago
+      Suma::Fixtures.static_string.create(namespace: "n2", modified_at: t2)
+
+      described_class.new(temp_dir_path).write_namespaces(["n1", "n2"])
+      expect(File.mtime(temp_dir_path + "en_n1.json")).to match_time(t1)
+      expect(File.mtime(temp_dir_path + "en_n2.json")).to match_time(t2)
+    end
   end
 
   describe "rebuild_outdated" do

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -41,70 +41,87 @@ export default {
   patch,
   put,
   del,
-  getMe: (data) => get(`/api/v1/me`, data),
-  updateMe: (data) => post(`/api/v1/me/update`, data),
-  changeLanguage: (data) => post(`/api/v1/me/language`, data),
-  getSupportedGeographies: (data) => get(`/api/v1/meta/supported_geographies`, data),
-  getSupportedLocales: (data) => get(`/api/v1/meta/supported_locales`, data),
-  getSupportedCurrencies: (data) => get(`/api/v1/meta/supported_currencies`, data),
-  getSupportedPaymentMethods: (data) =>
-    get(`/api/v1/meta/supported_payment_methods`, data),
-  geolocateIp: (data) => get(`/api/v1/meta/geolocate_ip`, data),
-  getSupportedOrganizations: (data) => get(`/api/v1/meta/supported_organizations`, data),
-  getLocaleFile: ({ namespace, locale, ...data }) =>
-    get(`/api/v1/meta/static_strings/${locale}/${namespace}`, data),
-  dashboard: (data) => get("/api/v1/me/dashboard", data),
-  getLedgersOverview: (data) => get("/api/v1/ledgers/overview", data),
-  getLedgerLines: ({ id, ...data }) => get(`/api/v1/ledgers/${id}/lines`, data),
-  authStart: (data) => post(`/api/v1/auth/start`, data),
-  authVerify: (data) => post(`/api/v1/auth/verify`, data),
-  authContactList: (data) => post(`/api/v1/auth/contact_list`, data),
-  authSignout: (data) => del(`/api/v1/auth`, data),
-  getMobilityMap: (data) => get("/api/v1/mobility/map", data),
-  getMobilityMapFeatures: (data) => get("/api/v1/mobility/map_features", data),
-  getMobilityVehicle: (data) => get("/api/v1/mobility/vehicle", data),
-  beginMobilityTrip: (data) => post("/api/v1/mobility/begin_trip", data),
-  endMobilityTrip: (data) => post("/api/v1/mobility/end_trip", data),
-  getMobilityTrips: (data) => get("/api/v1/mobility/trips", data),
+  getMe: (data, ...args) => get(`/api/v1/me`, data, ...args),
+  updateMe: (data, ...args) => post(`/api/v1/me/update`, data, ...args),
+  changeLanguage: (data, ...args) => post(`/api/v1/me/language`, data, ...args),
+  getSupportedGeographies: (data, ...args) =>
+    get(`/api/v1/meta/supported_geographies`, data, ...args),
+  getSupportedLocales: (data, ...args) =>
+    get(`/api/v1/meta/supported_locales`, data, ...args),
+  getSupportedCurrencies: (data, ...args) =>
+    get(`/api/v1/meta/supported_currencies`, data, ...args),
+  getSupportedPaymentMethods: (data, ...args) =>
+    get(`/api/v1/meta/supported_payment_methods`, data, ...args),
+  geolocateIp: (data, ...args) => get(`/api/v1/meta/geolocate_ip`, data, ...args),
+  getSupportedOrganizations: (data, ...args) =>
+    get(`/api/v1/meta/supported_organizations`, data, ...args),
+  getLocaleFile: ({ namespace, locale, ...data }, ...args) =>
+    get(`/api/v1/meta/static_strings/${locale}/${namespace}`, data, ...args),
+  dashboard: (data, ...args) => get("/api/v1/me/dashboard", data, ...args),
+  getLedgersOverview: (data, ...args) => get("/api/v1/ledgers/overview", data, ...args),
+  getLedgerLines: ({ id, ...data }, ...args) =>
+    get(`/api/v1/ledgers/${id}/lines`, data, ...args),
+  authStart: (data, ...args) => post(`/api/v1/auth/start`, data, ...args),
+  authVerify: (data, ...args) => post(`/api/v1/auth/verify`, data, ...args),
+  authContactList: (data, ...args) => post(`/api/v1/auth/contact_list`, data, ...args),
+  authSignout: (data, ...args) => del(`/api/v1/auth`, data, ...args),
+  getMobilityMap: (data, ...args) => get("/api/v1/mobility/map", data, ...args),
+  getMobilityMapFeatures: (data, ...args) =>
+    get("/api/v1/mobility/map_features", data, ...args),
+  getMobilityVehicle: (data, ...args) => get("/api/v1/mobility/vehicle", data, ...args),
+  beginMobilityTrip: (data, ...args) =>
+    post("/api/v1/mobility/begin_trip", data, ...args),
+  endMobilityTrip: (data, ...args) => post("/api/v1/mobility/end_trip", data, ...args),
+  getMobilityTrips: (data, ...args) => get("/api/v1/mobility/trips", data, ...args),
   getUserAgent: () => get("/api/useragent"),
   getCommerceOfferings: () => get("/api/v1/commerce/offerings"),
-  getCommerceOfferingDetails: ({ id, ...data }) =>
-    get(`/api/v1/commerce/offerings/${id}`, data),
-  putCartItem: ({ offeringId, ...data }) =>
-    put(`/api/v1/commerce/offerings/${offeringId}/cart/item`, data),
-  startCheckout: ({ offeringId, ...data }) =>
-    post(`/api/v1/commerce/offerings/${offeringId}/checkout`, data),
-  getCheckout: ({ id, ...data }) => get(`/api/v1/commerce/checkouts/${id}`, data),
-  updateCheckoutFulfillment: ({ checkoutId, ...data }) =>
-    post(`/api/v1/commerce/checkouts/${checkoutId}/modify_fulfillment`, data),
-  completeCheckout: ({ id, ...data }) =>
-    post(`/api/v1/commerce/checkouts/${id}/complete`, data),
-  getCheckoutConfirmation: ({ id, ...data }) =>
-    get(`/api/v1/commerce/checkouts/${id}/confirmation`, data),
-  getOrderHistory: (data) => get(`/api/v1/commerce/orders`, data),
-  getOrderDetails: ({ id, ...data }) => get(`/api/v1/commerce/orders/${id}`, data),
-  getUnclaimedOrderHistory: (data) => get(`/api/v1/commerce/orders/unclaimed`, data),
-  updateOrderFulfillment: ({ orderId, ...data }) =>
-    post(`/api/v1/commerce/orders/${orderId}/modify_fulfillment`, data),
-  claimOrder: ({ orderId, ...data }) =>
-    post(`/api/v1/commerce/orders/${orderId}/claim`, data),
+  getCommerceOfferingDetails: ({ id, ...data }, ...args) =>
+    get(`/api/v1/commerce/offerings/${id}`, data, ...args),
+  putCartItem: ({ offeringId, ...data }, ...args) =>
+    put(`/api/v1/commerce/offerings/${offeringId}/cart/item`, data, ...args),
+  startCheckout: ({ offeringId, ...data }, ...args) =>
+    post(`/api/v1/commerce/offerings/${offeringId}/checkout`, data, ...args),
+  getCheckout: ({ id, ...data }, ...args) =>
+    get(`/api/v1/commerce/checkouts/${id}`, data, ...args),
+  updateCheckoutFulfillment: ({ checkoutId, ...data }, ...args) =>
+    post(`/api/v1/commerce/checkouts/${checkoutId}/modify_fulfillment`, data, ...args),
+  completeCheckout: ({ id, ...data }, ...args) =>
+    post(`/api/v1/commerce/checkouts/${id}/complete`, data, ...args),
+  getCheckoutConfirmation: ({ id, ...data }, ...args) =>
+    get(`/api/v1/commerce/checkouts/${id}/confirmation`, data, ...args),
+  getOrderHistory: (data, ...args) => get(`/api/v1/commerce/orders`, data, ...args),
+  getOrderDetails: ({ id, ...data }, ...args) =>
+    get(`/api/v1/commerce/orders/${id}`, data, ...args),
+  getUnclaimedOrderHistory: (data, ...args) =>
+    get(`/api/v1/commerce/orders/unclaimed`, data, ...args),
+  updateOrderFulfillment: ({ orderId, ...data }, ...args) =>
+    post(`/api/v1/commerce/orders/${orderId}/modify_fulfillment`, data, ...args),
+  claimOrder: ({ orderId, ...data }, ...args) =>
+    post(`/api/v1/commerce/orders/${orderId}/claim`, data, ...args),
 
-  createBankAccount: (data) =>
-    post(`/api/v1/payment_instruments/bank_accounts/create`, data),
-  deleteBankAccount: (data) =>
-    del(`/api/v1/payment_instruments/bank_accounts/${data.id}`, data),
+  createBankAccount: (data, ...args) =>
+    post(`/api/v1/payment_instruments/bank_accounts/create`, data, ...args),
+  deleteBankAccount: (data, ...args) =>
+    del(`/api/v1/payment_instruments/bank_accounts/${data.id}`, data, ...args),
 
-  createCardStripe: (data) =>
-    post(`/api/v1/payment_instruments/cards/create_stripe`, data),
-  deleteCard: (data) => del(`/api/v1/payment_instruments/cards/${data.id}`, data),
+  createCardStripe: (data, ...args) =>
+    post(`/api/v1/payment_instruments/cards/create_stripe`, data, ...args),
+  deleteCard: (data, ...args) =>
+    del(`/api/v1/payment_instruments/cards/${data.id}`, data, ...args),
 
-  createFundingPayment: (data) => post(`/api/v1/payments/create_funding`, data),
+  createFundingPayment: (data, ...args) =>
+    post(`/api/v1/payments/create_funding`, data, ...args),
 
-  getPrivateAccounts: (data) => get(`/api/v1/anon_proxy/vendor_accounts`, data),
-  configurePrivateAccount: (data) =>
-    post(`/api/v1/anon_proxy/vendor_accounts/${data.id}/configure`, data),
-  makePrivateAccountAuthRequest: (data) =>
-    post(`/api/v1/anon_proxy/vendor_accounts/${data.id}/make_auth_request`, data),
+  getPrivateAccounts: (data, ...args) =>
+    get(`/api/v1/anon_proxy/vendor_accounts`, data, ...args),
+  configurePrivateAccount: (data, ...args) =>
+    post(`/api/v1/anon_proxy/vendor_accounts/${data.id}/configure`, data, ...args),
+  makePrivateAccountAuthRequest: (data, ...args) =>
+    post(
+      `/api/v1/anon_proxy/vendor_accounts/${data.id}/make_auth_request`,
+      data,
+      ...args
+    ),
   pollForNewPrivateAccountMagicLink: (data, opts) =>
     post(
       `/api/v1/anon_proxy/vendor_accounts/${data.id}/poll_for_new_magic_link`,
@@ -112,9 +129,11 @@ export default {
       opts
     ),
 
-  getPreferencesPublic: (data) => get("/api/v1/preferences/public", data),
-  updatePreferencesPublic: (data) => post("/api/v1/preferences/public", data),
-  updatePreferences: (data) => post("/api/v1/preferences", data),
+  getPreferencesPublic: (data, ...args) =>
+    get("/api/v1/preferences/public", data, ...args),
+  updatePreferencesPublic: (data, ...args) =>
+    post("/api/v1/preferences/public", data, ...args),
+  updatePreferences: (data, ...args) => post("/api/v1/preferences", data, ...args),
 
-  completeSurvey: (data) => post(`/api/v1/surveys`, data),
+  completeSurvey: (data, ...args) => post(`/api/v1/surveys`, data, ...args),
 };

--- a/webapp/src/localization/I18nProvider.jsx
+++ b/webapp/src/localization/I18nProvider.jsx
@@ -1,4 +1,5 @@
 import api from "../api";
+import config from "../config.js";
 import { dayjs } from "../modules/dayConfig";
 import doOnce from "../shared/doOnce";
 import { Logger } from "../shared/logger";
@@ -40,7 +41,10 @@ export default function I18nProvider({ children }) {
         return Promise.resolve();
       }
       return api
-        .getLocaleFile({ locale: language, namespace }, { camelize: false })
+        .getLocaleFile(
+          { locale: language, namespace, cachebust: config.release },
+          { camelize: false }
+        )
         .then((resp) => i18n.putFile(language, namespace, resp.data))
         .catch((e) =>
           logger

--- a/webapp/src/localization/I18nProvider.jsx
+++ b/webapp/src/localization/I18nProvider.jsx
@@ -7,7 +7,6 @@ import useMountEffect from "../shared/react/useMountEffect";
 import useUser from "../state/useUser";
 import { useCurrentLanguage } from "./currentLanguage";
 import i18n from "./i18n";
-import humps from "humps";
 import noop from "lodash/noop";
 import React from "react";
 
@@ -41,10 +40,8 @@ export default function I18nProvider({ children }) {
         return Promise.resolve();
       }
       return api
-        .getLocaleFile({ locale: language, namespace })
-        .then((resp) =>
-          i18n.putFile(language, namespace, humps.decamelizeKeys(resp.data))
-        )
+        .getLocaleFile({ locale: language, namespace }, { camelize: false })
+        .then((resp) => i18n.putFile(language, namespace, resp.data))
         .catch((e) =>
           logger
             .context({ error: e })

--- a/webapp/src/shared/apiBase.js
+++ b/webapp/src/shared/apiBase.js
@@ -14,15 +14,18 @@ function create(apiHost, config) {
     baseURL: apiHost,
     timeout: 20000,
     withCredentials: true,
-    transformResponse: [
-      ...axios.defaults.transformResponse,
-      (data) => humps.camelizeKeys(data),
-    ],
     transformRequest: [
       (data) => humps.decamelizeKeys(data),
       ...axios.defaults.transformRequest,
     ],
+    transformResponse: [...axios.defaults.transformResponse],
     ...rest,
+  });
+  instance.interceptors.response.use((response) => {
+    if (typeof response.data === "object" && response.config.camelize !== false) {
+      response.data = humps.camelizeKeys(response.data);
+    }
+    return response;
   });
   if (debug) {
     console.log(

--- a/webapp/src/shared/sentry.js
+++ b/webapp/src/shared/sentry.js
@@ -8,6 +8,12 @@ import * as Sentry from "@sentry/browser";
  * Add more shim methods as needed.
  */
 class SentryShim {
+  /**
+   * @param {function(Sentry.Scope): void} cb
+   */
+  withScope(cb) {
+    return Sentry.withScope(cb);
+  }
   captureMessage(message, context) {
     return Sentry.captureMessage(message, context);
   }


### PR DESCRIPTION
Improve static string fetch performance

We were fetching repeatedly. Use caching instead.

- Use http expires caching
- Use a SHA cache bust on the frontend request
- Set Last-Modified header from the served file,
  so the client will use If-Modified-Since.
- Check If-Modified-Since in the endpoint to avoid any
  issues with Rack.
- Set the cache file mtime to the latest modified_at
  of the static strings for that namespace.
- Handle missing namespace requests
- Add missing index on modified_at, it was used in queries

---

Add camelize:false option to API

We cannot rely on camelize/decamelize to be lossless:
for example, 'foo10' and 'foo_10' are both camelized as
'foo10' and we cannot know which it was originally.

Add a 'camelize:false' option to API requests.

Required switching from an axios transformer (pure) to an interceptor
(has access to config).

---

Log localization issues to Sentry

Also fix problems with logger's Sentry usage.
Needs to use withScope properly.
