### PR TITLE
Improve bootstrapping situation; auto-approve enrollments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,14 @@ reset-db-staging:
 	MERGE_HEROKU_ENV=$(staging_app) bundle exec rake db:reset
 bootstrap-db:
 	bundle exec rake bootstrap
+reinit-staging-db:
+	heroku ps:scale web=0 worker=0 --app $(staging_app)
+	heroku pg:reset --app=$(staging_app) --confirm=$(staging_app)
+	MERGE_HEROKU_ENV=$(staging_app) bundle exec foreman start release
+	MERGE_HEROKU_ENV=$(staging_app) bundle exec rake bootstrap[true]
+	heroku ps:scale web=1 worker=1 --app $(staging_app)
+	@echo "Randomizing passwords for all users:"
+	@MERGE_HEROKU_ENV=$(staging_app) bundle exec rake release:randomize_passwords
 
 reset-sidekiq-redis:
 	bundle exec rake sidekiq:reset

--- a/adminapp/src/components/ImageFileInput.jsx
+++ b/adminapp/src/components/ImageFileInput.jsx
@@ -1,3 +1,4 @@
+import formHelpers from "../modules/formHelpers";
 import MultiLingualText from "./MultiLingualText";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import { Button, FormHelperText, FormLabel, Stack } from "@mui/material";
@@ -17,6 +18,7 @@ import React from "react";
  * @constructor
  */
 function ImageFileInput({ image, caption, required, onImageChange, onCaptionChange }) {
+  caption = caption || formHelpers.initialTranslation;
   let src = {};
   if (image?.url) {
     src = image.url;

--- a/adminapp/src/components/detailPageImageProperties.jsx
+++ b/adminapp/src/components/detailPageImageProperties.jsx
@@ -16,8 +16,8 @@ export default function detailPageImageProperties(image, { h, label } = {}) {
     },
     {
       label: "Caption (En)",
-      value: image.caption.en,
+      value: image?.caption.en,
     },
-    { label: "Caption (Es)", value: image.caption.es },
+    { label: "Caption (Es)", value: image?.caption.es },
   ];
 }

--- a/lib/suma/admin_api/program_enrollments.rb
+++ b/lib/suma/admin_api/program_enrollments.rb
@@ -26,6 +26,11 @@ class Suma::AdminAPI::ProgramEnrollments < Suma::AdminAPI::V1
       self,
       Suma::Program::Enrollment,
       ProgramEnrollmentEntity,
+      around: lambda do |rt, m, &b|
+        m.approved = true
+        m.approved_by = rt.admin_member
+        b.call
+      end,
     ) do
       params do
         requires(:program, type: JSON) { use :model_with_id }

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -55,6 +55,9 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
         c.phone = ADMIN_PHONE
         c.onboarding_verified_at = Time.now
       end
+      admin.legal_entity.update(
+        address: Suma::Address.create(address1: "123 Main St", city: "Portland", state: "OR", postal_code: "97215"),
+      )
       admin.ensure_role(Suma::Role.cache.admin)
       Suma::Payment.ensure_cash_ledger(admin)
 
@@ -440,8 +443,6 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
         g.app_link = "/mobility"
         g.app_link_text = Suma::TranslatedText.find_or_create(en: "Check out mobility map", es: "Check out mobility map (ES)")
       end
-      mobility_program.add_enrollment(role: Suma::Role.cache.admin, approved_at: Time.now) unless
-        mobility_program.enrollments.any? { |e| e.role === Suma::Role.cache.admin }
 
       # Matches the vendor services fixtured previously
       ["lime_demo_mobility_deeplink", "biketown_demo_mobility_deeplink"].each do |internal_name|
@@ -459,6 +460,10 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
       return unless fm_program.commerce_offerings.empty?
       fm_program.add_commerce_offering(Suma::Commerce::Offering[confirmation_template: "2022_12_pilot_confirmation"])
       fm_program.add_commerce_offering(Suma::Commerce::Offering[confirmation_template: "2023_07_pilot_confirmation"])
+
+      Suma::Program.all.each do |pr|
+        pr.add_enrollment(role: Suma::Role.cache.admin, approved_at: Time.now)
+      end
     end
   end
 end

--- a/lib/suma/tasks/bootstrap.rb
+++ b/lib/suma/tasks/bootstrap.rb
@@ -9,8 +9,8 @@ class Suma::Tasks::Bootstrap < Rake::TaskLib
   def initialize
     super
     desc "Bootstrap a new database so you can use the app."
-    task :bootstrap do
-      raise "only run this in development" unless Suma::RACK_ENV == "development"
+    task :bootstrap, [:force] do |_, args|
+      raise "only run this in development" unless args[:force] || Suma::RACK_ENV == "development"
       ENV["SUMA_DB_SLOW_QUERY_SECONDS"] = "1"
       Suma.load_app?
       raise "only run with a fresh database" unless Suma::Member.dataset.empty?

--- a/lib/suma/tasks/release.rb
+++ b/lib/suma/tasks/release.rb
@@ -35,6 +35,15 @@ class Suma::Tasks::Release < Rake::TaskLib
           conn[:members].where(email: "admin@lithic.tech").update(soft_deleted_at: nil)
         end
       end
+
+      task :randomize_passwords do
+        Suma.load_app?
+        Suma::Member.exclude(email: nil).each do |m|
+          pw = SecureRandom.hex(24)
+          m.update(password: pw)
+          $stdout << "#{m.email}: #{pw}\n"
+        end
+      end
     end
   end
 end

--- a/spec/suma/admin_api/program_enrollments_spec.rb
+++ b/spec/suma/admin_api/program_enrollments_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe Suma::AdminAPI::ProgramEnrollments, :db do
       expect(last_response.headers).to include("Created-Resource-Admin")
       expect(Suma::Program::Enrollment.all).to have_length(1)
     end
+
+    it "is automatically approved" do
+      role = Suma::Role.create(name: "test")
+      program = Suma::Fixtures.program.create
+
+      post "/v1/program_enrollments/create", program: {id: program.id}, role: {id: role.id}
+
+      expect(last_response).to have_status(200)
+      expect(Suma::Program::Enrollment.first).to have_attributes(
+        approved_at: match_time(:now),
+      )
+    end
   end
 
   describe "GET /v1/program_enrollments/:id" do

--- a/spec/tasks/release_spec.rb
+++ b/spec/tasks/release_spec.rb
@@ -30,4 +30,15 @@ RSpec.describe Suma::Tasks::Release, :db do
       expect(admin.refresh).to_not be_soft_deleted
     end
   end
+
+  describe "randomize_passwords" do
+    it "randomizes passwords on all members", :redirect do
+      expect(SecureRandom).to receive(:hex).with(24).and_return("abcd1234")
+      m = Suma::Fixtures.member.create(email: "x@y.z")
+      Suma::Fixtures.member.create(email: nil)
+      invoke_rake_task("release:randomize_passwords")
+      expect($stdout.string).to eq("x@y.z: abcd1234\n")
+      expect(m.refresh.authenticate?("abcd1234")).to be(true)
+    end
+  end
 end

--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -1,2 +1,2 @@
-VITE_DEV_CARD_DETAILS={"name":"Your Name Here","number":"4242424242424242","expiry":"01 / 25","cvc":"123"}
+VITE_DEV_CARD_DETAILS={"name":"Your Name Here","number":"4242424242424242","expiry":"01 / 35","cvc":"123"}
 VITE_DEV_BANK_ACCOUNT_DETAILS={"name":"Test Account","routing":"111222333","account":"9123"}

--- a/webapp/src/config.js
+++ b/webapp/src/config.js
@@ -52,6 +52,12 @@ const config = {
   metricsEndpoint: env.VITE_METRICS_ENDPOINT,
 };
 
-initSentry({ dsn: config.sentryDsn, debug: config.debug, application: "web-app" });
+initSentry({
+  dsn: config.sentryDsn,
+  debug: config.debug,
+  application: "web-app",
+  release: config.release,
+  environment: config.environment,
+});
 
 export default config;


### PR DESCRIPTION
Restoring the staging DB after security testing exposed some issues with running the bootstrap command.

Boostrap db usability fixes

- Enroll admins in everything
- Add address to legal entity
- Use further-out card expiration for card dev details
- Add command to re-bootstrap staging db
- Add command to randomize passwords

---

Better handle missing images and captions in admin

---

Support 'force' command when bootstrapping

Allow use on staging.

---

Speed up static string seed import

- Add eager loading
- Use bulk insert and update

---

Also: Admin: Auto-approve enrollments created in admin

---

Add missing config to webapp sentry init

Was missing release and environment.
