### PR TITLE
Fix redis SSL, SSE.publish captures exceptions, and add member ID and phone to verification page

### DIFF
--- a/adminapp/src/pages/OrganizationMembershipVerificationDetailPage.jsx
+++ b/adminapp/src/pages/OrganizationMembershipVerificationDetailPage.jsx
@@ -55,10 +55,11 @@ export default function OrganizationMembershipVerificationDetailPage() {
           label: "Member",
           value: (
             <AdminLink model={model.membership.member}>
-              {model.membership.member.name}
+              ({model.membership.member.id}) {model.membership.member.name}
             </AdminLink>
           ),
         },
+        { label: "Phone", value: model.membership.member.formattedPhone },
         {
           label: "Membership",
           children: (

--- a/lib/suma/redis.rb
+++ b/lib/suma/redis.rb
@@ -12,10 +12,13 @@ module Suma::Redis
 
     def conn_params(url, **kw)
       params = {url:}
-      if url.start_with?("rediss:") && ENV["HEROKU_APP_ID"]
-        # rediss: schema is Redis with SSL. They use self-signed certs, so we have to turn off SSL verification.
+      if url.start_with?("rediss:")
+        # rediss: schema is Redis with SSL. redis-client needs ssl: true explicitly.
+        params[:ssl] = true
+        # Hereoku uses self-signed certs, so we have to turn off SSL verification.
         # There is not a clear KB on this, you have to piece it together from Heroku and Sidekiq docs.
-        params[:ssl_params] = {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+        # This is still required as of August 2025.
+        (params[:ssl_params] = {verify_mode: OpenSSL::SSL::VERIFY_NONE}) if ENV["HEROKU_APP_ID"]
       end
       params.merge!(kw)
       return params

--- a/lib/suma/sse.rb
+++ b/lib/suma/sse.rb
@@ -21,7 +21,7 @@ module Suma::SSE
     setting :redis_url, ""
 
     after_configured do
-      redis_url = Suma::Redis.fetch_url(self.redis_provider, self.redis_url)
+      redis_url = Suma::Redis.fetch_url(Suma::SSE.redis_provider, Suma::SSE.redis_url)
       self.publisher_redis = RedisClient.new(**Suma::Redis.conn_params(redis_url))
     end
   end

--- a/spec/suma/redis_spec.rb
+++ b/spec/suma/redis_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe Suma::Redis do
   describe "#conn_params" do
     it "returns keyword arguments" do
       params = described_class.conn_params("redis://localhost:1234/0", reconnect_attempts: 1, timeout: 1.0)
-      expect(params).to include(url: "redis://localhost:1234/0", reconnect_attempts: 1, timeout: 1.0)
+      expect(params).to eq({url: "redis://localhost:1234/0", reconnect_attempts: 1, timeout: 1.0})
+    end
+
+    it "uses ssl: true for rediss:// protocol" do
+      params = described_class.conn_params("rediss://localhost:1234/0")
+      expect(params).to eq({url: "rediss://localhost:1234/0", ssl: true})
     end
 
     it "returns ssl_params when using heroku redis" do


### PR DESCRIPTION
SSE.publish captures exceptions

In most cases, a missed publish isn't a big deal.

---

Add member ID and phone to verification detail

Needed to identify duplicates better.
Ie, anything highlighted in the duplicates list
should be visible from this page.

---

Use ssl:true param in redis connections

Apparently the redis-client gem needs this explicitly.
