### PR TITLE
Assert every admin API call checks role access

### DIFF
--- a/lib/suma/admin_api.rb
+++ b/lib/suma/admin_api.rb
@@ -33,6 +33,12 @@ module Suma::AdminAPI
             header "Created-Resource-Id", resource_id.to_s
             header "Created-Resource-Admin", admin_link
           end
+
+          def check_admin_role_access!(rw, key, admin: admin_member)
+            Thread.current[:checked_role_access] = true if Suma.test?
+            key = Suma::AdminAPI::Access.key(key, rw) unless key.is_a?(Symbol)
+            check_role_access!(admin, rw, key)
+          end
         end
 
         rescue_from Sequel::UniqueConstraintViolation do |e|

--- a/lib/suma/admin_api.rb
+++ b/lib/suma/admin_api.rb
@@ -34,6 +34,25 @@ module Suma::AdminAPI
             header "Created-Resource-Admin", admin_link
           end
 
+          # Run check_role_access! for a key or model.
+          #
+          # == Test environments
+          #
+          # This code also sets a thread local in a test RACK_ENV
+          # that shows the method was called. If the flag isn't set,
+          # the endpoint errors.
+          #
+          # It was way too easy to add admin endpoints without remember
+          # to check role access of the admin. This would be a persistent
+          # security concern.
+          #
+          # Instead, make sure every admin endpoint calls
+          # `check_admin_role_access!`, or uses
+          # `route_setting :skip_role_check, true` to bypass the check.
+          #
+          # Only perform this check during testing; we don't need to assert it
+          # other than in unit tests, since all endpoints must be unit tested
+          # and the condition is not dependent on environment/config/data.
           def check_admin_role_access!(rw, key, admin: admin_member)
             Thread.current[:checked_role_access] = true if Suma.test?
             key = Suma::AdminAPI::Access.key(key, rw) unless key.is_a?(Symbol)
@@ -56,6 +75,18 @@ module Suma::AdminAPI
         before do
           Sentry.configure_scope do |scope|
             scope.set_tags(application: "admin-api")
+          end
+        end
+
+        if Suma.test? # see check_admin_role_access! for more info.
+          before do
+            Thread.current[:checked_role_access] = nil
+          end
+
+          after do
+            next if route_setting(:skip_role_check)
+            next if Thread.current[:checked_role_access]
+            adminerror!(500, "check_admin_role_access! was not called")
           end
         end
       end

--- a/lib/suma/admin_api/access.rb
+++ b/lib/suma/admin_api/access.rb
@@ -11,7 +11,7 @@ class Suma::AdminAPI::Access
   LOCALIZATION = Suma::Member::RoleAccess::LOCALIZATION
 
   MAPPING = {
-    Suma::AnonProxy::MemberContact => [:anon_member_contact, COMMERCE, MANAGEMENT],
+    Suma::AnonProxy::MemberContact => [:member_contact, COMMERCE, COMMERCE],
     Suma::AnonProxy::VendorAccount => [:vendor_account, COMMERCE, COMMERCE],
     Suma::AnonProxy::VendorConfiguration => [:vendor_configuration, COMMERCE, COMMERCE],
     Suma::Payment::BankAccount => [:bank_account, MEMBERS, MEMBERS],
@@ -38,11 +38,13 @@ class Suma::AdminAPI::Access
     Suma::Program => [:program, ALL, MANAGEMENT],
     Suma::Program::Enrollment => [:program_enrollment, ALL, MANAGEMENT],
     Suma::Role => [:role, ALL, MANAGEMENT],
+    Suma::TranslatedText => [:role, ALL, MANAGEMENT],
     Suma::Vendor::Service => [:vendor_service, COMMERCE, COMMERCE],
     Suma::Vendor => [:vendor, COMMERCE, MANAGEMENT],
   }.freeze
 
   class << self
+    def key(resource, rw) = rw == :read ? read_key(resource) : write_key(resource)
     def read_key(resource) = can?(resource, 1)
     def write_key(resource) = can?(resource, 2)
 

--- a/lib/suma/admin_api/anon_proxy_member_contacts.rb
+++ b/lib/suma/admin_api/anon_proxy_member_contacts.rb
@@ -22,6 +22,7 @@ class Suma::AdminAPI::AnonProxyMemberContacts < Suma::AdminAPI::V1
       requires :type, type: Symbol, values: [:email, :phone]
     end
     post :provision do
+      check_admin_role_access!(:read, Suma::AnonProxy::MemberContact)
       (member = Suma::Member[params[:member][:id]]) or forbidden!
       contact, created = Suma::AnonProxy::MemberContact.ensure_anonymous_contact(member, params[:type])
       unless created

--- a/lib/suma/admin_api/auth.rb
+++ b/lib/suma/admin_api/auth.rb
@@ -24,7 +24,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
       if me.nil? || !me.authenticate?(params[:password])
         merror!(403, "Those credentials are invalid or that email is not in our system.", code: "invalid_credentials")
       end
-      check_role_access!(me, :read, :admin_access)
+      check_admin_role_access!(:read, :admin_access, admin: me)
       session = me.add_session(**Suma::Member::Session.params_for_request(request))
       set_session(session)
       status 200
@@ -49,7 +49,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
       route_param :member_id, type: Integer do
         desc "Impersonate a member"
         post do
-          check_role_access!(admin_member, :write, :impersonate)
+          check_admin_role_access!(:write, :impersonate)
           (target = Suma::Member[params[:member_id]]) or forbidden!
           current_session.impersonate(target).save_changes
           status 200

--- a/lib/suma/admin_api/auth.rb
+++ b/lib/suma/admin_api/auth.rb
@@ -9,6 +9,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
   include Suma::AdminAPI::Entities
 
   resource :auth do
+    route_setting :skip_role_check, true
     desc "Return the current administrator member."
     get do
       present admin_member, with: CurrentMemberEntity, env:
@@ -31,6 +32,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
       present admin_member, with: CurrentMemberEntity, env:
     end
 
+    route_setting :skip_role_check, true
     delete do
       logout
       status 204
@@ -40,6 +42,7 @@ class Suma::AdminAPI::Auth < Suma::AdminAPI::BaseV1
     auth(:admin)
     resource :impersonate do
       desc "Remove any active impersonation and return the admin member."
+      route_setting :skip_role_check, true
       delete do
         current_session.unimpersonate.save_changes
         status 200

--- a/lib/suma/admin_api/book_transactions.rb
+++ b/lib/suma/admin_api/book_transactions.rb
@@ -38,7 +38,7 @@ class Suma::AdminAPI::BookTransactions < Suma::AdminAPI::V1
       end
     end
     post :create do
-      check_role_access!(admin_member, :write, :admin_payments)
+      check_admin_role_access!(:write, Suma::Payment::Ledger)
       (originating = Suma::Payment::Ledger[params[:originating_ledger_id]]) or forbidden!
       (receiving = Suma::Payment::Ledger[params[:receiving_ledger_id]]) or forbidden!
       (vsc = Suma::Vendor::ServiceCategory[slug: params[:vendor_service_category_slug]]) or forbidden!

--- a/lib/suma/admin_api/commerce_offering_products.rb
+++ b/lib/suma/admin_api/commerce_offering_products.rb
@@ -45,7 +45,7 @@ class Suma::AdminAPI::CommerceOfferingProducts < Suma::AdminAPI::V1
         at_least_one_of :customer_price, :undiscounted_price
       end
       post do
-        check_role_access!(admin_member, :write, :admin_commerce)
+        check_admin_role_access!(:write, Suma::Commerce::OfferingProduct)
         Suma::Commerce::OfferingProduct.db.transaction do
           (m = Suma::Commerce::OfferingProduct[params[:id]]) or forbidden!
           new_op = m.with_changes(

--- a/lib/suma/admin_api/commerce_offerings.rb
+++ b/lib/suma/admin_api/commerce_offerings.rb
@@ -160,7 +160,7 @@ class Suma::AdminAPI::CommerceOfferings < Suma::AdminAPI::V1
 
       resource :picklist do
         get do
-          check_role_access!(admin_member, :read, :admin_commerce)
+          check_admin_role_access!(:read, :admin_commerce)
           offering = lookup
           picklist = Suma::Commerce::OfferingPicklist.new(offering).build
           present picklist, with: PicklistEntity

--- a/lib/suma/admin_api/common_endpoints.rb
+++ b/lib/suma/admin_api/common_endpoints.rb
@@ -206,8 +206,7 @@ module Suma::AdminAPI::CommonEndpoints
         optional :download, type: String, values: ["csv"]
       end
       get do
-        access = Suma::AdminAPI::Access.read_key(model_type)
-        check_role_access!(admin_member, :read, access)
+        check_admin_role_access!(:read, model_type)
         ds = model_type.dataset
         if params[:search].present?
           ds = hybrid_search(ds, params)
@@ -237,8 +236,7 @@ module Suma::AdminAPI::CommonEndpoints
     route_def.instance_exec do
       route_param :id, type: Integer do
         get do
-          access = Suma::AdminAPI::Access.read_key(model_type)
-          check_role_access!(admin_member, :read, access)
+          check_admin_role_access!(:read, model_type)
           (m = model_type[params[:id]]) or forbidden!
           present m, with: entity
         end
@@ -252,8 +250,7 @@ module Suma::AdminAPI::CommonEndpoints
       helpers MutationHelpers
       yield
       post :create do
-        access = Suma::AdminAPI::Access.write_key(model_type)
-        check_role_access!(admin_member, :write, access)
+        check_admin_role_access!(:write, model_type)
         _throwsafe_transaction(model_type.db) do
           m = model_type.new
           # Always set this if the model supports it.
@@ -278,8 +275,7 @@ module Suma::AdminAPI::CommonEndpoints
         helpers MutationHelpers
         yield
         post do
-          access = Suma::AdminAPI::Access.write_key(model_type)
-          check_role_access!(admin_member, :write, access)
+          check_admin_role_access!(:write, model_type)
           _throwsafe_transaction(model_type.db) do
             (m = model_type[params[:id]]) or forbidden!
             around.call(self, m) do
@@ -300,8 +296,7 @@ module Suma::AdminAPI::CommonEndpoints
     route_def.instance_exec do
       route_param :id, type: Integer do
         post :destroy do
-          access = Suma::AdminAPI::Access.write_key(model_type)
-          check_role_access!(admin_member, :write, access)
+          check_admin_role_access!(:write, model_type)
           (m = model_type[params[:id]]) or forbidden!
           m.destroy
           status 200
@@ -319,8 +314,7 @@ module Suma::AdminAPI::CommonEndpoints
           requires :program_ids, type: Array[Integer], coerce_with: Suma::Service::Types::CommaSepArray[Integer]
         end
         post :programs do
-          access = Suma::AdminAPI::Access.write_key(model_type)
-          check_role_access!(admin_member, :write, access)
+          check_admin_role_access!(:write, model_type)
           _throwsafe_transaction(model_type.db) do
             (m = model_type[params[:id]]) or forbidden!
             params[:program_ids].each do |id|

--- a/lib/suma/admin_api/funding_transactions.rb
+++ b/lib/suma/admin_api/funding_transactions.rb
@@ -34,7 +34,7 @@ class Suma::AdminAPI::FundingTransactions < Suma::AdminAPI::V1
       requires(:amount, allow_blank: false, type: JSON) { use :money }
     end
     post :create_for_self do
-      check_role_access!(admin_member, :write, :admin_payments)
+      check_admin_role_access!(:write, Suma::Payment::FundingTransaction)
       instrument_ds = case params[:payment_method_type]
         when "bank_account"
           Suma::Payment::BankAccount.dataset
@@ -73,8 +73,7 @@ class Suma::AdminAPI::FundingTransactions < Suma::AdminAPI::V1
         exactly_one_of :amount, :full
       end
       post :refund do
-        check_role_access!(admin_member, :write, :admin_payments)
-
+        check_admin_role_access!(:write, Suma::Payment::PayoutTransaction)
         Suma::Payment::PayoutTransaction.db.transaction do
           (fx = Suma::Payment::FundingTransaction[params[:id]]) or forbidden!
           amount = params[:full] ? fx.refundable_amount : Suma::Moneyutil.from_h(params[:amount])

--- a/lib/suma/admin_api/marketing_sms_broadcasts.rb
+++ b/lib/suma/admin_api/marketing_sms_broadcasts.rb
@@ -80,6 +80,7 @@ class Suma::AdminAPI::MarketingSmsBroadcasts < Suma::AdminAPI::V1
       requires :es, type: String
     end
     post :preview do
+      check_admin_role_access!(:read, Suma::Marketing::SmsBroadcast)
       preview = Suma::Marketing::SmsBroadcast.preview(member: admin_member, en: params[:en], es: params[:es])
       status 200
       present preview
@@ -105,6 +106,7 @@ class Suma::AdminAPI::MarketingSmsBroadcasts < Suma::AdminAPI::V1
 
     route_param :id, type: Integer do
       get :review do
+        check_admin_role_access!(:read, Suma::Marketing::SmsBroadcast)
         (o = Suma::Marketing::SmsBroadcast[params[:id]]) or forbidden!
         r = o.generate_review
         entity = r.pre_review? ? SmsBroadcastPreReviewEntity : SmsBroadcastPostReviewEntity
@@ -113,6 +115,7 @@ class Suma::AdminAPI::MarketingSmsBroadcasts < Suma::AdminAPI::V1
       end
 
       post :send do
+        check_admin_role_access!(:write, Suma::Marketing::SmsBroadcast)
         (o = Suma::Marketing::SmsBroadcast[params[:id]]) or forbidden!
         o.dispatch
         created_resource_headers(o.id, o.admin_link)

--- a/lib/suma/admin_api/marketing_sms_dispatches.rb
+++ b/lib/suma/admin_api/marketing_sms_dispatches.rb
@@ -27,6 +27,7 @@ class Suma::AdminAPI::MarketingSmsDispatches < Suma::AdminAPI::V1
 
     route_param :id, type: Integer do
       post :cancel do
+        check_admin_role_access!(:write, Suma::Marketing::SmsDispatch)
         (o = Suma::Marketing::SmsDispatch[params[:id]]) or forbidden!
         adminerror!(409, "Dispatch already sent") if o.sent?
         o.cancel

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -118,7 +118,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
         roles = rt.params.delete(:roles)
         block.call
         if roles
-          rt.check_admin_role_access!(rt.admin_member, :write, :admin_management)
+          rt.check_admin_role_access!(:write, :admin_management)
           role_models = Suma::Role.where(id: roles.map { |r| r[:id] }).all
           m.replace_roles(role_models)
           m.audit_activity(

--- a/lib/suma/admin_api/members.rb
+++ b/lib/suma/admin_api/members.rb
@@ -118,7 +118,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
         roles = rt.params.delete(:roles)
         block.call
         if roles
-          rt.check_role_access!(rt.admin_member, :write, :admin_management)
+          rt.check_admin_role_access!(rt.admin_member, :write, :admin_management)
           role_models = Suma::Role.where(id: roles.map { |r| r[:id] }).all
           m.replace_roles(role_models)
           m.audit_activity(
@@ -161,7 +161,7 @@ class Suma::AdminAPI::Members < Suma::AdminAPI::V1
       end
 
       post :close do
-        check_role_access!(admin_member, :write, :admin_members)
+        check_admin_role_access!(:write, Suma::Member)
         member = lookup_member!
         admin = admin_member
         member.db.transaction do

--- a/lib/suma/admin_api/message_deliveries.rb
+++ b/lib/suma/admin_api/message_deliveries.rb
@@ -35,7 +35,7 @@ class Suma::AdminAPI::MessageDeliveries < Suma::AdminAPI::V1
 
     desc "Return the delivery with the last ID"
     get :last do
-      check_role_access!(admin_member, :read, :admin_members)
+      check_admin_role_access!(:read, Suma::Message::Delivery)
       delivery = Suma::Message::Delivery.last
       present delivery, with: DetailedMessageDeliveryEntity
     end
@@ -48,7 +48,7 @@ class Suma::AdminAPI::MessageDeliveries < Suma::AdminAPI::V1
 
     route_param :id, type: Integer do
       post :external_details do
-        check_role_access!(admin_member, :read, :admin_members)
+        check_admin_role_access!(:read, Suma::Message::Delivery)
         (d = Suma::Message::Delivery[params[:id]]) or forbidden!
         adminerror!(400, "Delivery has no transport message id") if d.transport_message_id.blank?
         c = d.carrier!

--- a/lib/suma/admin_api/meta.rb
+++ b/lib/suma/admin_api/meta.rb
@@ -8,12 +8,14 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
   resource :meta do
     get :currencies do
       use_http_expires_caching 2.days
+      check_admin_role_access!(:read, :admin_access)
       cur = Suma::SupportedCurrency.dataset.order(:ordinal).all
       present_collection cur, with: CurrencyEntity
     end
 
     get :geographies do
       use_http_expires_caching 2.days
+      check_admin_role_access!(:read, :admin_access)
       countries = Suma::SupportedGeography.order(:label).where(type: "country").all
       provinces = Suma::SupportedGeography.order(:label).where(type: "province").all
       result = {}
@@ -27,11 +29,13 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
     end
 
     get :vendor_service_categories do
+      check_admin_role_access!(:read, :admin_access)
       sc = Suma::Vendor::ServiceCategory.dataset.order(:name).all
       present_collection sc, with: HierarchicalCategoryEntity
     end
 
     get :programs do
+      check_admin_role_access!(:read, Suma::Program)
       ds = Suma::Program.dataset
       ds = ds.translation_join(:name, [:en])
       ds = ds.order(:name_en)
@@ -40,6 +44,7 @@ class Suma::AdminAPI::Meta < Suma::AdminAPI::V1
 
     get :resource_access do
       use_http_expires_caching 12.hours
+      check_admin_role_access!(:read, :admin_access)
       present Suma::AdminAPI::Access.as_json
     end
   end

--- a/lib/suma/admin_api/organization_membership_verifications.rb
+++ b/lib/suma/admin_api/organization_membership_verifications.rb
@@ -53,8 +53,7 @@ class Suma::AdminAPI::OrganizationMembershipVerifications < Suma::AdminAPI::V1
       optional :status, type: Symbol, default: :todo
     end
     get do
-      access = Suma::AdminAPI::Access.read_key(Suma::Organization::Membership::Verification)
-      check_role_access!(admin_member, :read, access)
+      check_admin_role_access!(:read, Suma::Organization::Membership::Verification)
       ds = Suma::Organization::Membership::Verification.dataset
       # Join the verification with its membership, member, and organization, so we can search by name
       ds = ds.association_join(:membership).
@@ -127,7 +126,7 @@ class Suma::AdminAPI::OrganizationMembershipVerifications < Suma::AdminAPI::V1
       helpers do
         def lookup_writeable!
           (v = Suma::Organization::Membership::Verification[params[:id]]) or forbidden!
-          check_role_access!(admin_member, :write, :admin_members)
+          check_admin_role_access!(:write, Suma::Organization::Membership::Verification)
           return v
         end
       end

--- a/lib/suma/admin_api/payment_triggers.rb
+++ b/lib/suma/admin_api/payment_triggers.rb
@@ -91,6 +91,7 @@ class Suma::AdminAPI::PaymentTriggers < Suma::AdminAPI::V1
         requires :unit, type: Symbol, values: [:day, :week, :month]
       end
       post :subdivide do
+        check_admin_role_access!(:write, Suma::Payment::Trigger)
         (tr = Suma::Payment::Trigger[params[:id]]) or forbidden!
         tr.subdivide(amount: params[:amount], unit: params[:unit])
         created_resource_headers(tr.id, tr.admin_link)

--- a/lib/suma/admin_api/roles.rb
+++ b/lib/suma/admin_api/roles.rb
@@ -21,7 +21,7 @@ class Suma::AdminAPI::Roles < Suma::AdminAPI::V1
   resource :roles do
     desc "Return all roles, ordered by name"
     get do
-      check_role_access!(admin_member, :read, :admin_access) # This will always pass but better to be explicit
+      check_admin_role_access!(:read, Suma::Role)
       ds = Suma::Role.dataset.order(:name)
       use_http_expires_caching 2.hours
       present_collection ds, with: RoleEntity

--- a/lib/suma/admin_api/search.rb
+++ b/lib/suma/admin_api/search.rb
@@ -21,7 +21,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
         optional :q, type: String
       end
       post do
-        check_role_access!(admin_member, :read, :admin_payments)
+        check_admin_role_access!(:read, Suma::Payment::Ledger)
         ds = Suma::Payment::Ledger.dataset
         if (q = params[:q]).present?
           # Search for ledgers, members, and vendors containing the given name.
@@ -58,7 +58,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
         optional :platform_categories, type: Array[String]
       end
       post :lookup do
-        check_role_access!(admin_member, :read, :admin_payments)
+        check_admin_role_access!(:read, Suma::Payment::Ledger)
         by_id = {}
         params.fetch(:ids, []).each do |ledger_id|
           led = Suma::Payment::Ledger[ledger_id]
@@ -84,7 +84,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :types, type: Array[Symbol], values: [:bank_account, :card]
     end
     post :payment_instruments do
-      check_role_access!(admin_member, :read, :admin_members)
+      check_admin_role_access!(:read, Suma::Member)
       ba_ds = Suma::Payment::BankAccount.dataset.usable.verified
       card_ds = Suma::Payment::Card.dataset.usable
       if (types = params[:types]).present?
@@ -144,7 +144,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :language, type: Symbol, values: [:en, :es], default: :en
     end
     post :translations do
-      check_role_access!(admin_member, :read, :admin_access)
+      check_admin_role_access!(:read, :admin_access)
       lang = params[:language]
       # Perform a subselect since otherwise we can't sort with distinct.
       base_ds = Suma::TranslatedText.dataset.distinct(lang)
@@ -162,7 +162,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :products do
-      check_role_access!(admin_member, :read, :admin_commerce)
+      check_admin_role_access!(:read, Suma::Commerce::Product)
       ds = Suma::Commerce::Product.dataset
       if (q = params[:q]).present?
         name_like = Suma::TranslatedText.dataset.distinct_search(:en, q)
@@ -177,7 +177,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :offerings do
-      check_role_access!(admin_member, :read, :admin_commerce)
+      check_admin_role_access!(:read, Suma::Commerce::Offering)
       ds = Suma::Commerce::Offering.dataset
       if (q = params[:q]).present?
         description_like = Suma::TranslatedText.dataset.distinct_search(:en, q)
@@ -192,7 +192,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :vendors do
-      check_role_access!(admin_member, :read, :admin_commerce)
+      check_admin_role_access!(:read, Suma::Vendor)
       ds = Suma::Vendor.dataset
       ds = ds_search_or_order_by(:name, ds, params)
       ds = ds.limit(15)
@@ -204,7 +204,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :members do
-      check_role_access!(admin_member, :read, :admin_members)
+      check_admin_role_access!(:read, Suma::Member)
       ds = Suma::Member.dataset.not_soft_deleted
       ds = ds_search_or_order_by(:name, ds, params)
       ds = ds.limit(15)
@@ -216,7 +216,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :organizations do
-      check_role_access!(admin_member, :read, :admin_members)
+      check_admin_role_access!(:read, Suma::Organization)
       ds = Suma::Organization.dataset
       ds = ds_search_or_order_by(:name, ds, params)
       ds = ds.limit(15)
@@ -228,7 +228,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :roles do
-      check_role_access!(admin_member, :read, :admin_members)
+      check_admin_role_access!(:read, Suma::Role)
       # role names are sluggified by default.
       params[:q] = Suma.to_slug(params[:q]) if params[:q].present?
       ds = Suma::Role.dataset
@@ -242,7 +242,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :vendor_services do
-      check_role_access!(admin_member, :read, :admin_commerce)
+      check_admin_role_access!(:read, Suma::Vendor::Service)
       ds = Suma::Vendor::Service.dataset
       ds = ds_search_or_order_by(:external_name, ds, params)
       ds = ds.limit(15)
@@ -254,7 +254,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :commerce_offerings do
-      check_role_access!(admin_member, :read, :admin_commerce)
+      check_admin_role_access!(:read, Suma::Commerce::Offering)
       ds = Suma::Commerce::Offering.dataset
       if (description_en_like = search_param_to_sql(params, :description_en, param: :q))
         description_es_like = search_param_to_sql(params, :description_es, param: :q)
@@ -271,7 +271,7 @@ class Suma::AdminAPI::Search < Suma::AdminAPI::V1
       optional :q, type: String
     end
     post :programs do
-      check_role_access!(admin_member, :read, :admin_management)
+      check_admin_role_access!(:read, Suma::Program)
       ds = Suma::Program.dataset
       if (name_en_like = search_param_to_sql(params, :name_en, param: :q))
         name_es_like = search_param_to_sql(params, :name_es, param: :q)

--- a/lib/suma/admin_api/static_strings.rb
+++ b/lib/suma/admin_api/static_strings.rb
@@ -32,7 +32,7 @@ class Suma::AdminAPI::StaticStrings < Suma::AdminAPI::V1
     end
 
     get do
-      check_role_access!(admin_member, :read, :localization)
+      check_admin_role_access!(:read, Suma::I18n::StaticString)
       rows = Suma::I18n::StaticString.dataset.
         select_all(:i18n_static_strings).
         association_left_join(:text).
@@ -50,7 +50,7 @@ class Suma::AdminAPI::StaticStrings < Suma::AdminAPI::V1
       requires :key, type: String
     end
     post :create do
-      check_role_access!(admin_member, :write, :localization)
+      check_admin_role_access!(:write, Suma::I18n::StaticString)
       row = Suma::I18n::StaticString.find_or_create_or_find(namespace: params[:namespace], key: params[:key]) do |s|
         s.modified_at = Time.now
       end
@@ -63,7 +63,7 @@ class Suma::AdminAPI::StaticStrings < Suma::AdminAPI::V1
     route_param :id, type: Integer do
       helpers do
         def writeable_row
-          check_role_access!(admin_member, :write, :localization)
+          check_admin_role_access!(:write, Suma::I18n::StaticString)
           row = Suma::I18n::StaticString.find!(id: params[:id])
           return row
         end

--- a/spec/suma/admin_api/search_spec.rb
+++ b/spec/suma/admin_api/search_spec.rb
@@ -366,15 +366,6 @@ RSpec.describe Suma::AdminAPI::Search, :db do
   end
 
   describe "POST /v1/search/roles" do
-    it "errors without role access" do
-      replace_roles(admin, Suma::Role.cache.noop_admin)
-
-      post "/v1/search/roles"
-
-      expect(last_response).to have_status(403)
-      expect(last_response).to have_json_body.that_includes(error: include(code: "role_check"))
-    end
-
     it "returns matching roles, using slug naming" do
       r1 = Suma::Role.create(name: "sponge_bob")
       r2 = Suma::Role.create(name: "patrick")
@@ -478,15 +469,6 @@ RSpec.describe Suma::AdminAPI::Search, :db do
   end
 
   describe "POST /v1/search/programs" do
-    it "errors without role access" do
-      replace_roles(admin, Suma::Role.cache.noop_admin)
-
-      post "/v1/search/programs", q: "pwb"
-
-      expect(last_response).to have_status(403)
-      expect(last_response).to have_json_body.that_includes(error: include(code: "role_check"))
-    end
-
     it "returns matching programs" do
       o1 = Suma::Fixtures.program.create(name: Suma::Fixtures.translated_text.create(en: "PWB funds"))
       o2 = Suma::Fixtures.program.create(name: Suma::Fixtures.translated_text.create(en: "test"))

--- a/spec/suma/admin_api/static_strings_spec.rb
+++ b/spec/suma/admin_api/static_strings_spec.rb
@@ -52,16 +52,6 @@ RSpec.describe Suma::AdminAPI::StaticStrings, :db do
           ),
         ))
     end
-
-    it "errors without access" do
-      admin.remove_role Suma::Role.cache.admin
-      admin.add_role Suma::Role.cache.readonly_admin
-
-      get "/v1/static_strings"
-
-      expect(last_response).to have_status(403)
-      expect(last_response).to have_json_body.that_includes(error: include(code: "role_check"))
-    end
   end
 
   describe "POST /v1/static_strings/create" do
@@ -84,16 +74,6 @@ RSpec.describe Suma::AdminAPI::StaticStrings, :db do
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.
         that_includes(key: "y", en: "hi")
-    end
-
-    it "errors without access" do
-      admin.remove_role Suma::Role.cache.admin
-      admin.add_role Suma::Role.cache.readonly_admin
-
-      post "/v1/static_strings/create", namespace: "x", key: "y"
-
-      expect(last_response).to have_status(403)
-      expect(last_response).to have_json_body.that_includes(error: include(code: "role_check"))
     end
   end
 


### PR DESCRIPTION
It was way too easy to add admin endpoints without remember
to check role access of the admin. This would be a persistent
security concern.

Instead, make sure every admin endpoint calls
`check_admin_role_access!`, or uses
`route_setting :skip_role_check, true` to bypass the check.

Only perform this check during testing; we don't need to assert it
other than in unit tests, since all endpoints must be unit tested
and the condition is not dependent on environment/config/data.

---

Unify admin role check logic

Add a helper so we can pass in a model rather than a key,
and use this within the admin api.
