### PR TITLE
Hide negative-ordinal organizations

### DIFF
--- a/adminapp/src/pages/OrganizationForm.jsx
+++ b/adminapp/src/pages/OrganizationForm.jsx
@@ -39,7 +39,10 @@ export default function OrganizationForm({
         <TextField
           {...register("ordinal")}
           label="Ordinal"
-          helperText="The order in which organizations are displayed in the member onboarding flow, higher first."
+          helperText="The order in which organizations are displayed in the member onboarding flow.
+          Decimals are ok.
+          Higher values appear before lower values.
+          Negative values will hide the organization."
           name="ordinal"
           value={resource.ordinal}
           type="number"

--- a/lib/suma/api/meta.rb
+++ b/lib/suma/api/meta.rb
@@ -56,8 +56,10 @@ class Suma::API::Meta < Suma::API::V1
 
     get :supported_organizations do
       use_http_expires_caching 30.minutes
-      ds = Suma::Organization.order(Sequel.desc(:ordinal), :name)
-      orgs = ds.select(:name).all.map { |o| {name: o.name} }
+      ds = Suma::Organization.
+        where { ordinal >= 0.0 }.
+        order(Sequel.desc(:ordinal), :name)
+      orgs = ds.select_map(:name).map { |name| {name:} }
       present_collection orgs
     end
 

--- a/spec/suma/api/meta_spec.rb
+++ b/spec/suma/api/meta_spec.rb
@@ -141,6 +141,20 @@ RSpec.describe Suma::API::Meta, :db do
         ],
       )
     end
+
+    it "excludes organizations with a negative ordinal" do
+      Suma::Fixtures.organization.create(name: "ord-1", ordinal: -1)
+      Suma::Fixtures.organization.create(name: "ord1", ordinal: 1)
+
+      get "/v1/meta/supported_organizations"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        items: [
+          {name: "ord1"},
+        ],
+      )
+    end
   end
 
   describe "GET /v1/meta/static_strings/<locale>/<namespace>", :static_strings do


### PR DESCRIPTION
There is now way to hide an organization
as a supported organization during member signup.

If an organization has a negative ordinal, hide it from /meta/supported_organizations.

This is used to support test organizations.