### PR TITLE
Enrollment removal: Deleted members; unexpected Lime auth 200s

### DIFF
--- a/lib/suma/anon_proxy/auth_to_vendor/lime.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lime.rb
@@ -43,6 +43,8 @@ class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
       },
       logger: self.vendor_account.logger,
     )
+    # Not sure why yet but we can get 200s without a token when making many requests.
+    raise Suma::Http::Error, resp unless resp.parsed_response.key?("token")
     return resp.parsed_response.fetch("token")
   end
 

--- a/lib/suma/lyft/pass.rb
+++ b/lib/suma/lyft/pass.rb
@@ -405,14 +405,17 @@ class Suma::Lyft::Pass
     )
   end
 
-  def revoke_member(member, program_id:)
-    self.logger.info "revoking_lyft_pass", member_id: member.id, lyft_program_id: program_id, phone: member.phone
+  # Revoke the member's access to Lyft Pass.
+  # @param [String] phone If given, use this as the phone instead of member.phone.
+  #   Useful when a member is deleted and its current phone is a placeholder.
+  def revoke_member(member, program_id:, phone: member.phone)
+    self.logger.info "revoking_lyft_pass", member_id: member.id, lyft_program_id: program_id, phone:
     Suma::Http.post(
       "https://www.lyft.com/api/rideprograms/enrollment/revoke",
       {
         ride_program_id: program_id,
         user_identifier: {
-          phone_number: Suma::PhoneNumber.format_e164(member.phone),
+          phone_number: Suma::PhoneNumber.format_e164(phone),
         },
       },
       headers: self.auth_headers,

--- a/lib/suma/program/enrollment.rb
+++ b/lib/suma/program/enrollment.rb
@@ -113,6 +113,15 @@ class Suma::Program::Enrollment < Suma::Postgres::Model(:program_enrollments)
     return :pending
   end
 
+  # Return the unique enrolled members for this enrollment.
+  # Look them up through direct membership, organization, and roles.
+  def members
+    return [self.member] if self.member
+    return self.organization.memberships.map(&:member) if self.organization
+    result = self.role.members + self.role.organizations.flat_map(&:memberships).map(&:member)
+    return result.uniq
+  end
+
   def rel_admin_link = "/program-enrollment/#{self.id}"
 
   def hybrid_search_fields

--- a/lib/suma/program/enrollment_remover.rb
+++ b/lib/suma/program/enrollment_remover.rb
@@ -90,7 +90,9 @@ class Suma::Program::EnrollmentRemover
     lp = Suma::Lyft::Pass.from_config
     lp.authenticate
     registrations.each do |r|
-      lp.revoke_member(r.account.member, program_id: r.external_program_id)
+      member = r.account.member
+      phone = member.soft_deleted? ? member.previous_phones.first : member.phone
+      lp.revoke_member(r.account.member, program_id: r.external_program_id, phone:) if phone
       r.destroy
     end
   end

--- a/spec/suma/anon_proxy/auth_to_vendor_spec.rb
+++ b/spec/suma/anon_proxy/auth_to_vendor_spec.rb
@@ -87,6 +87,16 @@ RSpec.describe Suma::AnonProxy::AuthToVendor, :db do
         expect(req).to have_been_made
         expect(token).to eq("ey123.ey456.789")
       end
+
+      it "raises an HTTP error if the response does not include a 'token' key" do
+        req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
+          to_return(json_response({}))
+
+        expect do
+          va.auth_to_vendor.exchange_magic_link_token("mytoken")
+        end.to raise_error(/HttpError\(status: 200/)
+        expect(req).to have_been_made
+      end
     end
 
     describe "log_out" do

--- a/spec/suma/program/enrollment_spec.rb
+++ b/spec/suma/program/enrollment_spec.rb
@@ -132,4 +132,39 @@ RSpec.describe "Suma::Program::Enrollment", :db do
       enrollment_status: :unenrolled,
     )
   end
+
+  describe "members" do
+    it "returns a directly enrolled member" do
+      m = Suma::Fixtures.member.create
+      e = Suma::Fixtures.program_enrollment.create(member: m)
+      expect(e.members).to contain_exactly(m)
+    end
+
+    it "returns organization memberships" do
+      om1 = Suma::Fixtures.organization_membership.verified.create
+      om2 = Suma::Fixtures.organization_membership.create(verified_organization: om1.verified_organization)
+      e = Suma::Fixtures.program_enrollment.create(organization: om1.verified_organization)
+      expect(e.members).to contain_exactly(om1.member, om2.member)
+    end
+
+    it "returns role members, and members of role organizations" do
+      role = Suma::Fixtures.role.create
+      om = Suma::Fixtures.organization_membership.verified.create
+      role.add_organization(om.verified_organization)
+      m = Suma::Fixtures.member.create
+      role.add_member(m)
+      e = Suma::Fixtures.program_enrollment.create(role:)
+      expect(e.members).to contain_exactly(om.member, m)
+    end
+
+    it "returns unique members" do
+      role = Suma::Fixtures.role.create
+      m = Suma::Fixtures.member.create
+      role.add_member(m)
+      om = Suma::Fixtures.organization_membership.verified.create(member: m)
+      role.add_organization(om.verified_organization)
+      e = Suma::Fixtures.program_enrollment.create(role:)
+      expect(e.members).to contain_exactly(m)
+    end
+  end
 end


### PR DESCRIPTION
Lime AuthToVendor: Error for non-token responses

No idea why yet but we can get 200 responses without a token.
Raise Http::Error when this happens.

---

Enrollment removal: Lyft handles deleted members

If a member is deleted, we error trying to revoke their lyft pass.
This fixes that bug by revoking the most recent previous phone
if the member is deleted.

Note that we do NOT process unenrollments when a member is
soft deleted. This was pretty confusing to set up,
and I'm not totally sure we want it yet,
so we will only still remove someone
when they're unenrolled
(we may want to remove all enrollments when someone is soft deleted).

---

Add Program::Enrollment#members

Use it to get all unique members for an enrollment/program.
