### PR TITLE
Lime unenroll ignore auth terms responses

### DIFF
--- a/lib/suma/anon_proxy/auth_to_vendor/lime.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lime.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require "suma/http"
+
 class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
+  class NoToken < Suma::Http::Error; end
+
   AGREEMENT_PARAMS = {user_agreement_version: "5", user_agreement_country_code: "US"}.freeze
   USER_AGENT = "Android Lime/3.219.0; (com.limebike; build:3.219.0; Android 33) 4.12.0"
   APP_VERSION = "3.219.0"
@@ -44,7 +48,7 @@ class Suma::AnonProxy::AuthToVendor::Lime < Suma::AnonProxy::AuthToVendor
       logger: self.vendor_account.logger,
     )
     # Not sure why yet but we can get 200s without a token when making many requests.
-    raise Suma::Http::Error, resp unless resp.parsed_response.key?("token")
+    raise NoToken, resp unless resp.parsed_response.key?("token")
     return resp.parsed_response.fetch("token")
   end
 

--- a/lib/suma/anon_proxy/message_handler/lime.rb
+++ b/lib/suma/anon_proxy/message_handler/lime.rb
@@ -37,7 +37,13 @@ class Suma::AnonProxy::MessageHandler::Lime < Suma::AnonProxy::MessageHandler
     if vendor_account.pending_closure
       lime_atv = Suma::AnonProxy::AuthToVendor::Lime.new(vendor_account)
       # This will log the user out of their own device, which is good enough.
-      lime_atv.exchange_magic_link_token(token)
+      begin
+        lime_atv.exchange_magic_link_token(token)
+      rescue Suma::AnonProxy::AuthToVendor::Lime::NoToken
+        # If when we log in, we're served with a user agreement rather than an auth token,
+        # that is good enough (we think).
+        nil
+      end
       vendor_account.update(pending_closure: false)
     else
       link_to_use = Suma::UrlShortener.enabled? ? Suma::UrlShortener.shortener.shorten(magic_link).url : magic_link

--- a/spec/data/lime/app_post_sign_terms.json
+++ b/spec/data/lime/app_post_sign_terms.json
@@ -1,0 +1,31 @@
+{
+  "user_agreement": {
+    "id": "views::useragreementview",
+    "type": "user_agreement_view",
+    "attributes": {
+      "user_agreement_url": "https://www.li.me/user-agreement",
+      "user_agreement_country_code": "US",
+      "user_agreement_version": 6,
+      "user_agreement_v2": {
+        "id": "views::useragreementview",
+        "type": "user_agreement_view",
+        "attributes": {
+          "title": "Please agree before proceeding",
+          "body": null,
+          "show_checkbox": true,
+          "checkbox_text": "\u003cfont style='font-size:13px' face='Montserrat'\u003eI confirm that I agree to Lime's \u003ca href='https://www.li.me/user-agreement' style='color:#05C500;text-decoration:none;'\u003eUser Agreement\u003c/a\u003e, and I acknowledge that I have read Lime's \u003ca href='https://www.li.me/legal/privacy-policy' style='color:#05C500;text-decoration:none;'\u003ePrivacy Notice\u003c/a\u003e.\u003c/font\u003e"
+        }
+      }
+    }
+  },
+  "user_agreement_v2": {
+    "id": "views::useragreementview",
+    "type": "user_agreement_view",
+    "attributes": {
+      "title": "Please agree before proceeding",
+      "body": null,
+      "show_checkbox": true,
+      "checkbox_text": "\u003cfont style='font-size:13px' face='Montserrat'\u003eI confirm that I agree to Lime's \u003ca href='https://www.li.me/user-agreement' style='color:#05C500;text-decoration:none;'\u003eUser Agreement\u003c/a\u003e, and I acknowledge that I have read Lime's \u003ca href='https://www.li.me/legal/privacy-policy' style='color:#05C500;text-decoration:none;'\u003ePrivacy Notice\u003c/a\u003e.\u003c/font\u003e"
+    }
+  }
+}

--- a/spec/suma/anon_proxy/auth_to_vendor_spec.rb
+++ b/spec/suma/anon_proxy/auth_to_vendor_spec.rb
@@ -88,13 +88,13 @@ RSpec.describe Suma::AnonProxy::AuthToVendor, :db do
         expect(token).to eq("ey123.ey456.789")
       end
 
-      it "raises an HTTP error if the response does not include a 'token' key" do
+      it "raises an error if the response does not include a 'token' key" do
         req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
           to_return(json_response({}))
 
         expect do
           va.auth_to_vendor.exchange_magic_link_token("mytoken")
-        end.to raise_error(/HttpError\(status: 200/)
+        end.to raise_error(Suma::AnonProxy::AuthToVendor::Lime::NoToken, /HttpError\(status: 200/)
         expect(req).to have_been_made
       end
     end

--- a/spec/suma/anon_proxy/message_handler_spec.rb
+++ b/spec/suma/anon_proxy/message_handler_spec.rb
@@ -193,25 +193,43 @@ RSpec.describe Suma::AnonProxy::MessageHandler, :db do
       expect(vendor_account.contact.member.message_deliveries).to be_empty
     end
 
-    it "logs in the user if the vendor account has a pending closure" do
-      vendor_account.update(pending_closure: true)
-      req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
-        with(
-          body: {
-            "has_virtual_card" => "false",
-            "magic_link_token" => "M1ZgpMepjL5kW9XgzCmnsBKQ",
-            "user_agreement_country_code" => "US", "user_agreement_version" => "5",
-          },
-        ).to_return(fixture_response("lime/app_post_magic_link"))
+    describe "when the vendor account has a pending closure" do
+      before(:each) do
+        vendor_account.update(pending_closure: true)
+      end
 
-      got = Suma::AnonProxy::MessageHandler.handle(
-        Suma::AnonProxy::Relay.create!("fake-email-relay"),
-        signin_message,
-      )
+      it "logs in the user if the vendor account has a pending closure" do
+        req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
+          with(
+            body: {
+              "has_virtual_card" => "false",
+              "magic_link_token" => "M1ZgpMepjL5kW9XgzCmnsBKQ",
+              "user_agreement_country_code" => "US", "user_agreement_version" => "5",
+            },
+          ).to_return(fixture_response("lime/app_post_magic_link"))
 
-      expect(req).to have_been_made
-      expect(got).to have_attributes(vendor_account:, outbound_delivery: nil)
-      expect(vendor_account.refresh).to have_attributes(latest_access_code: nil, pending_closure: false)
+        got = Suma::AnonProxy::MessageHandler.handle(
+          Suma::AnonProxy::Relay.create!("fake-email-relay"),
+          signin_message,
+        )
+
+        expect(req).to have_been_made
+        expect(got).to have_attributes(vendor_account:, outbound_delivery: nil)
+        expect(vendor_account.refresh).to have_attributes(latest_access_code: nil, pending_closure: false)
+      end
+
+      it "ignores NoToken errors" do
+        req = stub_request(:post, "https://web-production.lime.bike/api/rider/v2/onboarding/login").
+          to_return(fixture_response("lime/app_post_sign_terms"))
+
+        Suma::AnonProxy::MessageHandler.handle(
+          Suma::AnonProxy::Relay.create!("fake-email-relay"),
+          signin_message,
+        )
+
+        expect(req).to have_been_made
+        expect(vendor_account.refresh).to have_attributes(pending_closure: false)
+      end
     end
   end
 end


### PR DESCRIPTION
We could get a 200 while closing a user's lime account, that instead of a token is a 'view terms' screen.

Ignore these errors, we hope it's fine.