### PR TITLE
Run async indexing after transaction commit; skip symbol-only lines

### DIFF
--- a/lib/sequel/plugins/hybrid_search.rb
+++ b/lib/sequel/plugins/hybrid_search.rb
@@ -241,9 +241,13 @@ module Sequel::Plugins::HybridSearch
       content = [self.model.table_name.to_s.gsub(/[^a-zA-Z]/, " ")]
       text.lines.each do |li|
         idx = li.index(":")
-        next nil if idx.nil?
+        next if idx.nil?
         s = li[(idx + 1)..].strip
         next if s.blank?
+        # Ignore symbol-only lines. See https://www.ascii-code.com/ for a table;
+        # " -/" catches all everything from codes 32 to 47, for example.
+        # Rubocop has a bug here, %r{} regex form cannot be used due to the backtick, so turn it off.
+        next if s.match?(/^[ -\/:-@\[-`{-~]+$/) # rubocop:disable Style/RegexpLiteral
         content << s
       end
       return content.join("\n")

--- a/spec/sequel/plugins/hybrid_searchable_spec.rb
+++ b/spec/sequel/plugins/hybrid_searchable_spec.rb
@@ -214,11 +214,13 @@ RSpec.describe "sequel-hybrid-searchable" do
 
     it "sets the search content to just values after a colon, and exclues symbol-only lines" do
       geralt = model.create(name: "Geralt")
-      expect(geralt.refresh).to have_attributes(search_content: match(/^svs tester\n\d+\nGeralt$/))
+      expect(geralt.refresh).to have_attributes(search_content: match(/\Asvs tester\n\d+\nGeralt\Z/))
       geralt.update(desc: "of Rivia")
-      expect(geralt.refresh).to have_attributes(search_content: match(/^svs tester\n\d+\nGeralt\nof Rivia$/))
+      expect(geralt.refresh).to have_attributes(search_content: match(/\Asvs tester\n\d+\nGeralt\nof Rivia\Z/))
       geralt.update(desc: "[]")
-      expect(geralt.refresh).to have_attributes(search_content: match(/^svs tester\n\d+\nGeralt$/))
+      expect(geralt.refresh).to have_attributes(search_content: match(/\Asvs tester\n\d+\nGeralt\Z/))
+      geralt.update(desc: "😀")
+      expect(geralt.refresh).to have_attributes(search_content: match(/\Asvs tester\n\d+\nGeralt\n😀\Z/))
     end
 
     it "can load and overwrite a legacy hash" do


### PR DESCRIPTION
Run async indexing after transaction commit

Another source of race condition is that the reindexing
was happening immediately as part of the update,
NOT waiting until the transaction that spawned it
had committed. This caused reindexing to see old data.

Instead, run indexing after the transaction commits.

---

Do not write symbol-only lines as search content

We had stuff like '[]' in search content.
Exclude lines that are symbol-only ASCII characters.