### PR TITLE
Fix duplicate role error during enrollment removal; refactor shared role code

### DIFF
--- a/lib/sequel/plugins/many_to_many_ensurer.rb
+++ b/lib/sequel/plugins/many_to_many_ensurer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "sequel"
+
+module Sequel::Plugins::ManyToManyEnsurer
+  DEFAULT_OPTIONS = {
+    singular: nil,
+  }.freeze
+  def self.configure(model, association, opts={})
+    opts = DEFAULT_OPTIONS.merge(opts)
+    singular = opts[:singular] || association.to_s.singularize
+    assoc = model.association_reflections.fetch(association)
+    assoc_cls = nil
+    model.instance_eval do
+      define_method(:"ensure_#{singular}") do |arg|
+        assoc_cls ||= Kernel.const_get(assoc.fetch(:class_name))
+        many = arg.is_a?(assoc_cls) ? arg : assoc_cls.find!(arg)
+        raise "No #{assoc_cls} for #{arg}" if model.nil?
+        self.send(assoc.fetch(:add_method), many) if
+          self.send(assoc.fetch(:dataset_method)).where(assoc_cls.qualified_primary_key_hash(many.pk)).empty?
+      end
+    end
+  end
+end

--- a/lib/sequel/plugins/many_to_many_pubsub.rb
+++ b/lib/sequel/plugins/many_to_many_pubsub.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "sequel"
+
+module Sequel::Plugins::ManyToManyPubsub
+  DEFAULT_OPTIONS = {
+    singular: nil,
+    publish: ->(name, receiver, many) { receiver.publish_deferred(name, receiver.pk, many.pk) },
+  }.freeze
+  def self.configure(model, association, opts={})
+    opts = DEFAULT_OPTIONS.merge(opts)
+    singular = opts[:singular] || association.to_s.singularize
+    publish = opts[:publish]
+    model.many_to_many(
+      association,
+      after_add: lambda do |receiver, many|
+        publish.call("#{singular}.added", receiver, many)
+      end,
+      after_remove: lambda do |receiver, many|
+        publish.call("#{singular}.removed", receiver, many)
+      end,
+      **opts,
+    )
+  end
+end

--- a/lib/suma/async/enrollment_removal_runner.rb
+++ b/lib/suma/async/enrollment_removal_runner.rb
@@ -48,7 +48,7 @@ class Suma::Async::EnrollmentRemovalRunner
         role = self.lookup_model(Suma::Role, event.payload[1])
         removers = [
           Suma::Program::EnrollmentRemover.new(member).reenroll do
-            member.add_role(role)
+            member.ensure_role(role)
           end,
         ]
       when "suma.organization.role.removed"
@@ -56,7 +56,7 @@ class Suma::Async::EnrollmentRemovalRunner
         role = self.lookup_model(Suma::Role, event.payload[1])
         removers = organization.memberships.map do |m|
           Suma::Program::EnrollmentRemover.new(m.member).reenroll do
-            organization.add_role(role)
+            organization.ensure_role(role)
           end
         end
       else

--- a/lib/suma/organization.rb
+++ b/lib/suma/organization.rb
@@ -24,12 +24,12 @@ class Suma::Organization < Suma::Postgres::Model(:organizations)
               key: :former_organization_id,
               order: order_desc
   one_to_many :program_enrollments, class: "Suma::Program::Enrollment", order: order_desc
-  many_to_many :roles,
-               class: "Suma::Role",
-               join_table: :roles_organizations,
-               order: order_assoc(:asc, :name),
-               **Suma::Role.association_options
-
+  plugin :many_to_many_pubsub,
+         :roles,
+         class: "Suma::Role",
+         join_table: :roles_organizations,
+         order: order_assoc(:asc, :name)
+  plugin :many_to_many_ensurer, :roles
   plugin :association_array_replacer, :roles
 
   def rel_admin_link = "/organization/#{self.id}"

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -15,6 +15,13 @@ module Suma::Postgres
 
   class InTransaction < StandardError; end
 
+  class NoMatchingRow < Sequel::NoMatchingRow
+    def initialize(ds)
+      super(ds.sql)
+      self.dataset = ds
+    end
+  end
+
   singleton_attr_accessor :unsafe_skip_transaction_check
   @unsafe_skip_transaction_check = false
   def self.check_transaction(db, error_msg)

--- a/lib/suma/role.rb
+++ b/lib/suma/role.rb
@@ -50,17 +50,6 @@ class Suma::Role < Suma::Postgres::Model(:roles)
     # Return a cache of roles lookups.
     # Generally callers should use +Suma::Member::RoleAccess+ rather than look at roles directly.
     def cache = @cache ||= Cache.new
-
-    def association_options
-      return {
-        after_add: lambda do |receiver, role|
-          receiver.publish_deferred("role.added", receiver.pk, role.pk)
-        end,
-        after_remove: lambda do |receiver, role|
-          receiver.publish_deferred("role.removed", receiver.pk, role.pk)
-        end,
-      }
-    end
   end
 
   many_to_many :members,

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -59,16 +59,25 @@ RSpec.describe "Suma::Member", :db do
     end
 
     it "can set a role by the role name" do
-      member.ensure_role(role.name)
+      member.ensure_role(name: role.name)
+      expect(member.roles).to contain_exactly(role)
+    end
+
+    it "can set a role by the role id" do
+      member.ensure_role(role.id)
       expect(member.roles).to contain_exactly(role)
     end
 
     it "noops if the member already has the role" do
-      member.ensure_role(role.name)
-      member.ensure_role(role.name)
+      member.ensure_role(name: role.name)
+      member.ensure_role(name: role.name)
       member.ensure_role(role)
       member.ensure_role(role)
       expect(member.roles).to contain_exactly(role)
+    end
+
+    it "errors if the role does not exist" do
+      expect { member.ensure_role(0) }.to raise_error(Sequel::NoMatchingRow)
     end
   end
 


### PR DESCRIPTION
Enrollment Remover: noop if role was re-added

If the enrollment remover runs and tries to add the removed role,
but the role has been re-added (let's say it was removed/added
inside of a transaction, so both events were sent),
a unique constraint violation is raised.

Instead, use `ensure_role`.

---

Refactor role pubsub info something reusable

Add :many_to_many_pubsub plugin for defining associations
that have pubsub support.

Also move the 'ensure_role' method there;
this is sort of unrelated but it can move into its own plugin
in the future, for running an adder conditionally on
a m2m association.

Now members and organizations have ensure_role.