### PR TITLE
Better localization of Stripe API errors

### DIFF
--- a/spec/suma/api/meta_spec.rb
+++ b/spec/suma/api/meta_spec.rb
@@ -157,6 +157,18 @@ RSpec.describe Suma::API::Meta, :db do
     end
   end
 
+  describe "GET /v1/meta/static_strings/<locale>/stripe", :static_strings do
+    it "returns stripe error codes and their localized messages" do
+      Suma::Fixtures.static_string.text("hi").create(namespace: "strings", key: "errors.card_invalid_zip")
+      Suma::I18n::StaticStringRebuilder.instance.rebuild_outdated
+
+      get "/v1/meta/static_strings/en/stripe"
+
+      expect(last_response).to have_status(200)
+      expect(last_response_json_body).to eq({errors: {incorrect_zip: ["s", "hi"]}})
+    end
+  end
+
   describe "GET /v1/meta/static_strings/<locale>/<namespace>", :static_strings do
     it "returns the static string file from the database" do
       Suma::Fixtures.static_string.text("hi").create(namespace: "forms", key: "s1")

--- a/webapp/src/localization/i18n.js
+++ b/webapp/src/localization/i18n.js
@@ -81,7 +81,7 @@ class I18n {
         // (cache is empty until first file is loaded).
         console.log(
           `localization key '${fqn}' not found, static string must be added`,
-          this.cache
+          JSON.stringify(this.cache)
         );
         console.trace();
         withSentry((sentry) => {

--- a/webapp/src/state/useStripeErrorMessage.jsx
+++ b/webapp/src/state/useStripeErrorMessage.jsx
@@ -1,0 +1,54 @@
+import { Lookup } from "../localization/index.jsx";
+import useI18n from "../localization/useI18n.jsx";
+import useMountEffect from "../shared/react/useMountEffect.jsx";
+import get from "lodash/get.js";
+import React from "react";
+
+/**
+ * Given a Stripe error response, return a localized message.
+ * - If the data doesn't look like a Stripe error, return null
+ *   so the caller can handle it differently.
+ * - Get the /static_strings/<locale>/stripe endpoint response.
+ *   This internally maps static strings
+ *   like {key: "errors.card_invalid_cvc", en: "Bad CVC"}
+ *   to stripe error codes like "incorrect_cvc",
+ *   and returns i18n-compatible strings, like:
+ *   {incorrect_cvc: "Bad CVC"}.
+ * - Lookup the Stripe error code ("incorrect_cvc") in the Stripe namespace
+ *   and return the localized text ("Bad CVC").
+ * - If the code is unmapped, log a normal missing localization error,
+ *   but use data.error.message instead of the localization key.
+ *   This is a nicer fallback.
+ * @returns {{localizeStripeError: ((function(*): void)|*)}}
+ */
+export default function useStripeErrorMessage() {
+  const { loadLanguageFileUnsafe } = useI18n();
+  const [loaded, setLoaded] = React.useState(false);
+
+  useMountEffect(() =>
+    loadLanguageFileUnsafe("stripe")
+      .then(() => setLoaded(true))
+      .catch(() => null)
+  );
+
+  const localizeStripeError = React.useCallback(
+    (data) => {
+      if (!get(data, "error.type")) {
+        return null;
+      } else if (!loaded) {
+        // Use the default message if our namespace isn't loaded.
+        return data.error.message;
+      }
+      const key = `errors.${data.error.code}`;
+      const localized = stripeTextLookup.t(key);
+      if (localized.endsWith(key)) {
+        return data.error.message;
+      }
+      return localized;
+    },
+    [loaded]
+  );
+  return { localizeStripeError };
+}
+
+const stripeTextLookup = new Lookup("stripe");


### PR DESCRIPTION
We localize Stripe errors from our backend, but we don't handle frontend calls to api.stripe.com properly
(just the call to get a card token).

Add a new 'stripe' static string namespace endpoint which returns the static error strings which are used as localized messages for Stripe error codes.

Then those error messages can be used by the frontend using the stripe error code (like 'incorrect_cvc'), not our i18n code ('card_invalid_cvc').

Also add 'loadLanguageFileUnsafe' so we can handle failures when loading the language file.