### PR TITLE
Create Front convos for Lime violations

### DIFF
--- a/lib/amigo/advisory_locked.rb
+++ b/lib/amigo/advisory_locked.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "sequel/advisory_lock"
+
+# Allows jobs to operate with an advisory lock,
+# and retry or give up if the lock is taken.
+# Register the +ServerMiddleware+,
+# and pass :advisory_lock to +sidekiq_options+ to activate.
+#
+# Supported options:
+#
+# - +:db+: Required. Connect to this +Sequel::Database+. Can also be a callable that returns the database.
+# - +:key+: Advisory lock bigint key. By default, hash the class name.
+# - +:backoff+: If the advisory lock is taken, when to retry again. Default to 1 minute. Use nil to not retry.
+module Amigo::AdvisoryLocked
+  def self.string_to_int64(s)
+    # "q>" grabs the first 8 bytes (of a digest/hash- for example MD5 is 128 bits, or 16 bytes)
+    # as a signed 64 bit integer. The first 8 bytes is enough entropy.
+    return Digest::MD5.digest(s).unpack1("q>")
+  end
+
+  def self.advisory_lock_options(cls)
+    opts = cls.get_sidekiq_options.fetch("advisory_lock", nil)
+    return nil if opts.nil?
+    if (db = opts["db"]) && !db.is_a?(Sequel::Database)
+      opts["db"] = db.call
+    end
+    opts["key"] ||= Amigo::AdvisoryLocked.string_to_int64(cls.name)
+    opts["backoff"] = 1.minutes unless opts.key?("backoff")
+    return opts
+  end
+
+  def self.advisory_lock(worker, db: nil)
+    opts = Amigo::AdvisoryLocked.advisory_lock_options(worker)
+    return nil if opts.nil?
+    return Sequel::AdvisoryLock.new(db || opts.fetch("db"), opts.fetch("key"))
+  end
+
+  class ServerMiddleware
+    def call(worker, job, _queue, &)
+      alock = Amigo::AdvisoryLocked.advisory_lock(worker.class)
+      return yield if alock.nil?
+      performed, _ = alock.with_lock?(&)
+      return if performed
+      backoff = Amigo::AdvisoryLocked.advisory_lock_options(worker.class).fetch("backoff")
+      worker.class.perform_in(backoff, *job.fetch("args")) if backoff
+    end
+  end
+end

--- a/lib/sequel/advisory_lock.rb
+++ b/lib/sequel/advisory_lock.rb
@@ -3,6 +3,18 @@
 require "sequel"
 
 class Sequel::AdvisoryLock
+  class << self
+    def parts_to_key(key1, key2)
+      return ((key2.to_i & 0xFFFFFFFF) << 32) | (key1.to_i & 0xFFFFFFFF)
+    end
+
+    def key_to_parts(n)
+      low  = n & 0xFFFFFFFF
+      high = (n >> 32) & 0xFFFFFFFF
+      return [low, high]
+    end
+  end
+
   def initialize(db, key_or_key1, key2=nil, shared: false, xact: false)
     @db = db
     xstr = xact ? "_xact" : ""

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "amigo"
+require "amigo/advisory_locked"
 require "appydays/configurable"
 require "appydays/loggable"
 require "sentry-sidekiq"
@@ -34,6 +35,7 @@ module Suma::Async
     "suma/async/gbfs_sync_enqueue",
     "suma/async/gbfs_sync_run",
     "suma/async/hybrid_search_reindex",
+    "suma/async/lime_violations_processor",
     "suma/async/lyft_pass_trip_sync",
     "suma/async/marketing_list_sync",
     "suma/async/marketing_sms_broadcast_dispatch",
@@ -70,6 +72,7 @@ module Suma::Async
       end
       config.server_middleware do |chain|
         chain.add(SidekiqUniqueJobs::Middleware::Server)
+        chain.add(Amigo::AdvisoryLocked::ServerMiddleware)
       end
 
       SidekiqUniqueJobs::Server.configure(config)

--- a/lib/suma/async/lime_violations_processor.rb
+++ b/lib/suma/async/lime_violations_processor.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "amigo/scheduled_job"
+require "amigo/advisory_locked"
+require "suma/async"
+require "suma/lime/handle_violations"
+
+class Suma::Async::LimeViolationsProcessor
+  extend Amigo::ScheduledJob
+
+  sidekiq_options(
+    Suma::Async.cron_job_options.merge(advisory_lock: {db: Suma::Member.db}),
+  )
+  cron "41 * * * * *"
+  splay 30.seconds
+
+  def _perform
+    Suma::Lime::HandleViolations.new.run
+  end
+end

--- a/lib/suma/frontapp.rb
+++ b/lib/suma/frontapp.rb
@@ -52,6 +52,7 @@ module Suma::Frontapp
   configurable(:frontapp) do
     setting :auth_token, UNCONFIGURED_AUTH_TOKEN
     setting :list_sync_enabled, false
+    setting :default_inbox_id, "inb_123"
 
     after_configured do
       self.client = Frontapp::Client.new(auth_token: self.auth_token, user_agent: Suma::Http.user_agent)
@@ -62,6 +63,12 @@ end
 module Frontapp::Client::Channels
   def create_draft!(channel_id, params={})
     create("channels/#{channel_id}/drafts", params)
+  end
+end
+
+module Frontapp::Client::Conversations
+  def create_conversation(params={})
+    create("conversations", params)
   end
 end
 

--- a/lib/suma/frontapp.rb
+++ b/lib/suma/frontapp.rb
@@ -60,6 +60,16 @@ module Suma::Frontapp
   end
 end
 
+class Frontapp::Client
+  def create(path, body)
+    body_key = HTTP::FormData.send(:multipart?, body) ? :form : :json
+    res = @headers.post("#{base_url}#{path}", body_key => body)
+    response = JSON.parse(res.to_s)
+    raise Frontapp::Error.from_response(res) unless res.status.success?
+    response
+  end
+end
+
 module Frontapp::Client::Channels
   def create_draft!(channel_id, params={})
     create("channels/#{channel_id}/drafts", params)

--- a/lib/suma/lime/handle_violations.rb
+++ b/lib/suma/lime/handle_violations.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Suma::Lime::HandleViolations
+  LAST_SYNCED_PK_KEY = "lime/handleviolations/pk"
+  CUTOFF = 2.weeks
+
+  def run
+    last_synced_pk = Suma::Redis.cache.with { |c| c.call("GET", LAST_SYNCED_PK_KEY) }.to_i
+    rows = Suma::Webhookdb.postmark_inbound_messages_dataset.
+      where(from_email: ["support@limebike.com", "no-reply@li.me"]).
+      where(Sequel.ilike(:subject, "%Service Violation Notification%") | Sequel.ilike(:subject, "%Parking violation%")).
+      where { pk > last_synced_pk }.
+      where { timestamp > CUTOFF.ago }.
+      order(:pk).
+      all
+    return 0 if rows.empty?
+    rows.each do |row|
+      member = Suma::AnonProxy::MemberContact[email: row.fetch(:to_email)]&.member
+      html_body = row.fetch(:data).fetch("HtmlBody")
+      body_lines = [
+        "Anonymous email: #{row.fetch(:to_email)}",
+        member && "Member #{member.id}: #{member.name}, #{member.us_phone}",
+        member&.admin_link,
+        "Originally sent by Lime: #{row.fetch(:timestamp).iso8601}",
+        "\n",
+        row.fetch(:data).fetch("TextBody"),
+      ].compact
+
+      Suma::Frontapp.client.create_conversation(
+        type: "discussion",
+        inbox_id: Suma::Frontapp.to_inbox_id(Suma::Frontapp.default_inbox_id),
+        subject: row.fetch(:subject),
+        comment: {
+          body: body_lines.join("\n"),
+          attachments: ["data:text/html;name=limewarning.html;base64,#{Base64.strict_encode64(html_body)}"],
+        },
+      )
+    end
+    Suma::Redis.cache.with { |c| c.call("SET", LAST_SYNCED_PK_KEY, rows.last.fetch(:pk).to_s) }
+    return rows.size
+  end
+end

--- a/lib/suma/lime/handle_violations.rb
+++ b/lib/suma/lime/handle_violations.rb
@@ -30,10 +30,10 @@ class Suma::Lime::HandleViolations
         type: "discussion",
         inbox_id: Suma::Frontapp.to_inbox_id(Suma::Frontapp.default_inbox_id),
         subject: row.fetch(:subject),
-        comment: {
-          body: body_lines.join("\n"),
-          attachments: ["data:text/html;name=limewarning.html;base64,#{Base64.strict_encode64(html_body)}"],
-        },
+        "comment[body]" => body_lines.join("\n"),
+        "attachments[0]" => HTTP::FormData::Part.new(
+          html_body, content_type: "text/html", filename: "limewarning.html",
+        ),
       )
     end
     Suma::Redis.cache.with { |c| c.call("SET", LAST_SYNCED_PK_KEY, rows.last.fetch(:pk).to_s) }

--- a/spec/amigo/advisory_locked_spec.rb
+++ b/spec/amigo/advisory_locked_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "amigo/advisory_locked"
+
+RSpec.describe Amigo::AdvisoryLocked do
+  def connectdb(&) = Sequel.connect(ENV.fetch("DATABASE_URL"), &)
+
+  before(:all) do
+    @oldmode = Sidekiq::Testing.__test_mode
+    Sidekiq::Testing.disable!
+    @db = connectdb
+  end
+
+  after(:all) do
+    Sidekiq::Testing.__set_test_mode(@oldmode)
+    @db.disconnect
+  end
+
+  before(:each) do
+    Sidekiq.redis(&:flushdb)
+    Sidekiq.default_configuration.server_middleware.add(described_class::ServerMiddleware)
+  end
+
+  after(:each) do
+    Sidekiq.default_configuration.server_middleware.remove(described_class::ServerMiddleware)
+    Sidekiq.redis(&:flushdb)
+  end
+
+  let(:db) { @db }
+
+  define_method(:job_cls) do |cb: nil, db: @db, **opts|
+    cls = Class.new do
+      include Sidekiq::Job
+
+      def self.to_s = "Amigo::AdvisoryLocked::TestClass"
+      def self.runs = @runs ||= []
+
+      sidekiq_options(advisory_lock: {db:}.merge(**opts))
+
+      attr_accessor :runs
+
+      define_method :perform do |*args|
+        self.class.runs ||= []
+        self.class.runs << args
+        cb&.call
+      end
+    end
+    stub_const(cls.to_s, cls)
+    cls
+  end
+
+  it "runs the job" do
+    cls = job_cls
+    cls.perform_async
+    cls.perform_async(1)
+    drain_sidekiq_jobs(Sidekiq::Queue.new)
+    expect(cls.runs).to eq([[1], []])
+  end
+
+  it "schedules for the future if the lock is taken and backoff is not set" do
+    cls = job_cls
+    expect(cls).to receive(:perform_in).with(60)
+    cls.perform_async
+    connectdb do |db|
+      described_class.advisory_lock(cls, db:).with_lock do
+        drain_sidekiq_jobs(Sidekiq::Queue.new)
+      end
+    end
+    expect(cls.runs).to eq([])
+  end
+
+  it "does not reschedule if the lock is taken and backoff is nil" do
+    cls = job_cls(backoff: nil)
+    expect(cls).to_not receive(:perform_in)
+    cls.perform_async
+    connectdb do |db|
+      described_class.advisory_lock(cls, db:).with_lock do
+        drain_sidekiq_jobs(Sidekiq::Queue.new)
+      end
+    end
+    expect(cls.runs).to eq([])
+  end
+
+  it "uses the given backoff if not set" do
+    cls = job_cls(backoff: 5)
+    expect(cls).to receive(:perform_in).with(5)
+    cls.perform_async
+    connectdb do |db|
+      described_class.advisory_lock(cls, db:).with_lock do
+        drain_sidekiq_jobs(Sidekiq::Queue.new)
+      end
+    end
+    expect(cls.runs).to eq([])
+  end
+
+  it "will invoke a callable to get the database" do
+    cls = job_cls(db: -> { raise ClosedQueueError })
+    cls.perform_async
+    expect { drain_sidekiq_jobs(Sidekiq::Queue.new) }.to raise_error(ClosedQueueError)
+  end
+
+  it "hashes the class name as the key" do
+    low, high = Sequel::AdvisoryLock.key_to_parts(Amigo::AdvisoryLocked.string_to_int64(job_cls.to_s))
+    cls = job_cls(
+      cb: -> { expect(@db[:pg_locks].where(objid: low, classid: high).all).to have_attributes(length: 1) },
+    )
+    cls.perform_async
+    drain_sidekiq_jobs(Sidekiq::Queue.new)
+    expect(cls.runs).to eq([[]])
+  end
+
+  it "will use the given key rather than the hashed class name" do
+    cls = job_cls(
+      key: 123_789,
+      cb: -> { expect(@db[:pg_locks].where(objid: 123_789, classid: 0).all).to have_attributes(length: 1) },
+    )
+    cls.perform_async
+    drain_sidekiq_jobs(Sidekiq::Queue.new)
+    expect(cls.runs).to eq([[]])
+  end
+end

--- a/spec/sequel/advisory_lock_spec.rb
+++ b/spec/sequel/advisory_lock_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Sequel::AdvisoryLock do
 
   let(:db) { @db }
 
+  it "can convert a bigint key to and from int parts" do
+    parts = described_class.key_to_parts(87_000_123_654)
+    expect(parts).to eq([1_100_777_734, 20])
+    expect(described_class.parts_to_key(*parts)).to eq(87_000_123_654)
+  end
+
   it "can lock with a Long key" do
     lock = described_class.new(db, 6_000_123_654)
     expect(lock.dataset(this: true).all).to be_empty

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -729,32 +729,19 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
       member = Suma::Fixtures.member.create(name: "Joleen Klocko", phone: "12375589839")
       mc = Suma::Fixtures.anon_proxy_member_contact.email("test@example.com").create(member:)
 
-      reqs = [
-        stub_request(:post, "https://api2.frontapp.com/conversations").
-          with(
-            body: {
-              type: "discussion",
-              inbox_id: "inb_123",
-              subject: "Service Violation Notification",
-              comment: {
-                body: "Anonymous email: test@example.com\nMember #{member.id}: Joleen Klocko, (237) 558-9839\nhttp://localhost:22014/member/#{member.id}\nOriginally sent by Lime: 2025-08-27T23:13:09+00:00\n\n\ntxtbody",
-                attachments: ["data:text/html;name=limewarning.html;base64,aHRtbGJvZHk="],
-              },
-            }.to_json,
-          ).to_return(json_response({})),
-        stub_request(:post, "https://api2.frontapp.com/conversations").
-          with(
-            body: {
-              type: "discussion",
-              inbox_id: "inb_123",
-              subject: "Parking violation",
-              comment: {
-                body: "Anonymous email: nonexist@in.mysuma.org\nOriginally sent by Lime: 2025-08-27T23:13:09+00:00\n\n\ntxtbody",
-                attachments: ["data:text/html;name=limewarning.html;base64,aHRtbGJvZHk="],
-              },
-            }.to_json,
-          ).to_return(json_response({})),
-      ]
+      req = stub_request(:post, "https://api2.frontapp.com/conversations").
+        with do |req|
+        expect(req.body).to include("Content-Disposition: form-data; name=\"type\"\r\n\r\ndiscussion")
+        expect(req.body).to include("name=\"inbox_id\"\r\n\r\ninb_123")
+        if req.body.include?("Service Violation")
+          expect(req.body).to include("name=\"subject\"\r\n\r\nService Violation Notification")
+          expect(req.body).to include("name=\"comment[body]\"\r\n\r\nAnonymous email: test@example.com\nMember #{member.id}: Joleen Klocko, (237) 558-9839\nhttp://localhost:22014/member/#{member.id}\nOriginally sent by Lime: 2025-08-27T23:13:09+00:00\n\n\ntxtbody")
+        else
+          expect(req.body).to include("name=\"subject\"\r\n\r\nParking violation")
+          expect(req.body).to include("name=\"comment[body]\"\r\n\r\nAnonymous email: nonexist@in.mysuma.org\nOriginally sent by Lime: 2025-08-27T23:13:09+00:00\n\n\ntxtbody")
+        end
+        expect(req.body).to include("name=\"attachments[0]\"; filename=\"limewarning.html\"\r\nContent-Type: text/html\r\n\r\nhtmlbody")
+      end.to_return(json_response({}), json_response({}))
 
       Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
         message_id: "valid-to-email",
@@ -790,7 +777,7 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
       )
 
       Suma::Async::LimeViolationsProcessor.new.perform(true)
-      expect(reqs).to all(have_been_made)
+      expect(req).to have_been_made.times(2)
 
       # Ensure we keep track of what's been synced
       Suma::Async::LimeViolationsProcessor.new.perform(true)

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -714,6 +714,91 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
     end
   end
 
+  describe "LimeViolationsProcessor" do
+    # rubocop:disable Layout/LineLength
+
+    before(:each) do
+      Suma::Webhookdb.postmark_inbound_messages_dataset.delete
+      Suma::Redis.cache.with do |c|
+        c.call("DEL", Suma::Lime::HandleViolations::LAST_SYNCED_PK_KEY)
+      end
+    end
+
+    it "creates Front discussion conversations for violation messages" do
+      now = Time.parse("2025-08-27T23:13:09+00:00")
+      member = Suma::Fixtures.member.create(name: "Joleen Klocko", phone: "12375589839")
+      mc = Suma::Fixtures.anon_proxy_member_contact.email("test@example.com").create(member:)
+
+      reqs = [
+        stub_request(:post, "https://api2.frontapp.com/conversations").
+          with(
+            body: {
+              type: "discussion",
+              inbox_id: "inb_123",
+              subject: "Service Violation Notification",
+              comment: {
+                body: "Anonymous email: test@example.com\nMember #{member.id}: Joleen Klocko, (237) 558-9839\nhttp://localhost:22014/member/#{member.id}\nOriginally sent by Lime: 2025-08-27T23:13:09+00:00\n\n\ntxtbody",
+                attachments: ["data:text/html;name=limewarning.html;base64,aHRtbGJvZHk="],
+              },
+            }.to_json,
+          ).to_return(json_response({})),
+        stub_request(:post, "https://api2.frontapp.com/conversations").
+          with(
+            body: {
+              type: "discussion",
+              inbox_id: "inb_123",
+              subject: "Parking violation",
+              comment: {
+                body: "Anonymous email: nonexist@in.mysuma.org\nOriginally sent by Lime: 2025-08-27T23:13:09+00:00\n\n\ntxtbody",
+                attachments: ["data:text/html;name=limewarning.html;base64,aHRtbGJvZHk="],
+              },
+            }.to_json,
+          ).to_return(json_response({})),
+      ]
+
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "valid-to-email",
+        from_email: "support@limebike.com",
+        to_email: mc.email,
+        subject: "Service Violation Notification",
+        timestamp: now,
+        data: Sequel.pg_jsonb({"HtmlBody" => "htmlbody", "TextBody" => "txtbody"}),
+      )
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "invalid-to-email",
+        from_email: "no-reply@li.me",
+        to_email: "nonexist@in.mysuma.org",
+        subject: "Parking violation",
+        timestamp: now,
+        data: Sequel.pg_jsonb({"HtmlBody" => "htmlbody", "TextBody" => "txtbody"}),
+      )
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "old",
+        from_email: "no-reply@li.me",
+        to_email: "nonexist@in.mysuma.org",
+        subject: "Parking violation",
+        timestamp: now - 4.weeks,
+        data: Sequel.pg_jsonb({}),
+      )
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "bad-subject",
+        from_email: "no-reply@li.me",
+        to_email: "nonexist@in.mysuma.org",
+        subject: "Not an expected subject",
+        timestamp: now,
+        data: Sequel.pg_jsonb({}),
+      )
+
+      Suma::Async::LimeViolationsProcessor.new.perform(true)
+      expect(reqs).to all(have_been_made)
+
+      # Ensure we keep track of what's been synced
+      Suma::Async::LimeViolationsProcessor.new.perform(true)
+    end
+
+    # rubocop:enable Layout/LineLength
+  end
+
   describe "OfferingScheduleFulfillment" do
     it "on create, enqueues a processing job at the fulfillment time" do
       o = Suma::Fixtures.offering.timed_fulfillment.create
@@ -786,16 +871,6 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
       # Ensure we keep track of what's been synced
       Suma::Async::ProcessAnonProxyInboundWebhookdbRelays.new.perform(true)
       expect(Suma::AnonProxy::MessageHandler::Fake.handled).to have_length(1)
-    end
-
-    it "reschedules for the future if the advisory lock is taken" do
-      expect(Suma::Async::ProcessAnonProxyInboundWebhookdbRelays).to receive(:perform_in)
-      j = Suma::Async::ProcessAnonProxyInboundWebhookdbRelays.new
-      Sequel.connect(Suma::Postgres::Model.uri) do |db|
-        j.advisory_lock(db:).with_lock do
-          j.perform(true)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Lime is sending us violation emails about parking
or rider behavior.

We can eventually respond to these automatically,
so for now, create Front discussion conversations
when we find violation emails from Lime.

---

Add Amigo advisory lock middleware

Add :advisory_lock as a sidekiq option,
which will run a job with an advisory lock to ensure it is unique.