### PR TITLE
Create mobility trips from Lime email receipts

### DIFF
--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -35,6 +35,7 @@ module Suma::Async
     "suma/async/gbfs_sync_enqueue",
     "suma/async/gbfs_sync_run",
     "suma/async/hybrid_search_reindex",
+    "suma/async/lime_trip_sync",
     "suma/async/lime_violations_processor",
     "suma/async/lyft_pass_trip_sync",
     "suma/async/marketing_list_sync",

--- a/lib/suma/async/lime_trip_sync.rb
+++ b/lib/suma/async/lime_trip_sync.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "amigo/scheduled_job"
+require "suma/lime/sync_trips_from_email"
+
+class Suma::Async::LimeTripSync
+  extend Amigo::ScheduledJob
+
+  sidekiq_options(Suma::Async.cron_job_options)
+  cron "*/30 * * * *"
+  splay 5.seconds
+
+  def _perform
+    Suma::Lime::SyncTripsFromEmail.new.run
+  end
+end

--- a/lib/suma/lime/sync_trips_from_email.rb
+++ b/lib/suma/lime/sync_trips_from_email.rb
@@ -57,7 +57,7 @@ class Suma::Lime::SyncTripsFromEmail
           external_trip_id: receipt.ride_id,
         )
       rescue Sequel::UniqueConstraintViolation
-        self.logger.debug("ride_already_exists", ride_id:)
+        self.logger.debug("ride_already_exists", ride_id: receipt.ride_id)
         raise Sequel::Rollback
       end
 

--- a/lib/suma/lime/sync_trips_from_email.rb
+++ b/lib/suma/lime/sync_trips_from_email.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# For all Lime trips we have receipt emails from,
+# create mobility trips for them.
+# Lime receipt emails are pretty bare, but we do our best!
+class Suma::Lime::SyncTripsFromEmail
+  include Appydays::Loggable
+
+  DEFAULT_VEHICLE_TYPE = Suma::Mobility::ESCOOTER
+  CUTOFF = 2.weeks
+
+  def row_iterator = Suma::Webhookdb::RowIterator.new("lime/synctrips/pk")
+
+  def run
+    ds = self.dataset
+    self.row_iterator.each(ds) do |row|
+      if Suma::AnonProxy::VendorAccountRegistration.where(external_program_id: row.fetch(:to_email)).empty?
+        self.logger.warn("lime_receipt_missing_member",
+                         member_contact_email: row.fetch(:to_email),
+                         webhookdb_row_pk: row.fetch(:pk),)
+        next
+      end
+      ride_id = row.fetch(:message_id)
+      return nil unless Suma::Mobility::Trip.where(external_trip_id: ride_id).empty?
+      self.create_trip_from_row(row)
+    end
+  end
+
+  def dataset
+    ds = Suma::Webhookdb.postmark_inbound_messages_dataset.
+      where(from_email: ["no-reply@li.me"]).
+      where(subject: "Receipt for your Lime ride").
+      where { timestamp > CUTOFF.ago }
+    return ds
+  end
+
+  def create_trip_from_row(row)
+    registration = Suma::AnonProxy::VendorAccountRegistration.find!(external_program_id: row.fetch(:to_email))
+    vendor_config = registration.account.configuration
+    program = Suma::Enumerable.one!(vendor_config.programs)
+    pricing = Suma::Enumerable.one!(program.pricings)
+    receipt = self.parse_row_to_receipt(row)
+    registration.db.transaction(savepoint: true) do
+      begin
+        trip = Suma::Mobility::Trip.start_trip(
+          member: registration.account.member,
+          vehicle_id: receipt.ride_id,
+          vehicle_type: receipt.vehicle_type,
+          vendor_service: pricing.vendor_service,
+          rate: pricing.vendor_service_rate,
+          lat: 0,
+          lng: 0,
+          at: receipt.started_at,
+          ended_at: receipt.ended_at,
+          end_lat: 0,
+          end_lng: 0,
+          external_trip_id: receipt.ride_id,
+        )
+      rescue Sequel::UniqueConstraintViolation
+        self.logger.debug("ride_already_exists", ride_id:)
+        raise Sequel::Rollback
+      end
+
+      charge = trip.end_trip(lat: 0, lng: 0, adapter_kw: {receipt:})
+      receipt[:line_items].each do |li|
+        charge.add_off_platform_line_item(
+          amount: li[:amount],
+          memo: Suma::TranslatedText.create(all: li[:memo]),
+        )
+      end
+    end
+  end
+
+  LINE_ITEM_HEADINGS = ["Start Fee", "Discount"].freeze
+
+  def parse_row_to_receipt(row)
+    r = Suma::Mobility::VendorAdapter::LimeDeeplink::RideReceipt.new(
+      vehicle_type: DEFAULT_VEHICLE_TYPE,
+      ride_id: row.fetch(:message_id),
+      ended_at: row.fetch(:timestamp) - 1.minute,
+      line_items: [],
+    )
+    lines = row.fetch(:data).fetch("TextBody").lines.reject(&:blank?).map(&:strip)
+    i = 0
+    while i < lines.length
+      line = lines[i]
+      if LINE_ITEM_HEADINGS.include?(line)
+        r.line_items << {memo: line, amount: Monetize.parse(lines[i + 1])}
+        i += 1
+      elsif line.start_with?("Riding -")
+        r.line_items << {memo: line, amount: Monetize.parse(lines[i + 1])}
+        minutes = line[/\((\d+) min\)/, 1].to_i
+        r.started_at = r.ended_at - (minutes * 60)
+        i += 1
+      elsif line == "Total"
+        total = lines[i + 1] == "FREE" ? Money.new(0) : Monetize.parse(lines[i + 1])
+        r.total = total
+      end
+      i += 1
+    end
+    return r
+  end
+end

--- a/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
+++ b/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
@@ -14,4 +14,26 @@ class Suma::Mobility::VendorAdapter::LimeDeeplink
     account = Suma::AnonProxy::VendorAccount.where(configuration:, member:)
     return account.first
   end
+
+  def begin_trip(_trip)
+    return Suma::Mobility::VendorAdapter::BeginTripResult.new
+  end
+
+  class RideReceipt < Suma::TypedStruct
+    attr_accessor :ride_id,
+                  :vehicle_type,
+                  :started_at,
+                  :ended_at,
+                  :total,
+                  :line_items
+  end
+
+  def end_trip(_trip, receipt:)
+    return Suma::Mobility::VendorAdapter::EndTripResult.new(
+      cost_cents: receipt.total.cents,
+      cost_currency: receipt.total.currency,
+      end_time: receipt.ended_at,
+      duration_minutes: ((receipt.ended_at - receipt.started_at) / 60.0).to_i,
+    )
+  end
 end

--- a/spec/suma/lime/sync_trips_from_email_spec.rb
+++ b/spec/suma/lime/sync_trips_from_email_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require "suma/lime/sync_trips_from_email"
+
+RSpec.describe Suma::Lime::SyncTripsFromEmail, :db do
+  let(:program) do
+    Suma::Fixtures.program.create(
+      vendor: Suma::Lime.deeplink_vendor,
+    )
+  end
+  before(:each) do
+    Suma::Webhookdb.postmark_inbound_messages_dataset.delete
+    described_class.new.row_iterator.reset
+  end
+
+  describe "run" do
+    let(:text_body) do
+      <<~TXT
+        Start Fee
+        $0.50
+        Riding - $0.07/min (76 min)
+        $5.32
+        Discount
+        -$5.82
+        Subtotal
+        $0.00
+        Total
+        FREE
+      TXT
+    end
+
+    it "creates trips from receipt emails" do
+      member = Suma::Fixtures.member.onboarding_verified.with_cash_ledger.create
+      va = Suma::Fixtures.anon_proxy_vendor_account.create(member:)
+      mc = Suma::Fixtures.anon_proxy_member_contact.email.create(member:)
+      va.add_registration(external_program_id: mc.email)
+      program = Suma::Fixtures.program.with_pricing(
+        vendor_service: Suma::Fixtures.vendor_service.
+          mobility.
+          create(charge_after_fulfillment: true, mobility_vendor_adapter_key: "lime_deeplink"),
+        vendor_service_rate: Suma::Fixtures.vendor_service_rate.create,
+      ).create
+      va.configuration.add_program(program)
+
+      now = Time.parse("2024-07-15T12:00:00Z")
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "valid",
+        from_email: "no-reply@li.me",
+        to_email: mc.email,
+        subject: "Receipt for your Lime ride",
+        timestamp: now,
+        data: Sequel.pg_jsonb({"TextBody" => text_body}),
+      )
+      Timecop.freeze(now) do
+        described_class.new.run
+      end
+
+      expect(Suma::Mobility::Trip.all).to contain_exactly(
+        have_attributes(
+          vehicle_id: "valid",
+          vendor_service: be === program.pricings.first.vendor_service,
+          begin_lat: 0.0,
+          begin_lng: 0.0,
+          began_at: match_time("2024-07-15T10:43:00Z"),
+          end_lat: 0.0,
+          end_lng: 0.0,
+          ended_at: match_time("2024-07-15T11:59:00Z"),
+          vendor_service_rate: be === program.pricings.first.vendor_service_rate,
+          member: be === member,
+          external_trip_id: "valid",
+          vehicle_type: "escooter",
+        ),
+      )
+    end
+
+    it "noops if no program registration with the email exists" do
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "valid",
+        from_email: "no-reply@li.me",
+        to_email: "m1@in.mysuma.org",
+        subject: "Receipt for your Lime ride",
+        timestamp: Time.now,
+        data: "{}",
+      )
+      described_class.new.run
+
+      expect(Suma::Mobility::Trip.all).to be_empty
+    end
+
+    it "errors if there is not only 1 program for the configuration, so we cannot figure out which one to use" do
+      member = Suma::Fixtures.member.onboarding_verified.with_cash_ledger.create
+      va = Suma::Fixtures.anon_proxy_vendor_account.create(member:)
+      mc = Suma::Fixtures.anon_proxy_member_contact.email.create(member:)
+      va.add_registration(external_program_id: mc.email)
+      va.configuration.add_program(Suma::Fixtures.program.create)
+      va.configuration.add_program(Suma::Fixtures.program.create)
+
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "valid",
+        from_email: "no-reply@li.me",
+        to_email: mc.email,
+        subject: "Receipt for your Lime ride",
+        timestamp: Time.now,
+        data: "{}",
+      )
+      expect do
+        described_class.new.run
+      end.to raise_error(/have exactly 1 item/)
+    end
+
+    it "errors if the associated program does not have pricing" do
+      member = Suma::Fixtures.member.onboarding_verified.with_cash_ledger.create
+      va = Suma::Fixtures.anon_proxy_vendor_account.create(member:)
+      mc = Suma::Fixtures.anon_proxy_member_contact.email.create(member:)
+      va.add_registration(external_program_id: mc.email)
+      program = Suma::Fixtures.program.create
+      va.configuration.add_program(program)
+
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "valid",
+        from_email: "no-reply@li.me",
+        to_email: mc.email,
+        subject: "Receipt for your Lime ride",
+        timestamp: Time.now,
+        data: Sequel.pg_jsonb({"TextBody" => text_body}),
+      )
+
+      expect do
+        described_class.new.run
+      end.to raise_error(ArgumentError, /must have exactly 1 item/)
+    end
+
+    it "does not create duplicate trips" do
+      member = Suma::Fixtures.member.onboarding_verified.with_cash_ledger.create
+      va = Suma::Fixtures.anon_proxy_vendor_account.create(member:)
+      mc = Suma::Fixtures.anon_proxy_member_contact.email.create(member:)
+      va.add_registration(external_program_id: mc.email)
+      program = Suma::Fixtures.program.with_pricing(
+        vendor_service: Suma::Fixtures.vendor_service.
+          mobility.
+          create(charge_after_fulfillment: true, mobility_vendor_adapter_key: "lime_deeplink"),
+        vendor_service_rate: Suma::Fixtures.vendor_service_rate.create,
+      ).create
+      va.configuration.add_program(program)
+
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "valid",
+        from_email: "no-reply@li.me",
+        to_email: mc.email,
+        subject: "Receipt for your Lime ride",
+        timestamp: Time.now,
+        data: Sequel.pg_jsonb({"TextBody" => text_body}),
+      )
+      described_class.new.run
+      described_class.new.row_iterator.reset
+      described_class.new.run
+
+      expect(Suma::Mobility::Trip.all).to have_length(1)
+    end
+  end
+
+  describe "dataset" do
+    it "ignores messages that are not receipts or are old" do
+      now = Time.now
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "valid",
+        from_email: "no-reply@li.me",
+        subject: "Receipt for your Lime ride",
+        timestamp: now,
+        data: "{}",
+      )
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "bad-subject",
+        from_email: "no-reply@li.me",
+        subject: "Something else",
+        timestamp: now,
+        data: "{}",
+      )
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "bad-from",
+        from_email: "support@lime.com",
+        subject: "Receipt for your Lime ride",
+        timestamp: now,
+        data: "{}",
+      )
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        message_id: "old",
+        from_email: "no-reply@li.me",
+        subject: "Receipt for your Lime ride",
+        timestamp: now - 4.weeks,
+        data: "{}",
+      )
+      expect(described_class.new.dataset.select_map(&:message_id)).to contain_exactly("valid")
+    end
+  end
+
+  describe "parse_row_to_receipt" do
+    it "parses the row" do
+      txt = <<~TXT
+        Thank you for riding with Lime.
+
+        Summary
+        Date of Issue: Aug 23, 2025
+
+
+        Start Fee
+        $0.50
+
+
+        Riding - $0.07/min (76 min)
+        $5.32
+
+
+        Discount
+        -$5.82
+
+
+        Subtotal
+        $0.00
+
+
+        Total
+
+        FREE
+      TXT
+      row = {message_id: "xyz", timestamp: Time.parse("2024-07-15T12:00:00Z"), data: {"TextBody" => txt}}
+      receipt = described_class.new.parse_row_to_receipt(row)
+      expect(receipt).to have_attributes(
+        ride_id: "xyz",
+        started_at: Time.parse("2024-07-15T10:43:00Z"),
+        ended_at: Time.parse("2024-07-15T11:59:00Z"),
+        total: cost("$0"),
+        line_items: [
+          {amount: cost("$0.50"), memo: "Start Fee"},
+          {amount: cost("$5.32"), memo: "Riding - $0.07/min (76 min)"},
+          {amount: cost("-$5.82"), memo: "Discount"},
+        ],
+      )
+    end
+
+    it "can parse non-free rides" do
+      txt = <<~TXT
+        Thank you for riding with Lime.
+
+        Summary
+        Date of Issue: Aug 23, 2025
+
+
+        Start Fee
+        $0.50
+
+
+        Riding - $0.07/min (76 min)
+        $5.32
+
+
+        Discount
+        -$4.62
+
+
+        Subtotal
+        $1.20
+
+
+        Total
+
+        $1.20
+      TXT
+      row = {message_id: "xyz", timestamp: Time.parse("2024-07-15T12:00:00Z"), data: {"TextBody" => txt}}
+      receipt = described_class.new.parse_row_to_receipt(row)
+      expect(receipt).to have_attributes(
+        total: cost("$1.20"),
+      )
+    end
+  end
+end

--- a/spec/suma/lime/sync_trips_from_email_spec.rb
+++ b/spec/suma/lime/sync_trips_from_email_spec.rb
@@ -3,11 +3,6 @@
 require "suma/lime/sync_trips_from_email"
 
 RSpec.describe Suma::Lime::SyncTripsFromEmail, :db do
-  let(:program) do
-    Suma::Fixtures.program.create(
-      vendor: Suma::Lime.deeplink_vendor,
-    )
-  end
   before(:each) do
     Suma::Webhookdb.postmark_inbound_messages_dataset.delete
     described_class.new.row_iterator.reset
@@ -141,7 +136,8 @@ RSpec.describe Suma::Lime::SyncTripsFromEmail, :db do
       described_class.new.run
       described_class.new.row_iterator.reset
       described_class.new.run
-
+      expect(Suma::Mobility::Trip).to receive(:where).and_return([])
+      described_class.new.run
       expect(Suma::Mobility::Trip.all).to have_length(1)
     end
 


### PR DESCRIPTION
Add an async job to automatically create Lime trips from receipt emails.

We will do work related to the actual charging as per #862 in future PRs. This puts it on par with Lyft Pass at least, where we can create suma trips for free 3rd party trips.