### PR TITLE
Better admin search (trigram/fuzzy support); retry on web app timeouts; retry faster if loc file hangs

### DIFF
--- a/db/migrations/088_trigram_search.rb
+++ b/db/migrations/088_trigram_search.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "sequel/unambiguous_constraint"
+
+Sequel.migration do
+  tables = [
+    :anon_proxy_member_contacts,
+    :anon_proxy_vendor_accounts,
+    :programs,
+    :anon_proxy_vendor_configurations,
+    :charges,
+    :commerce_offerings,
+    :commerce_orders,
+    :vendors,
+    :commerce_products,
+    :marketing_lists,
+    :marketing_sms_broadcasts,
+    :marketing_sms_dispatches,
+    :members,
+    :message_deliveries,
+    :mobility_trips,
+    :organizations,
+    :organization_memberships,
+    :organization_membership_verifications,
+    :payment_bank_accounts,
+    :payment_book_transactions,
+    :payment_cards,
+    :payment_funding_transactions,
+    :payment_payout_transactions,
+    :program_enrollments,
+    :payment_ledgers,
+    :payment_triggers,
+    :vendor_services,
+  ]
+
+  # rubocop:disable Sequel/IrreversibleMigration
+  change do
+    tables.each do |tbl|
+      alter_table(tbl) do
+        add_index :search_content,
+                  name: :"#{tbl}_search_content_trigram_index",
+                  type: :gist
+      end
+    end
+    # rubocop:enable Sequel/IrreversibleMigration
+  end
+end

--- a/lib/sequel/plugins/hybrid_search.rb
+++ b/lib/sequel/plugins/hybrid_search.rb
@@ -25,6 +25,8 @@ module Sequel::Plugins::HybridSearch
     keyword_scale: 1,
     # How many times to retry if reindexing fails (API server is down, etc.).
     indexing_retries: 4,
+    # False to avoid registering in +SequelHybridSearch.indexable_models+.
+    indexable: true,
     # Called to figure out how long to sleep between retries.
     # By default, use exponential backoff with a base delay of 4 seconds.
     indexing_backoff: ->(attempt) { 4 * (2**(attempt - 1)) },
@@ -43,7 +45,7 @@ module Sequel::Plugins::HybridSearch
     model.hybrid_search_keyword_scale = opts[:keyword_scale]
     model.hybrid_search_indexing_retries = opts[:indexing_retries]
     model.hybrid_search_indexing_backoff = opts[:indexing_backoff]
-    SequelHybridSearch.searchable_models << model
+    SequelHybridSearch.indexable_models << model unless opts[:indexable] == false
     model.plugin :pgvector, model.hybrid_search_vector_column
   end
 

--- a/lib/sequel/sequel_hybrid_search.rb
+++ b/lib/sequel/sequel_hybrid_search.rb
@@ -10,8 +10,8 @@ module SequelHybridSearch
   INDEXING_DEFAULT_MODE = :async
 
   class << self
-    def searchable_models = @searchable_models ||= []
-    def reindex_all = self.searchable_models.sum(&:hybrid_search_reindex_all)
+    def indexable_models = @indexable_models ||= []
+    def reindex_all = self.indexable_models.sum(&:hybrid_search_reindex_all)
 
     def indexing_mode = @indexing_mode || INDEXING_DEFAULT_MODE
 

--- a/lib/suma/payment/instrument.rb
+++ b/lib/suma/payment/instrument.rb
@@ -3,10 +3,9 @@
 require "suma/payment"
 
 class Suma::Payment::Instrument < Suma::Postgres::Model(:payment_instruments)
-  plugin :hybrid_search
+  plugin :hybrid_search, indexable: false
 
   class << self
-    def view? = true
     def primary_key = :id
 
     def type_strings_to_types

--- a/lib/suma/postgres/model_utilities.rb
+++ b/lib/suma/postgres/model_utilities.rb
@@ -26,9 +26,6 @@ module Suma::Postgres::ModelUtilities
   module ClassMethods
     def anonymous? = self.name.blank? || self.name.start_with?("Sequel::_Model")
 
-    # Override on view-based models.
-    def view? = false
-
     # The application name, set on database connections.
     attr_reader :appname
 

--- a/spec/sequel/plugins/hybrid_searchable_spec.rb
+++ b/spec/sequel/plugins/hybrid_searchable_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "sequel-hybrid-searchable" do
       model.create(name: "Geralt", desc: "Rivia")
       model.create(name: "Rivia", desc: "Ciri")
       model.hybrid_search_reindex_all
-      expect(model.dataset.exclude(name: "Geralt").hybrid_search("test models named 'geralt'")).to be_empty
+      expect(model.dataset.exclude(name: "Geralt").hybrid_search("geralt")).to be_empty
     end
 
     it "errors if the model has no primary key" do
@@ -178,15 +178,15 @@ RSpec.describe "sequel-hybrid-searchable" do
     end
 
     it "uses OR for the keyword search (instead of 'AND')" do
-      m1 = model.create(name: "Tim 1")
-      m2 = model.create(name: "Tim 2")
+      m1 = model.create(name: "Sherlock 1")
+      m2 = model.create(name: "Sherlock 2")
       m3 = model.create(name: "Barry")
       model.hybrid_search_reindex_all
 
-      got = model.dataset.hybrid_search("Tim and here is a bunch of extra text").all
+      got = model.dataset.hybrid_search("Sherlock xyz zzz yyy").all
       expect(got).to have_same_ids_as(m2, m1)
 
-      got = model.dataset.hybrid_search("Barry Tim").all
+      got = model.dataset.hybrid_search("Barry Sherlock").all
       expect(got).to have_same_ids_as(m1, m2, m3)
     end
 
@@ -207,6 +207,15 @@ RSpec.describe "sequel-hybrid-searchable" do
 
       page = model.dataset.hybrid_search(q).limit(2, 4).all
       expect(page).to have_same_ids_as(rows[4]).ordered
+    end
+
+    it "uses the trigram index" do
+      m1 = model.create(name: "My name is Lammy Jr")
+      model.create(name: "No name")
+      model.hybrid_search_reindex_all
+
+      got = model.dataset.hybrid_search("Lam").all
+      expect(got).to have_same_ids_as(m1)
     end
   end
 

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Suma::AdminAPI::Members, :db do
     end
 
     it "will search a US phone number as an E164 form in search", :hybrid_search do
-      nomatch = Suma::Fixtures.member(phone: "13334445556").create
+      nomatch = Suma::Fixtures.member(phone: "19998887777").create
       match = Suma::Fixtures.member(phone: "13334445555").create
 
       Suma::Member.hybrid_search_reindex_all

--- a/spec/suma/admin_api/programs_spec.rb
+++ b/spec/suma/admin_api/programs_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Suma::AdminAPI::Programs, :db do
 
       def make_non_matching_items
         return [
-          Suma::Fixtures.program(name: translated_text("wibble wobble")).create,
+          Suma::Fixtures.program(name: translated_text("frumfrom")).create,
         ]
       end
     end

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -369,8 +369,8 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
 
   describe "HybridSearchReindex" do
     it "reindexes all models if called without an argument" do
-      expect(SequelHybridSearch.searchable_models).to be_present
-      SequelHybridSearch.searchable_models.each do |model|
+      expect(SequelHybridSearch.indexable_models).to be_present
+      SequelHybridSearch.indexable_models.each do |model|
         expect(model).to receive(:hybrid_search_reindex_all).and_return(0)
       end
       Suma::Async::HybridSearchReindex.new.perform

--- a/spec/suma/postgres/hybrid_search_spec.rb
+++ b/spec/suma/postgres/hybrid_search_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe Suma::Postgres::HybridSearch, :db do
   end
 
   describe "all hybrid searchable models" do
-    SequelHybridSearch.searchable_models.each do |m|
-      next if m.view?
+    SequelHybridSearch.indexable_models.each do |m|
       describe m.name do
         it_behaves_like "a hybrid searchable object" do
           let(:instance) do

--- a/webapp/src/localization/I18nProvider.jsx
+++ b/webapp/src/localization/I18nProvider.jsx
@@ -42,7 +42,7 @@ export default function I18nProvider({ children }) {
       return api
         .getLocaleFile(
           { locale: language, namespace, cachebust: config.release },
-          { camelize: false }
+          { camelize: false, timeout: 5000 }
         )
         .then((resp) => i18n.putFile(language, namespace, resp.data))
         .tapCatch((e) =>


### PR DESCRIPTION
Add trigram search support to hybrid search

Using full text search does not allow for fuzzy matching.
Add trigram searching to support it.
This includes trigram similarity in the keyword rankings.

Also overhaul how rrf was being used,
which creates much more sensible results.
See code for more details.

Also gist indices to search_content for faster ops.

---

Refactor hybrid search 'indexable models'

We need to know what hybrid search plugin models
are indexable, not searchable, so rename this constant/registry
from 'searchable' to 'indexable'.

Then remove the `view?` helper on our models,
and allow plugins to be configured as
`plugin :hybrid_search, indexable: false`
to skip their indexing.

---

Retry on timeout; speed up localization requests

- Use a 5s timeout to get localization strings.
  This endpoint is basically static, so requests
  should be very fast.
- When requests fail due to timeout, and it is idempotent,
  automatically retry. axios-retry was not automatically
  retrying on timeouts.