### PR TITLE
Trip discounts; fix unauthed 401s; disable violations processor flag; role descriptions; trip admin detail

### DIFF
--- a/adminapp/src/pages/MobilityTripDetailPage.jsx
+++ b/adminapp/src/pages/MobilityTripDetailPage.jsx
@@ -31,7 +31,17 @@ export default function MobilityTripDetailPage() {
         {
           label: "Vendor Service",
           value: (
-            <AdminLink model={model.vendorService}>{model.vendorService?.name}</AdminLink>
+            <AdminLink model={model.vendorService}>
+              {model.vendorService?.internalName}
+            </AdminLink>
+          ),
+        },
+        {
+          label: "Service Rate",
+          value: (
+            <AdminLink model={model.vendorServiceRate}>
+              {model.vendorServiceRate?.name}
+            </AdminLink>
           ),
         },
         { label: "Vehicle ID", value: model.vehicleId },
@@ -72,25 +82,6 @@ export default function MobilityTripDetailPage() {
             ]}
           />
         ),
-        <DetailGrid
-          title="Rate"
-          properties={[
-            { label: "Id", value: model.rate.id },
-            { label: "Name", value: model.rate.name },
-            { label: "Created", value: formatDate(model.rate.createdAt) },
-            { label: "Unit Amount", value: <Money>{model.rate.unitAmount}</Money> },
-            { label: "Surcharge", value: <Money>{model.rate.surcharge}</Money> },
-            { label: "Unit Offset", value: model.rate.unitOffset },
-            {
-              label: "Undiscounted Amount",
-              value: <Money>{model.rate.undiscountedAmount}</Money>,
-            },
-            {
-              label: "Undiscounted Surcharge",
-              value: <Money>{model.rate.undiscountedSurcharge}</Money>,
-            },
-          ]}
-        />,
       ]}
     </ResourceDetail>
   );

--- a/adminapp/src/pages/RoleDetailPage.jsx
+++ b/adminapp/src/pages/RoleDetailPage.jsx
@@ -13,6 +13,7 @@ export default function RoleDetailPage() {
       properties={(model) => [
         { label: "ID", value: model.id },
         { label: "Name", value: model.name },
+        { label: "Description", value: model.description },
       ]}
     >
       {(model) => [

--- a/adminapp/src/pages/RoleForm.jsx
+++ b/adminapp/src/pages/RoleForm.jsx
@@ -26,6 +26,16 @@ export default function RoleForm({
           name="name"
           value={resource.name}
           fullWidth
+          required
+          onChange={setFieldFromInput}
+        />
+        <TextField
+          {...register("description")}
+          label="Description"
+          name="description"
+          value={resource.description}
+          fullWidth
+          helperText="What does it mean for a member or organization to have this role?"
           onChange={setFieldFromInput}
         />
       </Stack>

--- a/adminapp/src/pages/RoleListPage.jsx
+++ b/adminapp/src/pages/RoleListPage.jsx
@@ -25,6 +25,13 @@ export default function RoleListPage() {
           sortable: true,
           render: (c) => <AdminLink model={c}>{c.name}</AdminLink>,
         },
+        {
+          id: "description",
+          label: "Description",
+          align: "left",
+          sortable: false,
+          render: (c) => c.description,
+        },
       ]}
     />
   );

--- a/db/migrations/089_role_description.rb
+++ b/db/migrations/089_role_description.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:roles) do
+      add_column :description, :text, null: false, default: ""
+    end
+  end
+end

--- a/lib/suma/admin_api/roles.rb
+++ b/lib/suma/admin_api/roles.rb
@@ -9,10 +9,15 @@ class Suma::AdminAPI::Roles < Suma::AdminAPI::V1
     include Suma::AdminAPI::Entities::AutoExposeBase
   end
 
+  class RoleListEntity < RoleEntity
+    expose :description
+  end
+
   class DetailedRoleEntity < RoleEntity
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
 
+    expose :description
     expose :members, with: Suma::AdminAPI::Entities::MemberEntity
     expose :organizations, with: Suma::AdminAPI::Entities::OrganizationEntity
     expose :program_enrollments, with: Suma::AdminAPI::Entities::ProgramEnrollmentEntity
@@ -25,7 +30,7 @@ class Suma::AdminAPI::Roles < Suma::AdminAPI::V1
       check_admin_role_access!(:read, Suma::Role)
       ds = Suma::Role.dataset.order(:name)
       use_http_expires_caching 2.hours
-      present_collection ds, with: RoleEntity
+      present_collection ds, with: RoleListEntity
     end
 
     Suma::AdminAPI::CommonEndpoints.create(
@@ -35,6 +40,7 @@ class Suma::AdminAPI::Roles < Suma::AdminAPI::V1
     ) do
       params do
         requires :name, type: String, allow_blank: false
+        optional :description, type: String
       end
     end
 
@@ -51,6 +57,7 @@ class Suma::AdminAPI::Roles < Suma::AdminAPI::V1
     ) do
       params do
         optional :name, type: String, allow_blank: false
+        optional :description, type: String
       end
     end
   end

--- a/lib/suma/async/lime_violations_processor.rb
+++ b/lib/suma/async/lime_violations_processor.rb
@@ -15,6 +15,7 @@ class Suma::Async::LimeViolationsProcessor
   splay 30.seconds
 
   def _perform
+    return unless Suma::Lime.violations_processor_enabled
     Suma::Lime::HandleViolations.new.run
   end
 end

--- a/lib/suma/lime.rb
+++ b/lib/suma/lime.rb
@@ -12,6 +12,9 @@ module Suma::Lime
     setting :maas_auth_token, UNCONFIGURED_AUTH_TOKEN
     # Slug of the Vendor to use for deeplinking into the Lime app.
     setting :deeplink_vendor_slug, "lime"
+    # Turn off the violations processor. We want to make sure we only run this on production,
+    # even if other environments (like development) point towards the production email table.
+    setting :violations_processor_enabled, false
   end
 
   # @return [Suma::Vendor]

--- a/lib/suma/lime/sync_trips_from_email.rb
+++ b/lib/suma/lime/sync_trips_from_email.rb
@@ -71,8 +71,6 @@ class Suma::Lime::SyncTripsFromEmail
     end
   end
 
-  LINE_ITEM_HEADINGS = ["Start Fee", "Discount"].freeze
-
   def parse_row_to_receipt(row)
     r = Suma::Mobility::VendorAdapter::LimeDeeplink::RideReceipt.new(
       vehicle_type: DEFAULT_VEHICLE_TYPE,
@@ -85,8 +83,12 @@ class Suma::Lime::SyncTripsFromEmail
     riding_line_item = pause_line_item = nil
     while i < lines.length
       line = lines[i]
-      if LINE_ITEM_HEADINGS.include?(line)
+      if line == "Start Fee"
         r.line_items << {memo: line, amount: Monetize.parse(lines[i + 1])}
+        i += 1
+      elsif line == "Discount"
+        r.discount = Monetize.parse(lines[i + 1]) * -1
+        r.line_items << {memo: line, amount: -r.discount}
         i += 1
       elsif line.start_with?("Riding -", "Pause -")
         match = line.match(%r{(\$\d+\.\d\d)/min \((\d+) min\)})

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -478,7 +478,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
     lines = [
       self.onboarding_verified? ? "My identify has been verified" : "My identity is unverified.",
       self.soft_deleted? && "I have been deleted.",
-      self.roles.include?(Suma::Role.cache.admin) && "I am an administrator.",
+      self.roles.any?(Suma::Role.cache.admin) && "I am an administrator.",
       "I am a member of #{self.organization_memberships.count} organizations.",
       "I have been assigned #{self.roles.count} roles.",
     ]

--- a/lib/suma/member/role_access.rb
+++ b/lib/suma/member/role_access.rb
@@ -55,7 +55,7 @@ class Suma::Member::RoleAccess
     @member = member
     @features = {}
     # rubocop:disable Style/GuardClause, Style/IfUnlessModifier
-    if member.roles.include?(Suma::Role.cache.admin)
+    if member.roles.any?(Suma::Role.cache.admin)
       self.add_feature(UPLOAD_FILES, true, true)
       self.add_feature(IMPERSONATE, true, true)
       self.add_feature(ADMIN_ACCESS, true, true)
@@ -67,32 +67,32 @@ class Suma::Member::RoleAccess
       self.add_feature(MARKETING_SMS, true, true)
       self.add_feature(LOCALIZATION, true, true)
     end
-    if member.roles.include?(Suma::Role.cache.readonly_admin)
+    if member.roles.any?(Suma::Role.cache.readonly_admin)
       self.add_feature(ADMIN_ACCESS, true, false)
       self.add_feature(ADMIN_MEMBERS, true, false)
       self.add_feature(ADMIN_COMMERCE, true, false)
       self.add_feature(ADMIN_PAYMENTS, true, false)
       self.add_feature(ADMIN_MANAGEMENT, true, false)
     end
-    if member.roles.include?(Suma::Role.cache.noop_admin)
+    if member.roles.any?(Suma::Role.cache.noop_admin)
       self.add_feature(ADMIN_ACCESS, true, false)
     end
-    if member.roles.include?(Suma::Role.cache.upload_files)
+    if member.roles.any?(Suma::Role.cache.upload_files)
       self.add_feature(UPLOAD_FILES, true, true)
     end
-    if member.roles.include?(Suma::Role.cache.onboarding_manager)
+    if member.roles.any?(Suma::Role.cache.onboarding_manager)
       self.add_feature(ADMIN_ACCESS, true, true)
       self.add_feature(ADMIN_MEMBERS, true, true)
     end
-    if member.roles.include?(Suma::Role.cache.sensitive_messages)
+    if member.roles.any?(Suma::Role.cache.sensitive_messages)
       self.add_feature(ADMIN_SENSITIVE_MESSAGES, true, false)
     end
-    if member.roles.include?(Suma::Role.cache.sms_marketing)
+    if member.roles.any?(Suma::Role.cache.sms_marketing)
       self.add_feature(ADMIN_ACCESS, true, true)
       self.add_feature(ADMIN_MEMBERS, true, false)
       self.add_feature(MARKETING_SMS, true, true)
     end
-    if member.roles.include?(Suma::Role.cache.translator)
+    if member.roles.any?(Suma::Role.cache.translator)
       self.add_feature(ADMIN_ACCESS, true, true)
       self.add_feature(LOCALIZATION, true, true)
     end

--- a/lib/suma/mobility/vendor_adapter.rb
+++ b/lib/suma/mobility/vendor_adapter.rb
@@ -8,14 +8,12 @@ module Suma::Mobility::VendorAdapter
   BeginTripResult = Struct.new(:raw_result, keyword_init: true)
   EndTripResult = Struct.new(
     :raw_result,
-    :cost_cents,
-    :cost_currency,
+    :cost,
+    :undiscounted,
     :duration_minutes,
     :end_time,
     keyword_init: true,
-  ) do
-    def cost = Money.new(self.cost_cents, self.cost_currency)
-  end
+  )
 
   class << self
     def create(name)

--- a/lib/suma/mobility/vendor_adapter/internal.rb
+++ b/lib/suma/mobility/vendor_adapter/internal.rb
@@ -29,8 +29,8 @@ class Suma::Mobility::VendorAdapter::Internal
     ended = Time.now
     duration = (ended - trip.began_at) / 60.0
     return EndTripResult.new(
-      cost_cents: trip.vendor_service_rate.calculate_total(duration).cents.to_i,
-      cost_currency: "USD",
+      cost: trip.vendor_service_rate.calculate_total(duration),
+      undiscounted: trip.vendor_service_rate.calculate_undiscounted_total(duration),
       end_time: ended,
       duration_minutes: duration.to_i,
     )

--- a/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
+++ b/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
@@ -25,13 +25,14 @@ class Suma::Mobility::VendorAdapter::LimeDeeplink
                   :started_at,
                   :ended_at,
                   :total,
+                  :discount,
                   :line_items
   end
 
   def end_trip(_trip, receipt:)
     return Suma::Mobility::VendorAdapter::EndTripResult.new(
-      cost_cents: receipt.total.cents,
-      cost_currency: receipt.total.currency,
+      cost: receipt.total,
+      undiscounted: receipt.discount + receipt.total,
       end_time: receipt.ended_at,
       duration_minutes: ((receipt.ended_at - receipt.started_at) / 60.0).to_i,
     )

--- a/lib/suma/mobility/vendor_adapter/lime_maas.rb
+++ b/lib/suma/mobility/vendor_adapter/lime_maas.rb
@@ -35,8 +35,8 @@ class Suma::Mobility::VendorAdapter::LimeMaas
     )
     duration = resp.dig("data", "duration_seconds") / 60.0
     return EndTripResult.new(
-      cost_cents: trip.vendor_service_rate.calculate_total(duration).cents.to_i,
-      cost_currency: "USD",
+      cost: trip.vendor_service_rate.calculate_total(duration),
+      undiscounted: trip.vendor_service_rate.calculate_undiscounted_total(duration),
       end_time: resp.dig("data", "completed_at"),
       duration_minutes: duration.ceil,
     )

--- a/lib/suma/mobility/vendor_adapter/lyft_deeplink.rb
+++ b/lib/suma/mobility/vendor_adapter/lyft_deeplink.rb
@@ -23,14 +23,15 @@ class Suma::Mobility::VendorAdapter::LyftDeeplink
   def end_trip(_trip, ride_response:)
     start_time = Time.at(ride_response.fetch("ride").fetch("pickup").fetch("timestamp_ms") / 1000)
     end_time = Time.at(ride_response.fetch("ride").fetch("dropoff").fetch("timestamp_ms") / 1000)
-    zero_money = Money.new(0, ride_response.fetch("money").fetch("currency"))
+    total_h = ride_response.fetch("money")
+    zero_money = Money.new(0, total_h.fetch("currency"))
     total_of_non_promo_items = ride_response.fetch("ride").fetch("line_items").sum(zero_money) do |li|
       next 0 if li.fetch("title") == "Promo applied"
       Money.new(li.fetch("money").fetch("amount"), li.fetch("money").fetch("currency"))
     end
     return Suma::Mobility::VendorAdapter::EndTripResult.new(
-      cost_cents: total_of_non_promo_items.cents,
-      cost_currency: total_of_non_promo_items.currency,
+      cost: total_of_non_promo_items,
+      undiscounted: Money.new(total_h.fetch("amount"), total_h.fetch("currency")),
       end_time:,
       duration_minutes: (end_time - start_time).minutes,
     )

--- a/lib/suma/yosoy.rb
+++ b/lib/suma/yosoy.rb
@@ -193,7 +193,6 @@ class Suma::Yosoy
       expire_at = ts + self.middleware.inactivity_timeout
       return unless Time.now > expire_at
       self.logout
-      self.unauthenticated!(message: "Cookie expired")
     end
 
     def logout

--- a/spec/suma/admin_api/anon_proxy_member_contacts_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_member_contacts_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::AnonProxyMemberContacts, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/anon_proxy_member_contacts" }
-      let(:search_term) { "abc" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.anon_proxy_member_contact.create(email: "abc  123"),
+          Suma::Fixtures.anon_proxy_member_contact.create(email: "zzz  123"),
         ]
       end
 

--- a/spec/suma/admin_api/anon_proxy_vendor_accounts_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_vendor_accounts_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::AnonProxyVendorAccounts, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/anon_proxy_vendor_accounts" }
-      let(:search_term) { "abc" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.anon_proxy_vendor_account.with_access_code("abc  123").create,
+          Suma::Fixtures.anon_proxy_vendor_account.with_access_code("zzz  123").create,
         ]
       end
 

--- a/spec/suma/admin_api/anon_proxy_vendor_configurations_spec.rb
+++ b/spec/suma/admin_api/anon_proxy_vendor_configurations_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::AnonProxyVendorConfigurations, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/anon_proxy_vendor_configurations" }
-      let(:search_term) { "abcdefg" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.anon_proxy_vendor_configuration.vendor(name: "abcdefg").create,
+          Suma::Fixtures.anon_proxy_vendor_configuration.vendor(name: "zzz").create,
         ]
       end
 

--- a/spec/suma/admin_api/book_transactions_spec.rb
+++ b/spec/suma/admin_api/book_transactions_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Suma::AdminAPI::BookTransactions, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/book_transactions" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "ZZZ" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.book_transaction(memo: translated_text("zim zam zom")).create,
-          Suma::Fixtures.book_transaction(opaque_id: "Zim Zam").create,
+          Suma::Fixtures.book_transaction(memo: translated_text("zzz zam zom")).create,
+          Suma::Fixtures.book_transaction(opaque_id: "Zim Zzz").create,
         ]
       end
 

--- a/spec/suma/admin_api/charges_spec.rb
+++ b/spec/suma/admin_api/charges_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Suma::AdminAPI::Charges, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/charges" }
-      let(:search_term) { "abcdefg" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
-        return [Suma::Fixtures.charge(opaque_id: "abcdefg").create]
+        return [Suma::Fixtures.charge(opaque_id: "zzz").create]
       end
 
       def make_non_matching_items

--- a/spec/suma/admin_api/commerce_offerings_spec.rb
+++ b/spec/suma/admin_api/commerce_offerings_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Suma::AdminAPI::CommerceOfferings, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/commerce_offerings" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.offering(description: translated_text("zim")).create,
-          Suma::Fixtures.offering(description: translated_text("ZIM zam")).create,
+          Suma::Fixtures.offering(description: translated_text("zzz")).create,
+          Suma::Fixtures.offering(description: translated_text("ZIM zzz")).create,
         ]
       end
 

--- a/spec/suma/admin_api/commerce_orders_spec.rb
+++ b/spec/suma/admin_api/commerce_orders_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe Suma::AdminAPI::CommerceOrders, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/commerce_orders" }
-      let(:search_term) { "abcdefg" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.order.as_purchased_by(name: "abcdefg").create,
+          Suma::Fixtures.order.as_purchased_by(name: "zzz").create,
         ]
       end
 

--- a/spec/suma/admin_api/commerce_products_spec.rb
+++ b/spec/suma/admin_api/commerce_products_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::CommerceProducts, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/commerce_products" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.product(name: translated_text("ZIM zam")).create,
+          Suma::Fixtures.product(name: translated_text("zzz zam")).create,
         ]
       end
 

--- a/spec/suma/admin_api/common_endpoints_spec.rb
+++ b/spec/suma/admin_api/common_endpoints_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Suma::AdminAPI::CommonEndpoints, :db do
       Suma::Vendor.hybrid_search_reindex_all
       Suma::Vendor.hybrid_search_semantic_scale = 0
 
-      get "/v1/vendors", search: "Rivia"
+      get "/v1/vendors", search: "Rivia", order_by: "name", order_direction: "desc"
 
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(items: have_same_ids_as(geralt, ciri).ordered)
@@ -71,11 +71,11 @@ RSpec.describe Suma::AdminAPI::CommonEndpoints, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/vendors" }
-      let(:search_term) { "johns farm" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.vendor(name: "Johns Farmers Market").create,
+          Suma::Fixtures.vendor(name: "zzz Market").create,
         ]
       end
 

--- a/spec/suma/admin_api/funding_transactions_spec.rb
+++ b/spec/suma/admin_api/funding_transactions_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::FundingTransactions, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/funding_transactions" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.funding_transaction(memo: translated_text("zim zam zom")).with_fake_strategy.create,
+          Suma::Fixtures.funding_transaction(memo: translated_text("zim zzz zom")).with_fake_strategy.create,
         ]
       end
 

--- a/spec/suma/admin_api/marketing_lists_spec.rb
+++ b/spec/suma/admin_api/marketing_lists_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::MarketingLists, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/marketing_lists" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.marketing_list(label: "zim zam zom").create,
+          Suma::Fixtures.marketing_list(label: "zim zzz zom").create,
         ]
       end
 

--- a/spec/suma/admin_api/marketing_sms_broadcasts_spec.rb
+++ b/spec/suma/admin_api/marketing_sms_broadcasts_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::MarketingSmsBroadcasts, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/marketing_sms_broadcasts" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "ZZZ" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.marketing_sms_broadcast(label: "zim zam zom").create,
+          Suma::Fixtures.marketing_sms_broadcast(label: "zim zzz zom").create,
         ]
       end
 

--- a/spec/suma/admin_api/marketing_sms_dispatches_spec.rb
+++ b/spec/suma/admin_api/marketing_sms_dispatches_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::MarketingSmsDispatches, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/marketing_sms_dispatches" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "Zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.marketing_sms_dispatch.to(name: "zim zam zom").create,
+          Suma::Fixtures.marketing_sms_dispatch.to(name: "zim zzz zom").create,
         ]
       end
 

--- a/spec/suma/admin_api/members_spec.rb
+++ b/spec/suma/admin_api/members_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe Suma::AdminAPI::Members, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/members" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "ZZZ" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.member(note: "Hi, zim").create,
-          Suma::Fixtures.member(name: "Zim Zam").create,
+          Suma::Fixtures.member(note: "Hi, zzz").create,
+          Suma::Fixtures.member(name: "Zzz Zam").create,
         ]
       end
 

--- a/spec/suma/admin_api/message_deliveries_spec.rb
+++ b/spec/suma/admin_api/message_deliveries_spec.rb
@@ -27,18 +27,18 @@ RSpec.describe Suma::AdminAPI::MessageDeliveries, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/message_deliveries" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.message_delivery(to: "ZIM zam com").create,
-          Suma::Fixtures.message_delivery(template: "zim zam").create,
+          Suma::Fixtures.message_delivery(to: "zzz zam com").create,
+          Suma::Fixtures.message_delivery(template: "zzz zam").create,
         ]
       end
 
       def make_non_matching_items
         return [
-          Suma::Fixtures.message_delivery(to: "zam zam com", template: "zam zam").create,
+          Suma::Fixtures.message_delivery(to: "tam tam com", template: "tam tam").create,
         ]
       end
     end

--- a/spec/suma/admin_api/mobility_spec.rb
+++ b/spec/suma/admin_api/mobility_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::MobilityTrips, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/mobility_trips" }
-      let(:search_term) { "abcdefg" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.mobility_trip(external_trip_id: "abcdefg").create,
+          Suma::Fixtures.mobility_trip(external_trip_id: "zzz").create,
         ]
       end
 

--- a/spec/suma/admin_api/mobility_trips_spec.rb
+++ b/spec/suma/admin_api/mobility_trips_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Suma::AdminAPI::MobilityTrips, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/mobility_trips" }
-      let(:search_term) { "abcdefg" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.mobility_trip(external_trip_id: "abcdefg").create,
-          Suma::Fixtures.mobility_trip(vehicle_id: "abcdefg").create,
+          Suma::Fixtures.mobility_trip(external_trip_id: "zzz").create,
+          Suma::Fixtures.mobility_trip(vehicle_id: "zzz").create,
         ]
       end
 

--- a/spec/suma/admin_api/organization_memberships_spec.rb
+++ b/spec/suma/admin_api/organization_memberships_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Suma::AdminAPI::OrganizationMemberships, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/organization_memberships" }
-      let(:search_term) { "abcdefg" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.organization_membership.unverified("abcdefg").create,
+          Suma::Fixtures.organization_membership.unverified("zzz").create,
         ]
       end
 

--- a/spec/suma/admin_api/organizations_spec.rb
+++ b/spec/suma/admin_api/organizations_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe Suma::AdminAPI::Organizations, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/organizations" }
-      let(:search_term) { "Hacienda" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.organization(name: "Hacienda ABC").create,
+          Suma::Fixtures.organization(name: "zzz ABC").create,
         ]
       end
 

--- a/spec/suma/admin_api/payment_ledgers_spec.rb
+++ b/spec/suma/admin_api/payment_ledgers_spec.rb
@@ -49,10 +49,10 @@ RSpec.describe Suma::AdminAPI::PaymentLedgers, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/payment_ledgers" }
-      let(:search_term) { "match" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
-        return [Suma::Fixtures.ledger(name: "FM match 2023").create]
+        return [Suma::Fixtures.ledger(name: "FM zzz 2023").create]
       end
 
       def make_non_matching_items

--- a/spec/suma/admin_api/payment_triggers_spec.rb
+++ b/spec/suma/admin_api/payment_triggers_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::PaymentTriggers, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/payment_triggers" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.payment_trigger(memo: translated_text("zim zam zom")).create,
+          Suma::Fixtures.payment_trigger(memo: translated_text("zzz zam zom")).create,
         ]
       end
 

--- a/spec/suma/admin_api/payout_transactions_spec.rb
+++ b/spec/suma/admin_api/payout_transactions_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::PayoutTransactions, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/payout_transactions" }
-      let(:search_term) { "ZIM" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.payout_transaction(memo: translated_text("zim zam zom")).with_fake_strategy.create,
+          Suma::Fixtures.payout_transaction(memo: translated_text("zzz zam zom")).with_fake_strategy.create,
         ]
       end
 

--- a/spec/suma/admin_api/program_enrollments_spec.rb
+++ b/spec/suma/admin_api/program_enrollments_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::ProgramEnrollments, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/program_enrollments" }
-      let(:search_term) { "abcdefg" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.program_enrollment.in(Suma::Fixtures.program.named("abcdefg").create).create,
+          Suma::Fixtures.program_enrollment.in(Suma::Fixtures.program.named("zzz").create).create,
         ]
       end
 

--- a/spec/suma/admin_api/programs_spec.rb
+++ b/spec/suma/admin_api/programs_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::Programs, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/programs" }
-      let(:search_term) { "zibble" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.program(name: translated_text("zibble zabble")).create,
+          Suma::Fixtures.program(name: translated_text("zzz zabble")).create,
         ]
       end
 

--- a/spec/suma/admin_api/vendor_services_spec.rb
+++ b/spec/suma/admin_api/vendor_services_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Suma::AdminAPI::VendorServices, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/vendor_services" }
-      let(:search_term) { "demo" }
+      let(:search_term) { "zzz" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.vendor_service(internal_name: "Demo Mobility Deeplink").create,
+          Suma::Fixtures.vendor_service(internal_name: "zzz Mobility Deeplink").create,
         ]
       end
 

--- a/spec/suma/admin_api/vendors_spec.rb
+++ b/spec/suma/admin_api/vendors_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe Suma::AdminAPI::Vendors, :db do
 
     it_behaves_like "an endpoint capable of search" do
       let(:url) { "/v1/vendors" }
-      let(:search_term) { "johns farm" }
+      let(:search_term) { "ZZZ" }
 
       def make_matching_items
         return [
-          Suma::Fixtures.vendor(name: "Johns Farmers Market").create,
+          Suma::Fixtures.vendor(name: "Johns zzz Market").create,
         ]
       end
 

--- a/spec/suma/lime/sync_trips_from_email_spec.rb
+++ b/spec/suma/lime/sync_trips_from_email_spec.rb
@@ -274,6 +274,7 @@ RSpec.describe Suma::Lime::SyncTripsFromEmail, :db do
         started_at: Time.parse("2024-07-15T10:43:00Z"),
         ended_at: Time.parse("2024-07-15T11:59:00Z"),
         total: cost("$0"),
+        discount: cost("$5.82"),
         line_items: [
           include(amount: cost("$0.50"), memo: "Start Fee"),
           include(amount: cost("$5.32"), memo: "Riding - $0.07/min (76 min)"),

--- a/spec/suma/member/role_access_spec.rb
+++ b/spec/suma/member/role_access_spec.rb
@@ -101,4 +101,14 @@ RSpec.describe Suma::Member::RoleAccess, :db do
     member.add_role(Suma::Role.cache.upload_files)
     expect(member.role_access.as_json).to eq({"upload_files" => ["read", "write"]})
   end
+
+  it "searches for roles properly (any vs include)" do
+    member = Suma::Fixtures.member.create
+    member.add_role(Suma::Role.cache.upload_files)
+    member.refresh
+    # Change the role so == (used by include?) no longer matches,
+    # but === (used by any?) does.
+    member.roles.first.set(name: "Other Name")
+    expect(member.role_access.as_json).to eq({"upload_files" => ["read", "write"]})
+  end
 end

--- a/spec/suma/mobility/vendor_adapter_spec.rb
+++ b/spec/suma/mobility/vendor_adapter_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
     end
 
     it "returns the charge based on the rate" do
-      rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).create
+      rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
       trip = Suma::Fixtures.mobility_trip.create(began_at: 5.minutes.ago, vendor_service_rate: rate)
       endres = ad.end_trip(trip)
       expect(endres).to have_attributes(
-        cost_cents: 200,
-        cost_currency: "USD",
+        cost: cost("$2"),
+        undiscounted: cost("$4"),
         duration_minutes: 5,
       )
     end
@@ -59,12 +59,12 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
     end
 
     it "returns the charge based on the rate" do
-      rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).create
+      rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
       trip = Suma::Fixtures.mobility_trip.create(began_at: 5.minutes.ago, vendor_service_rate: rate)
       endres = ad.end_trip(trip)
       expect(endres).to have_attributes(
-        cost_cents: 200,
-        cost_currency: "USD",
+        cost: cost("$2"),
+        undiscounted: cost("$4"),
         duration_minutes: 5,
       )
     end


### PR DESCRIPTION
Add descriptions to roles

---

Mobility trip admin: Make 'rate' a link

When this was added, we didn't have rates in admin.
Now we do.

---

Fix member role checks (include -> any)

When we added fields like role description,
the cached role does not change, so == compares false.

---

Fix flaky endpoint ordering spec

---

Better handle yosoy cookie expiration

We were throwing a 401 if the cookie was expired.
However, this meant `authenticated_object?` could raise a 401,
even though it wasn't intended to.

Remove the `throw` behavior if the cookie is expired.

This should hopefully fix the 401s on unauthed routes.

---

Flag to disable violations processor

Turn off the violations processor.
We want to make sure we only run this on production,
even if other environments (like development)
point towards the production email table.

---

Trip discount should come from backend

Use undiscounted rate to calculate the discount using
the internal and fake adapter. Otherwise,
it must be parsed from the Lime receipt email
or Lyft Pass response.