### PR TITLE
Send an SMS receipt on trip completed; rewrite trip begin/end code

### DIFF
--- a/data/i18n/seeds/en/messages.json
+++ b/data/i18n/seeds/en/messages.json
@@ -1,5 +1,6 @@
 {
   "anon_proxy/lime_deep_link_access_code.sms": "Press this link to access your Lime account through suma: {{ value }}",
+  "mobility/trip_receipt.sms": "suma: Thanks for riding! Here is your receipt for your {{ minutes }} minute ride with {{ vendor_name }}: {{ trip_link }}",
   "offerings/2022_12_pilot_confirmation.sms": "Thanks for your order! We'll reach out by December 12 with information about pickup. Respond to this text or email info@mysuma.org if you need help. - suma",
   "offerings/2023_07_pilot_confirmation.sms": "Thanks for your order! Go to this link when you're at the market to claim your vouchers: {{ app_url }}/unclaimed-orders - suma",
   "offerings/2023_12_holiday_confirmation.sms": "suma: Thanks for your order! We'll reach out by December 15 with information about pickup. Reply HELP if you have questions. Reply STOP to unsubscribe.",

--- a/data/i18n/seeds/es/messages.json
+++ b/data/i18n/seeds/es/messages.json
@@ -1,5 +1,6 @@
 {
   "anon_proxy/lime_deep_link_access_code.sms": "Presione este enlace para acceder a su cuenta Lime a través de suma: {{ value }}",
+  "mobility/trip_receipt.sms": "suma: ¡Gracias por viajar con nosotros! Aquí tienes tu recibo por tu viaje de {{ minutes}} minutos con {{ vendor_name }}: {{ trip_link }}",
   "offerings/2022_12_pilot_confirmation.sms": "¡Gracias por tu pedido! Nos pondremos en contacto antes del 12 de diciembre con información sobre la recogida. Responda a este texto o envíe un correo electrónico a info@mysuma.org si necesita ayuda. - suma",
   "offerings/2023_07_pilot_confirmation.sms": "¡Gracias por tu orden! Ve a este enlace cuando estés en el mercado para reclamar tus cupones: {{ app_url }}/unclaimed-orders - suma",
   "offerings/2023_12_holiday_confirmation.sms": "suma: ¡Gracias por tu pedido! Nos pondremos en contacto antes del 15 de diciembre con información sobre la recogida. Responde HELP si tienes preguntas. Responda STOP para cancelar la suscripción.",

--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -246,6 +246,20 @@ module Suma
     Thread.current[:suma_request_now] = t
   end
 
+  # Dynamically require files using +Gem.find_files+.
+  # Skip spec files, and make sure required file paths are relative to the given root;
+  # otherwise, we'll load multiple copies of the same file, causing
+  # memory and coverage issues.
+  def self.require_files(root)
+    ext_len = -3 # '.rb'.size
+    Gem.find_files(File.join("#{root}/*.rb")).each do |path|
+      next if path.end_with?("_spec.rb")
+      index = path.rindex(root)
+      cleaned = path[index...ext_len]
+      Kernel.require cleaned
+    end
+  end
+
   def self.assert(&)
     do_assert = RACK_ENV == "test" || RACK_ENV == "development"
     return unless do_assert

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -150,7 +150,7 @@ class Suma::API::Mobility < Suma::API::V1
       member = current_member
       trip = Suma::Mobility::Trip.ongoing.where(member:).first
       merror!(409, "No ongoing trip", code: "no_active_trip") if trip.nil?
-      trip.end_trip(lat: params[:lat], lng: params[:lng])
+      trip.end_trip(lat: params[:lat], lng: params[:lng], now: current_time)
       add_current_member_header
       status 200
       present trip, with: MobilityTripEntity

--- a/lib/suma/async.rb
+++ b/lib/suma/async.rb
@@ -21,42 +21,6 @@ module Suma::Async
   require "suma/async/job_logger"
   require "suma/async/job_utils"
 
-  # Registry of all jobs that will be required when the async system is started/run.
-  JOBS = [
-    "suma/async/analytics_dispatch",
-    "suma/async/anon_proxy_destroyed_member_contact_cleanup",
-    "suma/async/deprecated_jobs",
-    "suma/async/enrollment_removal_runner",
-    "suma/async/forward_messages",
-    "suma/async/frontapp_list_sync",
-    "suma/async/frontapp_upsert_contact",
-    "suma/async/funding_transaction_processor",
-    "suma/async/gbfs_sync_enqueue",
-    "suma/async/gbfs_sync_run",
-    "suma/async/hybrid_search_reindex",
-    "suma/async/lime_trip_sync",
-    "suma/async/lime_violations_processor",
-    "suma/async/lyft_pass_trip_sync",
-    "suma/async/marketing_list_sync",
-    "suma/async/marketing_sms_broadcast_dispatch",
-    "suma/async/member_default_relations",
-    "suma/async/member_onboarding_verified_dispatch",
-    "suma/async/message_dispatched",
-    "suma/async/message_unsent_poller",
-    "suma/async/offering_schedule_fulfillment",
-    "suma/async/order_confirmation",
-    "suma/async/payment_instrument_charge_balance",
-    "suma/async/payment_instrument_expiring_notifier",
-    "suma/async/payment_instrument_expiring_scheduler",
-    "suma/async/payout_transaction_processor",
-    "suma/async/plaid_update_institutions",
-    "suma/async/process_anon_proxy_inbound_webhookdb_relays",
-    "suma/async/reset_code_create_dispatch",
-    "suma/async/reset_code_update_twilio",
-    "suma/async/signalwire_process_optouts",
-    "suma/async/stripe_refunds_backfiller",
-  ].freeze
-
   class << self
     def configure_sidekiq_server(config)
       url = Suma::Redis.fetch_url(self.sidekiq_redis_provider, self.sidekiq_redis_url)
@@ -170,7 +134,7 @@ module Suma::Async
   end
 
   def self._require_jobs
-    JOBS.each { |j| require(j) }
+    Suma.require_files("suma/async")
   end
 
   def self._setup_common

--- a/lib/suma/async/trip_receipt.rb
+++ b/lib/suma/async/trip_receipt.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "amigo/job"
+require "suma/messages/trip_receipt"
+
+class Suma::Async::TripReceipt
+  extend Amigo::Job
+
+  # Do not send receipts for trips ended more than 2 hours ago,
+  # it'd be confusing and it can easily happen during backfilling.
+  CUTOFF = 2.hours
+
+  on(/suma\.mobility\.trip\.(created|updated)/)
+
+  def _perform(event)
+    trip = self.lookup_model(Suma::Mobility::Trip, event)
+    return unless trip.ended?
+    return if trip.ended_at < CUTOFF.ago
+    # Don't bother checking for 'ended_at changed from nil' or whatever,
+    # the cutoff and idempotency is enough.
+    Suma::Idempotency.once_ever.under_key("trip-#{trip.id}-receipt") do
+      msg = Suma::Messages::TripReceipt.new(trip)
+      trip.member.message_preferences!.dispatch(msg)
+    end
+  end
+end

--- a/lib/suma/async/trip_receipt.rb
+++ b/lib/suma/async/trip_receipt.rb
@@ -16,6 +16,7 @@ class Suma::Async::TripReceipt
     trip = self.lookup_model(Suma::Mobility::Trip, event)
     return unless trip.ended?
     return if trip.ended_at < CUTOFF.ago
+    return unless trip.vendor_service.mobility_adapter.send_receipts?
     # Don't bother checking for 'ended_at changed from nil' or whatever,
     # the cutoff and idempotency is enough.
     Suma::Idempotency.once_ever.under_key("trip-#{trip.id}-receipt") do

--- a/lib/suma/messages/trip_receipt.rb
+++ b/lib/suma/messages/trip_receipt.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "suma/message/template"
+
+class Suma::Messages::TripReceipt < Suma::Message::Template
+  def self.fixtured(recipient)
+    trip = Suma::Fixtures.mobility_trip.ended.create(member: recipient)
+    tmpl = self.new(trip)
+    Suma::Fixtures.static_string.
+      message(tmpl, "sms").
+      text("test receipt (en)", es: "test receipt (es)").
+      create
+    return tmpl
+  end
+
+  def initialize(trip)
+    @trip = trip
+    super()
+  end
+
+  def template_folder = "mobility"
+  def localized? = true
+
+  def liquid_drops
+    return super.merge(
+      minutes: @trip.duration_minutes,
+      vendor_name: @trip.vendor_service.vendor.name,
+      trip_link: "#{Suma.app_url}/#{@trip.rel_app_link}",
+    )
+  end
+end

--- a/lib/suma/mobility/trip.rb
+++ b/lib/suma/mobility/trip.rb
@@ -165,6 +165,8 @@ class Suma::Mobility::Trip < Suma::Postgres::Model(:mobility_trips)
 
   def rel_admin_link = "/mobility-trip/#{self.id}"
 
+  def rel_app_link = "/trip/#{self.id}"
+
   def hybrid_search_fields
     return [
       :external_trip_id,

--- a/lib/suma/mobility/vendor_adapter.rb
+++ b/lib/suma/mobility/vendor_adapter.rb
@@ -5,6 +5,8 @@ require "suma/simple_registry"
 module Suma::Mobility::VendorAdapter
   extend Suma::SimpleRegistry
 
+  class Unsupported < StandardError; end
+
   BeginTripResult = Struct.new(:_, keyword_init: true)
   EndTripResult = Struct.new(
     :raw_result,
@@ -23,7 +25,7 @@ module Suma::Mobility::VendorAdapter
   # The adapter can set fields on the trip, which will be saved on success.
   #
   # NOTE: If this adapter is for off-platform rides (through a deeplink adapter),
-  # this method does not need to be implemented as it will not be called.
+  # raise +Unsupported+.
   #
   # @param [Suma::Mobility::Trip]
   # @return [BeginTripResult]
@@ -35,7 +37,7 @@ module Suma::Mobility::VendorAdapter
   # which will be saved on success.
   #
   # NOTE: If this adapter is for off-platform rides (through a deeplink adapter),
-  # this method does not need to be implemented as it will not be called.
+  # raise +Unsupported+.
   #
   # @param [Suma::Mobility::Trip]
   # @return [EndTripResult]
@@ -46,9 +48,15 @@ module Suma::Mobility::VendorAdapter
   # @param [true,false]
   def uses_deep_linking? = raise NotImplementedError
 
+  # True if suma should send receipts.
+  # This should be false where the underlying provider takes care of sending receipts
+  # (which usually means the provider is charging the member themselves).
+  def send_receipts? = raise NotImplementedError
+
   # Find the anonymous proxy vendor account for the member
   # that satisfies this adapter (usually this means finding one for the right vendor).
   # It is ok to return nil if the account or vendor does not exist.
+  # If this is not relevant, raise +Unsupported+.
   #
   # @return [nil,Suma::AnonProxy::VendorAccount]
   def find_anon_proxy_vendor_account(member) = raise NotImplementedError

--- a/lib/suma/mobility/vendor_adapter.rb
+++ b/lib/suma/mobility/vendor_adapter.rb
@@ -5,13 +5,11 @@ require "suma/simple_registry"
 module Suma::Mobility::VendorAdapter
   extend Suma::SimpleRegistry
 
-  BeginTripResult = Struct.new(:raw_result, keyword_init: true)
+  BeginTripResult = Struct.new(:_, keyword_init: true)
   EndTripResult = Struct.new(
     :raw_result,
     :cost,
     :undiscounted,
-    :duration_minutes,
-    :end_time,
     keyword_init: true,
   )
 
@@ -22,23 +20,36 @@ module Suma::Mobility::VendorAdapter
   end
 
   # Begin the trip with the underlying vendor.
-  # Used for MaaS and Proxy adapters. See /docs/mobility.md.
+  # The adapter can set fields on the trip, which will be saved on success.
+  #
+  # NOTE: If this adapter is for off-platform rides (through a deeplink adapter),
+  # this method does not need to be implemented as it will not be called.
+  #
   # @param [Suma::Mobility::Trip]
-  # @return [Suma::Mobility::VendorAdapter::BeginTripResult]
+  # @return [BeginTripResult]
   def begin_trip(trip) = raise NotImplementedError
-  # End a trip. See #begin_trip.
-  # Adapters used only in specific scenarios (like backfilling trips
-  # made off-platform) may take additional keyword arguments.
-  # @param [Suma::Mobility::Trip]
-  # @return [Suma::Mobility::VendorAdapter::EndTripResult]
-  def end_trip(trip, **) = raise NotImplementedError
 
-  # Should be true for Deep Link adapters. See /docs/mobility.md.
+  # End a trip using the underlying adapter.
+  # The trip will have its end fields set.
+  # This method can set fields (including end fields) on the trip,
+  # which will be saved on success.
+  #
+  # NOTE: If this adapter is for off-platform rides (through a deeplink adapter),
+  # this method does not need to be implemented as it will not be called.
+  #
+  # @param [Suma::Mobility::Trip]
+  # @return [EndTripResult]
+  def end_trip(trip) = raise NotImplementedError
+
+  # Should be true for Deep Link adapters.
+  #
   # @param [true,false]
   def uses_deep_linking? = raise NotImplementedError
+
   # Find the anonymous proxy vendor account for the member
   # that satisfies this adapter (usually this means finding one for the right vendor).
   # It is ok to return nil if the account or vendor does not exist.
+  #
   # @return [nil,Suma::AnonProxy::VendorAccount]
   def find_anon_proxy_vendor_account(member) = raise NotImplementedError
 

--- a/lib/suma/mobility/vendor_adapter/fake.rb
+++ b/lib/suma/mobility/vendor_adapter/fake.rb
@@ -21,13 +21,9 @@ class Suma::Mobility::VendorAdapter::Fake
   end
 
   def end_trip(trip)
-    ended = Time.now
-    duration = (ended - trip.began_at) / 60.0
     tr = EndTripResult.new(
-      cost: trip.vendor_service_rate.calculate_total(duration),
-      undiscounted: trip.vendor_service_rate.calculate_undiscounted_total(duration),
-      end_time: ended,
-      duration_minutes: duration.to_i,
+      cost: trip.vendor_service_rate.calculate_total(trip.duration_minutes),
+      undiscounted: trip.vendor_service_rate.calculate_undiscounted_total(trip.duration_minutes),
     )
     self.class.end_trip_callback&.call(tr)
     return tr

--- a/lib/suma/mobility/vendor_adapter/fake.rb
+++ b/lib/suma/mobility/vendor_adapter/fake.rb
@@ -5,11 +5,13 @@ class Suma::Mobility::VendorAdapter::Fake
 
   class << self
     attr_accessor :uses_deep_linking,
+                  :send_receipts,
                   :find_anon_proxy_vendor_account_results,
                   :end_trip_callback
 
     def reset
       self.uses_deep_linking = nil
+      self.send_receipts = nil
       self.find_anon_proxy_vendor_account_results = []
       self.end_trip_callback = nil
     end
@@ -30,5 +32,6 @@ class Suma::Mobility::VendorAdapter::Fake
   end
 
   def uses_deep_linking? = self.class.uses_deep_linking
+  def send_receipts? = self.class.send_receipts
   def find_anon_proxy_vendor_account(*) = self.class.find_anon_proxy_vendor_account_results.shift
 end

--- a/lib/suma/mobility/vendor_adapter/internal.rb
+++ b/lib/suma/mobility/vendor_adapter/internal.rb
@@ -33,4 +33,6 @@ class Suma::Mobility::VendorAdapter::Internal
   end
 
   def uses_deep_linking? = false
+  def find_anon_proxy_vendor_account(_member) = raise Unsupported
+  def send_receipts? = true
 end

--- a/lib/suma/mobility/vendor_adapter/internal.rb
+++ b/lib/suma/mobility/vendor_adapter/internal.rb
@@ -26,13 +26,9 @@ class Suma::Mobility::VendorAdapter::Internal
   end
 
   def end_trip(trip)
-    ended = Time.now
-    duration = (ended - trip.began_at) / 60.0
     return EndTripResult.new(
-      cost: trip.vendor_service_rate.calculate_total(duration),
-      undiscounted: trip.vendor_service_rate.calculate_undiscounted_total(duration),
-      end_time: ended,
-      duration_minutes: duration.to_i,
+      cost: trip.vendor_service_rate.calculate_total(trip.duration_minutes),
+      undiscounted: trip.vendor_service_rate.calculate_undiscounted_total(trip.duration_minutes),
     )
   end
 

--- a/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
+++ b/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
@@ -14,27 +14,4 @@ class Suma::Mobility::VendorAdapter::LimeDeeplink
     account = Suma::AnonProxy::VendorAccount.where(configuration:, member:)
     return account.first
   end
-
-  def begin_trip(_trip)
-    return Suma::Mobility::VendorAdapter::BeginTripResult.new
-  end
-
-  class RideReceipt < Suma::TypedStruct
-    attr_accessor :ride_id,
-                  :vehicle_type,
-                  :started_at,
-                  :ended_at,
-                  :total,
-                  :discount,
-                  :line_items
-  end
-
-  def end_trip(_trip, receipt:)
-    return Suma::Mobility::VendorAdapter::EndTripResult.new(
-      cost: receipt.total,
-      undiscounted: receipt.discount + receipt.total,
-      end_time: receipt.ended_at,
-      duration_minutes: ((receipt.ended_at - receipt.started_at) / 60.0).to_i,
-    )
-  end
 end

--- a/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
+++ b/lib/suma/mobility/vendor_adapter/lime_deeplink.rb
@@ -5,8 +5,11 @@ require "suma/lime"
 class Suma::Mobility::VendorAdapter::LimeDeeplink
   include Suma::Mobility::VendorAdapter
 
+  def begin_trip(_trip) = raise Unsupported
+  def end_trip(_trip) = raise Unsupported
   def requires_vendor_account? = true
   def uses_deep_linking? = true
+  def send_receipts? = true
 
   def find_anon_proxy_vendor_account(member)
     vendor = Suma::Lime.deeplink_vendor

--- a/lib/suma/mobility/vendor_adapter/lime_maas.rb
+++ b/lib/suma/mobility/vendor_adapter/lime_maas.rb
@@ -49,4 +49,6 @@ class Suma::Mobility::VendorAdapter::LimeMaas
   end
 
   def uses_deep_linking? = false
+  def send_receipts? = true
+  def find_anon_proxy_vendor_account(_member) = nil
 end

--- a/lib/suma/mobility/vendor_adapter/lyft_deeplink.rb
+++ b/lib/suma/mobility/vendor_adapter/lyft_deeplink.rb
@@ -15,25 +15,4 @@ class Suma::Mobility::VendorAdapter::LyftDeeplink
     account = Suma::AnonProxy::VendorAccount.where(configuration:, member:)
     return account.first
   end
-
-  def begin_trip(_trip)
-    return Suma::Mobility::VendorAdapter::BeginTripResult.new
-  end
-
-  def end_trip(_trip, ride_response:)
-    start_time = Time.at(ride_response.fetch("ride").fetch("pickup").fetch("timestamp_ms") / 1000)
-    end_time = Time.at(ride_response.fetch("ride").fetch("dropoff").fetch("timestamp_ms") / 1000)
-    total_h = ride_response.fetch("money")
-    zero_money = Money.new(0, total_h.fetch("currency"))
-    total_of_non_promo_items = ride_response.fetch("ride").fetch("line_items").sum(zero_money) do |li|
-      next 0 if li.fetch("title") == "Promo applied"
-      Money.new(li.fetch("money").fetch("amount"), li.fetch("money").fetch("currency"))
-    end
-    return Suma::Mobility::VendorAdapter::EndTripResult.new(
-      cost: total_of_non_promo_items,
-      undiscounted: Money.new(total_h.fetch("amount"), total_h.fetch("currency")),
-      end_time:,
-      duration_minutes: (end_time - start_time).minutes,
-    )
-  end
 end

--- a/lib/suma/mobility/vendor_adapter/lyft_deeplink.rb
+++ b/lib/suma/mobility/vendor_adapter/lyft_deeplink.rb
@@ -5,8 +5,11 @@ require "suma/lyft"
 class Suma::Mobility::VendorAdapter::LyftDeeplink
   include Suma::Mobility::VendorAdapter
 
+  def begin_trip(_trip) = raise Unsupported
+  def end_trip(_trip) = raise Unsupported
   def requires_vendor_account? = false
   def uses_deep_linking? = true
+  def send_receipts? = false
 
   protected def deeplink_vendor = Suma::Lyft.deeplink_vendor
 

--- a/lib/suma/spec_helpers/testing_helpers.rb
+++ b/lib/suma/spec_helpers/testing_helpers.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "suma/async"
+require "suma/spec_helpers"
+
+module Suma::SpecHelpers::TestingHelpers
+  def assert_implemented
+    # Go the long way around to avoid the rspect warning of on_potential_false_positives
+    yield
+  rescue WebMock::NetConnectNotAllowedError
+    # We expect we'll hit these at times because we aren't doing faking for these behavior tests.
+    nil
+  rescue StandardError => e
+    # NotImplementedError are not StandardError so will bubble up.
+    # This should not happen, as it's a programming error.
+    raise e if e.inspect.include?("ArgumentError: wrong number of arguments")
+    # Other errors are probably ok to ignore.
+  end
+end

--- a/spec/data/lime/complete_trip.json
+++ b/spec/data/lime/complete_trip.json
@@ -17,8 +17,8 @@
         "timestamp": 1528768782421
       }
     },
-    "started_at": "2021-01-19T10:15:20:12Z",
-    "updated_at": "2021-01-19T10:17:20:12Z",
+    "started_at": "2021-01-19T10:15:20Z",
+    "updated_at": "2021-01-19T10:17:20Z",
     "route": {
       "type": "FeatureCollection",
       "features": [
@@ -50,14 +50,14 @@
         }
       ]
     },
-    "duration_seconds": 5,
+    "duration_seconds": 300,
     "distance_meters": 50,
     "rate_plan_id": "e94d66ab-775e-44af-a8a5-1caa9ece92de",
     "vehicle_id": "TICTM376DA74U",
     "vehicle_attributes": {
       "battery_percentage": 10
     },
-    "completed_at": "2022-01-19T10:17:20:12Z",
+    "completed_at": "2021-01-19T10:20:20Z",
     "end_location": {
       "type": "Feature",
       "geometry": {

--- a/spec/data/lime/start_trip.json
+++ b/spec/data/lime/start_trip.json
@@ -17,8 +17,8 @@
         "timestamp": 1528768782421
       }
     },
-    "started_at": "2021-01-19T10:15:20:12Z",
-    "updated_at": "2021-01-19T10:17:20:12Z",
+    "started_at": "2021-01-19T10:15:20Z",
+    "updated_at": "2021-01-19T10:17:20Z",
     "route": {
       "type": "FeatureCollection",
       "features": [

--- a/spec/suma/lime/maas_client_spec.rb
+++ b/spec/suma/lime/maas_client_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Suma::Lime::MaasClient, :db do
       at: Time.at(1_681_238_802.098),
     )
     expect(req).to have_been_made
-    expect(resp).to include("data" => hash_including("completed_at" => "2022-01-19T10:17:20:12Z"))
+    expect(resp).to include("data" => hash_including("completed_at" => "2021-01-19T10:20:20Z"))
   end
 
   it "gets trip details" do

--- a/spec/suma/member_spec.rb
+++ b/spec/suma/member_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Suma::Member", :db do
       expect(c.ongoing_trip).to be_nil
       t = Suma::Fixtures.mobility_trip.ongoing.create(member: c)
       expect(c.refresh.ongoing_trip).to be === t
-      t.end_trip(lat: 1, lng: 2)
+      t.end_trip(lat: 1, lng: 2, now: Time.now)
       expect(c.refresh.ongoing_trip).to be_nil
     end
 

--- a/spec/suma/messages_spec.rb
+++ b/spec/suma/messages_spec.rb
@@ -2,6 +2,7 @@
 
 require "suma/messages/order_confirmation"
 require "suma/messages/single_value"
+require "suma/messages/trip_receipt"
 require "suma/messages/verification"
 
 RSpec.describe Suma::Messages, :db do
@@ -22,6 +23,14 @@ RSpec.describe Suma::Messages, :db do
       tmpl.dispatch(r, transport: :sms)
       expect(r.message_deliveries).to have_length(1)
       expect(r.message_deliveries.first.bodies.first.content).to eq("test single value (en)")
+    end
+
+    it "can fixture TripReceipt" do
+      tmpl = Suma::Messages::TripReceipt.fixtured(r)
+      tmpl.language = "en"
+      tmpl.dispatch(r, transport: :sms)
+      expect(r.message_deliveries).to have_length(1)
+      expect(r.message_deliveries.first.bodies.first.content).to eq("test receipt (en)")
     end
 
     it "can fixture Verification" do

--- a/spec/suma/mobility/behaviors.rb
+++ b/spec/suma/mobility/behaviors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rspec"
+require "suma/spec_helpers/testing_helpers"
+
+RSpec.shared_examples "a mobility vendor adapter" do
+  include Suma::SpecHelpers::TestingHelpers
+
+  let(:adapter) { described_class.new }
+
+  it "implements all abstract methods" do
+    assert_implemented { adapter.begin_trip(Suma::Fixtures.mobility_trip.instance) }
+    assert_implemented { adapter.end_trip(Suma::Fixtures.mobility_trip.instance) }
+    assert_implemented { adapter.uses_deep_linking? }
+    assert_implemented { adapter.send_receipts? }
+    assert_implemented { adapter.find_anon_proxy_vendor_account(Suma::Fixtures.member.create) }
+  end
+end

--- a/spec/suma/mobility/vendor_adapter/biketown_deeplink_spec.rb
+++ b/spec/suma/mobility/vendor_adapter/biketown_deeplink_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require "suma/mobility/behaviors"
+
 RSpec.describe Suma::Mobility::VendorAdapter::BiketownDeeplink, :db, reset_configuration: Suma::Biketown do
   let(:instance) { described_class.new }
   let(:member) { Suma::Fixtures.member.onboarding_verified.create }
   let(:vendor_service) { Suma::Fixtures.vendor_service.mobility.create }
   let(:vendor) { vendor_service.vendor }
+
+  it_behaves_like "a mobility vendor adapter"
 
   it "returns the vendor account for the Biketown vendor, if one exists" do
     Suma::Biketown.deeplink_vendor_slug = vendor.slug

--- a/spec/suma/mobility/vendor_adapter/fake_spec.rb
+++ b/spec/suma/mobility/vendor_adapter/fake_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "suma/mobility/behaviors"
+require "suma/mobility/vendor_adapter"
+
+RSpec.describe Suma::Mobility::VendorAdapter::Fake, :db do
+  let(:ad) { described_class.new }
+
+  it_behaves_like "a mobility vendor adapter"
+
+  it "can start and stop" do
+    trip = Suma::Mobility::Trip.new
+    expect(ad.begin_trip(trip)).to be_a(described_class::BeginTripResult)
+    expect(trip).to have_attributes(external_trip_id: be_present)
+    trip = Suma::Fixtures.mobility_trip.ended.create
+    expect(ad.end_trip(trip)).to be_a(described_class::EndTripResult)
+  end
+
+  it "returns the charge based on the rate" do
+    rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
+    t = Time.now
+    trip = Suma::Fixtures.mobility_trip.create(began_at: t, vendor_service_rate: rate)
+    trip.ended_at = t + 5.minutes
+    endres = ad.end_trip(trip)
+    expect(endres).to have_attributes(
+      cost: cost("$2"),
+      undiscounted: cost("$4"),
+    )
+  end
+end

--- a/spec/suma/mobility/vendor_adapter/internal_spec.rb
+++ b/spec/suma/mobility/vendor_adapter/internal_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "suma/mobility/behaviors"
+require "suma/mobility/vendor_adapter"
+
+RSpec.describe Suma::Mobility::VendorAdapter::Internal, :db do
+  let(:ad) { described_class.new }
+
+  it_behaves_like "a mobility vendor adapter"
+
+  it "does not use deep linking" do
+    expect(ad).to_not be_uses_deep_linking
+  end
+
+  it "can start and stop" do
+    trip = Suma::Mobility::Trip.new
+    expect(ad.begin_trip(trip)).to be_a(described_class::BeginTripResult)
+    expect(trip).to have_attributes(external_trip_id: be_present)
+    trip = Suma::Fixtures.mobility_trip.ended.create
+    expect(ad.end_trip(trip)).to be_a(described_class::EndTripResult)
+  end
+
+  it "returns the charge based on the rate" do
+    rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
+    t = Time.now
+    trip = Suma::Fixtures.mobility_trip.create(began_at: t, vendor_service_rate: rate)
+    trip.ended_at = t + 5.minutes
+    endres = ad.end_trip(trip)
+    expect(endres).to have_attributes(
+      cost: cost("$2"),
+      undiscounted: cost("$4"),
+    )
+  end
+end

--- a/spec/suma/mobility/vendor_adapter/lime_deeplink_spec.rb
+++ b/spec/suma/mobility/vendor_adapter/lime_deeplink_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require "suma/mobility/behaviors"
+
 RSpec.describe Suma::Mobility::VendorAdapter::LimeDeeplink, :db, reset_configuration: Suma::Lime do
   let(:instance) { described_class.new }
   let(:member) { Suma::Fixtures.member.onboarding_verified.create }
   let(:vendor_service) { Suma::Fixtures.vendor_service.mobility.create }
   let(:vendor) { vendor_service.vendor }
+
+  it_behaves_like "a mobility vendor adapter"
 
   it "returns the vendor account for the lime vendor, if one exists" do
     Suma::Lime.deeplink_vendor_slug = vendor.slug

--- a/spec/suma/mobility/vendor_adapter/lime_maas_spec.rb
+++ b/spec/suma/mobility/vendor_adapter/lime_maas_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "suma/mobility/behaviors"
 require "suma/mobility/vendor_adapter"
 
 RSpec.describe Suma::Mobility::VendorAdapter::LimeMaas, :db do
@@ -17,6 +18,8 @@ RSpec.describe Suma::Mobility::VendorAdapter::LimeMaas, :db do
       began_at: trip_started,
     )
   end
+
+  it_behaves_like "a mobility vendor adapter"
 
   it "registers an unregistered user when starting a trip" do
     register_user_req = stub_request(:post, "https://external-api.lime.bike/api/maas/v1/partner/users").

--- a/spec/suma/mobility/vendor_adapter/lyft_deeplink_spec.rb
+++ b/spec/suma/mobility/vendor_adapter/lyft_deeplink_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require "suma/mobility/behaviors"
+
 RSpec.describe Suma::Mobility::VendorAdapter::LyftDeeplink, :db, reset_configuration: Suma::Lyft do
   let(:instance) { described_class.new }
   let(:member) { Suma::Fixtures.member.onboarding_verified.create }
   let(:vendor_service) { Suma::Fixtures.vendor_service.mobility.create }
   let(:vendor) { vendor_service.vendor }
+
+  it_behaves_like "a mobility vendor adapter"
 
   it "returns the vendor account for the lyft vendor, if one exists" do
     Suma::Lyft.deeplink_vendor_slug = vendor.slug

--- a/spec/suma/mobility/vendor_adapter_spec.rb
+++ b/spec/suma/mobility/vendor_adapter_spec.rb
@@ -20,58 +20,6 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
     end
   end
 
-  describe "Fake" do
-    let(:ad) { Suma::Mobility::VendorAdapter::Fake.new }
-
-    it "can start and stop" do
-      trip = Suma::Mobility::Trip.new
-      expect(ad.begin_trip(trip)).to be_a(described_class::BeginTripResult)
-      expect(trip).to have_attributes(external_trip_id: be_present)
-      trip = Suma::Fixtures.mobility_trip.ended.create
-      expect(ad.end_trip(trip)).to be_a(described_class::EndTripResult)
-    end
-
-    it "returns the charge based on the rate" do
-      rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
-      t = Time.now
-      trip = Suma::Fixtures.mobility_trip.create(began_at: t, vendor_service_rate: rate)
-      trip.ended_at = t + 5.minutes
-      endres = ad.end_trip(trip)
-      expect(endres).to have_attributes(
-        cost: cost("$2"),
-        undiscounted: cost("$4"),
-      )
-    end
-  end
-
-  describe "Internal" do
-    let(:ad) { Suma::Mobility::VendorAdapter::Internal.new }
-
-    it "does not use deep linking" do
-      expect(ad).to_not be_uses_deep_linking
-    end
-
-    it "can start and stop" do
-      trip = Suma::Mobility::Trip.new
-      expect(ad.begin_trip(trip)).to be_a(described_class::BeginTripResult)
-      expect(trip).to have_attributes(external_trip_id: be_present)
-      trip = Suma::Fixtures.mobility_trip.ended.create
-      expect(ad.end_trip(trip)).to be_a(described_class::EndTripResult)
-    end
-
-    it "returns the charge based on the rate" do
-      rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
-      t = Time.now
-      trip = Suma::Fixtures.mobility_trip.create(began_at: t, vendor_service_rate: rate)
-      trip.ended_at = t + 5.minutes
-      endres = ad.end_trip(trip)
-      expect(endres).to have_attributes(
-        cost: cost("$2"),
-        undiscounted: cost("$4"),
-      )
-    end
-  end
-
   describe "vendor_account_requires_attention" do
     let(:member) { Suma::Fixtures.member.create }
     let(:ad) { Suma::Mobility::VendorAdapter::Fake.new }

--- a/spec/suma/mobility/vendor_adapter_spec.rb
+++ b/spec/suma/mobility/vendor_adapter_spec.rb
@@ -27,18 +27,19 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
       trip = Suma::Mobility::Trip.new
       expect(ad.begin_trip(trip)).to be_a(described_class::BeginTripResult)
       expect(trip).to have_attributes(external_trip_id: be_present)
-      trip = Suma::Fixtures.mobility_trip.ongoing.create
+      trip = Suma::Fixtures.mobility_trip.ended.create
       expect(ad.end_trip(trip)).to be_a(described_class::EndTripResult)
     end
 
     it "returns the charge based on the rate" do
       rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
-      trip = Suma::Fixtures.mobility_trip.create(began_at: 5.minutes.ago, vendor_service_rate: rate)
+      t = Time.now
+      trip = Suma::Fixtures.mobility_trip.create(began_at: t, vendor_service_rate: rate)
+      trip.ended_at = t + 5.minutes
       endres = ad.end_trip(trip)
       expect(endres).to have_attributes(
         cost: cost("$2"),
         undiscounted: cost("$4"),
-        duration_minutes: 5,
       )
     end
   end
@@ -54,18 +55,19 @@ RSpec.describe Suma::Mobility::VendorAdapter, :db do
       trip = Suma::Mobility::Trip.new
       expect(ad.begin_trip(trip)).to be_a(described_class::BeginTripResult)
       expect(trip).to have_attributes(external_trip_id: be_present)
-      trip = Suma::Fixtures.mobility_trip.ongoing.create
+      trip = Suma::Fixtures.mobility_trip.ended.create
       expect(ad.end_trip(trip)).to be_a(described_class::EndTripResult)
     end
 
     it "returns the charge based on the rate" do
       rate = Suma::Fixtures.vendor_service_rate.surcharge(100).unit_amount(20).discounted_by(0.5).create
-      trip = Suma::Fixtures.mobility_trip.create(began_at: 5.minutes.ago, vendor_service_rate: rate)
+      t = Time.now
+      trip = Suma::Fixtures.mobility_trip.create(began_at: t, vendor_service_rate: rate)
+      trip.ended_at = t + 5.minutes
       endres = ad.end_trip(trip)
       expect(endres).to have_attributes(
         cost: cost("$2"),
         undiscounted: cost("$4"),
-        duration_minutes: 5,
       )
     end
   end

--- a/spec/suma/payment/behaviors.rb
+++ b/spec/suma/payment/behaviors.rb
@@ -1,49 +1,34 @@
 # frozen_string_literal: true
 
 require "rspec"
+require "suma/spec_helpers/testing_helpers"
 
 RSpec.shared_examples "a funding transaction payment strategy" do
-  it "implements all abstract methods", on_potential_false_positives: :nothing do
-    run_error_test { strategy.short_name }
-    run_error_test { strategy.admin_details_typed }
-    run_error_test { strategy.check_validity }
-    run_error_test { strategy.supports_refunds? }
-    run_error_test { strategy.originating_instrument_label }
-    run_error_test { strategy.ready_to_collect_funds? }
-    run_error_test { strategy.collect_funds }
-    run_error_test { strategy.funds_cleared? }
-    run_error_test { strategy.funds_canceled? }
-  end
+  include Suma::SpecHelpers::TestingHelpers
 
-  def run_error_test
-    # Go the long way around to avoid the rspect warning of on_potential_false_positives
-    yield
-  rescue WebMock::NetConnectNotAllowedError
-    # We expect we'll hit these at times because we aren't doing faking for these behavior tests.
-    nil
-  rescue StandardError => e
-    expect(e).to_not be_a(NotImplementedError)
+  it "implements all abstract methods" do
+    assert_implemented { strategy.short_name }
+    assert_implemented { strategy.admin_details_typed }
+    assert_implemented { strategy.check_validity }
+    assert_implemented { strategy.supports_refunds? }
+    assert_implemented { strategy.originating_instrument_label }
+    assert_implemented { strategy.ready_to_collect_funds? }
+    assert_implemented { strategy.collect_funds }
+    assert_implemented { strategy.funds_cleared? }
+    assert_implemented { strategy.funds_canceled? }
   end
 end
 
 RSpec.shared_examples "a payout transaction payment strategy" do
-  it "implements all abstract methods", on_potential_false_positives: :nothing do
-    run_error_test { strategy.short_name }
-    run_error_test { strategy.admin_details_typed }
-    run_error_test { strategy.check_validity }
-    run_error_test { strategy.ready_to_send_funds? }
-    run_error_test { strategy.send_funds }
-    run_error_test { strategy.funds_settled? }
-  end
+  include Suma::SpecHelpers::TestingHelpers
 
-  def run_error_test
-    # Go the long way around to avoid the rspect warning of on_potential_false_positives
-    yield
-  rescue WebMock::NetConnectNotAllowedError
-    # We expect we'll hit these at times because we aren't doing faking for these behavior tests.
-    nil
-  rescue StandardError => e
-    expect(e).to_not be_a(NotImplementedError)
+  it "implements all abstract methods" do
+    assert_implemented { strategy.short_name }
+    assert_implemented { strategy.admin_details_typed }
+    assert_implemented { strategy.check_validity }
+    assert_implemented { strategy.ready_to_send_funds? }
+    assert_implemented { strategy.send_funds }
+    assert_implemented { strategy.funds_settled? }
   end
 end
 

--- a/spec/suma/payment/fake_strategy_spec.rb
+++ b/spec/suma/payment/fake_strategy_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Suma::Payment::FakeStrategy", :db do
     let(:xaction) { Suma::Fixtures.funding_transaction.with_fake_strategy.create }
 
     it "ignores webmock errors" do
-      run_error_test { Suma::Http.get("/fakeurl", logger: nil, timeout: nil) }
+      assert_implemented { Suma::Http.get("/fakeurl", logger: nil, timeout: nil) }
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe "Suma::Payment::FakeStrategy", :db do
     let(:xaction) { Suma::Fixtures.payout_transaction.with_fake_strategy.create }
 
     it "ignores webmock errors" do
-      run_error_test { Suma::Http.get("/fakeurl", logger: nil, timeout: nil) }
+      assert_implemented { Suma::Http.get("/fakeurl", logger: nil, timeout: nil) }
     end
   end
 

--- a/spec/suma/spec_helpers/testing_helpers_spec.rb
+++ b/spec/suma/spec_helpers/testing_helpers_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "suma/spec_helpers/testing_helpers"
+
+RSpec.describe Suma::SpecHelpers::TestingHelpers do
+  include Suma::SpecHelpers::TestingHelpers
+
+  describe "assert_implemented" do
+    include Suma::SpecHelpers::TestingHelpers
+
+    def foo(_x) = nil
+
+    it "raises for NotImplemented and Argument errors" do
+      assert_implemented { 1 }
+      assert_implemented { HTTParty.get("/") }
+      assert_implemented { 1 / 0 }
+      assert_implemented { raise "hi" }
+
+      expect do
+        # noinspection RubyArgCount
+        assert_implemented { foo(1, 2) }
+      end.to raise_error(ArgumentError)
+
+      expect do
+        assert_implemented { raise NotImplementedError }
+      end.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/suma_spec.rb
+++ b/spec/suma_spec.rb
@@ -305,4 +305,20 @@ RSpec.describe Suma do
       expect(z1.object_id).to_not eq(eu1.object_id)
     end
   end
+
+  describe "require_files" do
+    it "finds relevant files and passes them to require as rooted in the input path" do
+      expect(Gem).to receive(:find_files).with("suma/spec_helpers/*.rb").
+        and_return([
+                     "/Users/me/programming/suma/spec/suma/spec_helpers/postgres_spec.rb",
+                     "/Users/me/programming/suma/lib/suma/spec_helpers/async.rb",
+                     "/Users/me/programming/suma/spec/suma/spec_helpers/service_spec.rb",
+                     "/Users/me/programming/suma/lib/suma/spec_helpers/i18n.rb",
+                   ])
+      expect(Kernel).to receive(:require).with("suma/spec_helpers/async")
+      expect(Kernel).to receive(:require).with("suma/spec_helpers/i18n")
+
+      Suma.require_files("suma/spec_helpers")
+    end
+  end
 end


### PR DESCRIPTION
Send an SMS receipt on trip completed

---

Async: Dynamically require jobs, no more registry

---

Overhaul trip lifecycle management

How we did begin/end trip logic was pretty confusing.
It was initially based on MaaS style behavior,
but now we have primarily deeplinking.

This finds a good solution for both,
with far fewer conflicts (ie, it's clear what code is
responsible for setting what field).