### PR TITLE
Resources with no programs are inaccessible

### DIFF
--- a/adminapp/src/components/Programs.jsx
+++ b/adminapp/src/components/Programs.jsx
@@ -49,7 +49,7 @@ export default function Programs({
       // Show a chip if there are no programs.
       displayables.push({
         key: 0,
-        label: "* Resource has no programs. All members and organizations can access it.",
+        label: "* Resource has no programs. No one can access it.",
         variant: "outlined",
         color: "success",
       });

--- a/lib/suma/program.rb
+++ b/lib/suma/program.rb
@@ -11,6 +11,16 @@ class Suma::Program < Suma::Postgres::Model(:programs)
   include Suma::HasActivityAudit
   include Suma::Image::SingleAssociatedMixin
 
+  # True if +Suma::Program::Has+ types should be available to everyone when they have no programs (value of +true+),
+  # or available to no one until they are associated with a program (value of +false+).
+  #
+  # This value is +true+ when running tests, because otherwise we need to create a program to link
+  # every fixtured object to a member being tested.
+  #
+  # Since programs are designed to be orthogonal to the components they're providing access to,
+  # this makes tests and concepts messy. But it's a safer default outside of tests.
+  UNPROGRAMMED_ACCESSIBLE = Suma.test?
+
   plugin :hybrid_search
   plugin :timestamps
   plugin :tstzrange_fields, :period

--- a/lib/suma/program/has.rb
+++ b/lib/suma/program/has.rb
@@ -25,12 +25,12 @@ module Suma::Program::Has
 
   module DatasetMethods
     def eligible_to(member, as_of:)
-      # Include all rows that have no programs
-      unconstrained = Sequel.~(programs: Suma::Program.dataset)
-      ds = self.where(
-        unconstrained |
-        Sequel[program_enrollments: member.combined_program_enrollments_dataset.active(as_of:)],
-      )
+      cond = Sequel[program_enrollments: member.combined_program_enrollments_dataset.active(as_of:)]
+      if Suma::Program::UNPROGRAMMED_ACCESSIBLE
+        # Include all rows that have no programs
+        cond |= Sequel.~(programs: Suma::Program.dataset)
+      end
+      ds = self.where(cond)
       return ds
     end
   end

--- a/spec/suma/commerce/offering_spec.rb
+++ b/spec/suma/commerce/offering_spec.rb
@@ -77,39 +77,6 @@ RSpec.describe "Suma::Commerce::Offering", :db do
       expect(described_class.available_at(5.days.ago).all).to be_empty
       expect(described_class.available_at(5.days.from_now).all).to be_empty
     end
-
-    it "can find offerings eligible to a member based on programs" do
-      as_of = Time.now
-      mem_no_constraints = Suma::Fixtures.member.create
-      member_in_program = Suma::Fixtures.member.create
-      member_unapproved = Suma::Fixtures.member.create
-      member_unenrolled = Suma::Fixtures.member.create
-
-      program = Suma::Fixtures.program.create
-      Suma::Fixtures.program_enrollment(member: member_in_program, program:).create
-      Suma::Fixtures.program_enrollment(member: member_unapproved, program:).unapproved.create
-      Suma::Fixtures.program_enrollment(member: member_unenrolled, program:).unenrolled.create
-
-      no_program = Suma::Fixtures.offering.create
-      with_program = Suma::Fixtures.offering.with_programs(program).create
-
-      expect(described_class.eligible_to(mem_no_constraints, as_of:).all).to have_same_ids_as(no_program)
-      expect(described_class.eligible_to(member_in_program, as_of:).all).to have_same_ids_as(
-        no_program,
-        with_program,
-      )
-      expect(described_class.eligible_to(member_unapproved, as_of:).all).to have_same_ids_as(no_program)
-      expect(described_class.eligible_to(member_unenrolled, as_of:).all).to have_same_ids_as(no_program)
-
-      # Test the instance methods
-      expect(no_program).to be_eligible_to(mem_no_constraints, as_of:)
-      expect(no_program).to be_eligible_to(member_in_program, as_of:)
-      expect(no_program).to be_eligible_to(member_unapproved, as_of:)
-
-      expect(with_program).to_not be_eligible_to(mem_no_constraints, as_of:)
-      expect(with_program).to be_eligible_to(member_in_program, as_of:)
-      expect(with_program).to_not be_eligible_to(member_unapproved, as_of:)
-    end
   end
 
   describe "#begin_order_fulfillment" do

--- a/spec/suma/program/has_spec.rb
+++ b/spec/suma/program/has_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Suma::Program::Has, :db do
+  describe "datasets" do
+    it "can find instances eligible to a member based on programs" do
+      as_of = Time.now
+      mem_no_constraints = Suma::Fixtures.member.create
+      member_in_program = Suma::Fixtures.member.create
+      member_unapproved = Suma::Fixtures.member.create
+      member_unenrolled = Suma::Fixtures.member.create
+
+      program = Suma::Fixtures.program.create
+      Suma::Fixtures.program_enrollment(member: member_in_program, program:).create
+      Suma::Fixtures.program_enrollment(member: member_unapproved, program:).unapproved.create
+      Suma::Fixtures.program_enrollment(member: member_unenrolled, program:).unenrolled.create
+
+      no_program = Suma::Fixtures.offering.create
+      with_program = Suma::Fixtures.offering.with_programs(program).create
+
+      expect(Suma::Commerce::Offering.eligible_to(mem_no_constraints, as_of:).all).to have_same_ids_as(no_program)
+      expect(Suma::Commerce::Offering.eligible_to(member_in_program, as_of:).all).to have_same_ids_as(
+        no_program,
+        with_program,
+      )
+      expect(Suma::Commerce::Offering.eligible_to(member_unapproved, as_of:).all).to have_same_ids_as(no_program)
+      expect(Suma::Commerce::Offering.eligible_to(member_unenrolled, as_of:).all).to have_same_ids_as(no_program)
+
+      # Test the instance methods
+      expect(no_program).to be_eligible_to(mem_no_constraints, as_of:)
+      expect(no_program).to be_eligible_to(member_in_program, as_of:)
+      expect(no_program).to be_eligible_to(member_unapproved, as_of:)
+
+      expect(with_program).to_not be_eligible_to(mem_no_constraints, as_of:)
+      expect(with_program).to be_eligible_to(member_in_program, as_of:)
+      expect(with_program).to_not be_eligible_to(member_unapproved, as_of:)
+    end
+
+    it "does not include unconstrained instances if UNPROGRAMMED_ACCESSIBLE is false" do
+      as_of = Time.now
+      mem_no_constraints = Suma::Fixtures.member.create
+      member_in_program = Suma::Fixtures.member.create
+
+      program = Suma::Fixtures.program.create
+      Suma::Fixtures.program_enrollment(member: member_in_program, program:).create
+
+      no_program = Suma::Fixtures.offering.create
+      with_program = Suma::Fixtures.offering.with_programs(program).create
+
+      expect(Suma::Commerce::Offering.eligible_to(mem_no_constraints, as_of:).all).to have_same_ids_as(
+        no_program,
+      )
+      expect(Suma::Commerce::Offering.eligible_to(member_in_program, as_of:).all).to have_same_ids_as(
+        no_program,
+        with_program,
+      )
+      expect(no_program).to be_eligible_to(mem_no_constraints, as_of:)
+      expect(no_program).to be_eligible_to(member_in_program, as_of:)
+      expect(with_program).to_not be_eligible_to(mem_no_constraints, as_of:)
+      expect(with_program).to be_eligible_to(member_in_program, as_of:)
+
+      stub_const("Suma::Program::UNPROGRAMMED_ACCESSIBLE", false)
+      expect(Suma::Commerce::Offering.eligible_to(mem_no_constraints, as_of:).all).to be_empty
+      expect(Suma::Commerce::Offering.eligible_to(member_in_program, as_of:).all).to have_same_ids_as(
+        with_program,
+      )
+      expect(no_program).to_not be_eligible_to(mem_no_constraints, as_of:)
+      expect(no_program).to_not be_eligible_to(member_in_program, as_of:)
+      expect(with_program).to_not be_eligible_to(mem_no_constraints, as_of:)
+      expect(with_program).to be_eligible_to(member_in_program, as_of:)
+    end
+  end
+end


### PR DESCRIPTION
Previously, resources that could be linked to programs (offerings, services) were available to everyone
if they were not in a program.
This was good for testing, but bad for production.

This changes the default so that:

- In testing, we preserve the previous behavior, since otherwise testing becomes a considerable pain (programs need to be created in dozens of tests, and it's easy to forget).
- Outside of testing, we do not include unlinked resources.

This should not introduce accidental issues
(or at least, no more than the current setup),
since this change does not end up provoking different code paths in any caller; they just need to use `eligible_to`, and everything will work right as for how the data is set up.