### PR TITLE
Regain account access validation fix; support absurd trip report timestamps

### DIFF
--- a/lib/suma/lime/sync_trips_from_report.rb
+++ b/lib/suma/lime/sync_trips_from_report.rb
@@ -105,5 +105,11 @@ class Suma::Lime::SyncTripsFromReport
     return r
   end
 
-  def parsetime(t) = Time.strptime("#{t} -0700", "%m/%d/%Y %I:%M %p %Z")
+  def parsetime(t)
+    date, time, ampm = t.split
+    hr, min = time.split(":")
+    # Turn 12 AM into 00 AM
+    hr = "00" if hr == "12" && ampm == "AM"
+    return Time.strptime("#{date} #{hr}:#{min} -0700", "%m/%d/%Y %H:%M %Z")
+  end
 end

--- a/webapp/src/components/ELink.jsx
+++ b/webapp/src/components/ELink.jsx
@@ -1,9 +1,10 @@
 import ExternalLink from "./ExternalLink";
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 /**
  * Use this where we don't know if we have an internal or external link.
+ *
  * If the link starts with `/` or "#" we use Link,
  * otherwise we use ExternalLink.
  *
@@ -11,16 +12,27 @@ import { Link } from "react-router-dom";
  * - If link is local, and includes ##, then replace the current URL.
  * - If the link text includes __blank__ anywhere, then use an external link with target=_blank.
  *
+ * @param {string} href Same as `to`.
+ * @param {string} to Same as react-router-dom Link#to.
+ * @param {boolean} immediate If true, navigate directly using onPointerDown,
+ *   rather than the default behavior of onClick. This allows the caller to bypass
+ *   things like blur events that happen during form validation.
+ *   This is only relevant for local URLs.
+ * @param rest
  * @returns {JSX.Element}
  * @constructor
  */
-export default function ELink({ href, to, ...rest }) {
+export default function ELink({ href, to, immediate, ...rest }) {
+  const navigate = useNavigate();
   const u = href || to || "";
   if (u.includes("__blank__")) {
     const clean = u.replace("__blank__", "");
     return <ExternalLink href={clean} {...rest} />;
   }
   if (u.startsWith("/") || u.startsWith("#")) {
+    if (immediate) {
+      rest = { onPointerDown: (e) => navigate(e.target.attributes.href.value), ...rest };
+    }
     if (u.includes("##")) {
       return <Link to={u.replace("##", "#")} replace {...rest} />;
     }

--- a/webapp/src/components/SumaMarkdown.jsx
+++ b/webapp/src/components/SumaMarkdown.jsx
@@ -3,14 +3,22 @@ import ELink from "./ELink";
 import Markdown from "markdown-to-jsx";
 import React from "react";
 
-export default function SumaMarkdown({ options, overrides, children }) {
-  overrides = {
+/**
+ * Render Markdown with Suma components and options.
+ * @param {object} options Passed to Markdown, with exceptions listed here.
+ * @param {object} options.overrides Merged on top of the default overrides,
+ *   which include a Copyable component and custom link.
+ * @param children
+ */
+export default function SumaMarkdown({ options, children }) {
+  const { overrides, ...rest } = options;
+  const combinedOverrides = {
     a: { component: MdLink },
     Copyable: { component: Copyable, props: { inline: true } },
     ...overrides,
   };
-  options = { overrides, ...options };
-  return <Markdown options={options}>{children || ""}</Markdown>;
+  const mdopts = { overrides: combinedOverrides, ...rest };
+  return <Markdown options={mdopts}>{children || ""}</Markdown>;
 }
 
 // Ignore 'node' because we replace it with ELink

--- a/webapp/src/pages/Start.jsx
+++ b/webapp/src/pages/Start.jsx
@@ -1,12 +1,12 @@
 import api from "../api";
 import FormButtons from "../components/FormButtons";
-import FormControlGroup from "../components/FormControlGroup";
 import FormError from "../components/FormError";
+import PhoneInput from "../components/PhoneInput.jsx";
 import SignupAgreement from "../components/SignupAgreement";
+import { MdLink } from "../components/SumaMarkdown.jsx";
 import { t } from "../localization";
 import useI18n from "../localization/useI18n";
 import { dayjs } from "../modules/dayConfig";
-import { maskPhoneNumber } from "../modules/maskPhoneNumber";
 import { Logger } from "../shared/logger";
 import useToggle from "../shared/react/useToggle";
 import { extractErrorCode, extractLocalizedError, useError } from "../state/useError";
@@ -34,8 +34,7 @@ export default function Start() {
     mode: "all",
   });
 
-  const handlePhoneChange = (e) => {
-    const formattedNum = maskPhoneNumber(e.target.value);
+  const handlePhoneChange = (e, formattedNum) => {
     clearErrors();
     setValue("phone", formattedNum);
     setPhone(formattedNum);
@@ -75,22 +74,29 @@ export default function Start() {
       <h2>{t("forms.get_started")}</h2>
       <p id="phoneRequired">{t("forms.get_started_intro")}</p>
       <Form noValidate onSubmit={handleSubmit(handleSubmitForm)}>
-        <FormControlGroup
+        <PhoneInput
           className="mb-3"
-          type="tel"
           name="phone"
           label={t("forms.phone")}
-          pattern="^(\+\d{1,2}\s)?\(?\d{3}\)?[\s-]\d{3}[\s-]\d{4}$"
           register={register}
           errors={errors}
           value={phone}
           aria-describedby="phoneRequired"
-          autoComplete="tel"
           autoFocus
           required
-          onChange={handlePhoneChange}
+          onPhoneChange={handlePhoneChange}
         />
-        <p>{t("auth.phone_number_changed")}</p>
+        <p>
+          {t(
+            "auth.phone_number_changed",
+            {},
+            {
+              markdown: {
+                overrides: { a: { component: MdLink, props: { immediate: true } } },
+              },
+            }
+          )}
+        </p>
         <SignupAgreement
           checked={agreementChecked}
           onCheckedChanged={setAgreementChecked}


### PR DESCRIPTION
Webapp start: Fix validation on link click

Navigate direction on onPointerDown,
which bypasses the form validation behavior
which would cancel/pre-empt the onClick navigation.

---

Custom parsing for lime trip report dates

There is '12 AM' and '12 PM'