### PR TITLE
Pricing and eligibility fixes

### DIFF
--- a/adminapp/src/pages/VendorServiceRateForm.jsx
+++ b/adminapp/src/pages/VendorServiceRateForm.jsx
@@ -83,7 +83,7 @@ export default function VendorServiceRateForm({
             value={resource.ordinal}
             type="number"
             label="Priority/Ordinal"
-            helperText="When multiple rates for the same service are available to a member, the rate with the lowest ordinal will be used."
+            helperText="When multiple rates for the same service are available to a member, the rate with the highest ordinal will be used."
             fullWidth
             onChange={setFieldFromInput}
           />

--- a/lib/merge_heroku_env.rb
+++ b/lib/merge_heroku_env.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "yajl"
+
 module MergeHerokuEnv
   def self.merge(env=ENV)
     if (heroku_app = env.fetch("MERGE_HEROKU_ENV", nil))

--- a/lib/suma/api/mobility.rb
+++ b/lib/suma/api/mobility.rb
@@ -10,17 +10,14 @@ class Suma::API::Mobility < Suma::API::V1
 
   resource :mobility do
     helpers do
-      def fetch_pricings(ds)
-        return ds.
-            compress.
-            where(vendor_service: Suma::Vendor::Service.dataset.available_at(current_time)).
-            fetch_eligible_to(current_member, as_of: current_time)
+      def fetch_pricings(pricing_id: nil)
+        dataset = Suma::Program::Pricing.where(id: pricing_id) if pricing_id
+        rows = Suma::Program::Pricing.fetch_eligible_to(current_member, as_of: current_time, dataset:)
+        return rows
       end
 
       def find_pricing_and_vehicles(provider_id, **criteria)
-        pricing = fetch_pricings(
-          Suma::Program::Pricing.where(Sequel[:program_pricings][:id] => provider_id),
-        ).first
+        pricing = fetch_pricings(pricing_id: provider_id).first
         return nil, [] if pricing.nil?
         matches = Suma::Mobility::Vehicle.where(criteria).where(
           vendor_service_id: pricing.vendor_service_id,
@@ -41,7 +38,8 @@ class Suma::API::Mobility < Suma::API::V1
       max_lat, max_lng = params[:ne]
       ds = Suma::Mobility::Vehicle.search(min_lat:, min_lng:, max_lat:, max_lng:)
       ds = ds.where(vehicle_type: params[:types]) if params.key?(:types)
-      pricings_by_service_id = fetch_pricings(Suma::Program::Pricing).index_by(&:vendor_service_id)
+      # The highest-ordinal rate for a service will be last, so that is what will be selected.
+      pricings_by_service_id = fetch_pricings.index_by(&:vendor_service_id)
       ds = ds.where(vendor_service_id: pricings_by_service_id.keys)
       ds = ds.order(:id)
       program_pricings = []

--- a/lib/suma/lime/sync_trips_from_report.rb
+++ b/lib/suma/lime/sync_trips_from_report.rb
@@ -24,8 +24,9 @@ class Suma::Lime::SyncTripsFromReport
   COST_TO_SUMA = "COST_TO_SUMA"
   LIME_ACCESS_COST = "LIME_ACCESS_COST"
 
-  def initialize(cutoff: DEFAULT_CUTOFF)
+  def initialize(cutoff: DEFAULT_CUTOFF, now: Time.now)
     @cutoff = cutoff
+    @now = now
   end
 
   def row_iterator = Suma::Webhookdb::RowIterator.new("lime/synctripsreport/pk")
@@ -165,11 +166,18 @@ class Suma::Lime::SyncTripsFromReport
   def parse_trip_from_row(row, user_email:)
     registration = Suma::AnonProxy::VendorAccountRegistration.find!(external_program_id: user_email)
     vendor_config = registration.account.configuration
-    program = Suma::Enumerable.one!(vendor_config.programs)
-    pricing = Suma::Enumerable.one!(program.pricings)
+    member = registration.account.member
+    pricing = Suma::Program::Pricing.
+      fetch_eligible_to(
+        member,
+        as_of: @now,
+        dataset: Suma::Program::Pricing.where(program: vendor_config.programs_dataset),
+      ).first
+    raise Suma::InvalidPrecondition, "No pricing found for #{vendor_config.inspect}" if pricing.nil?
+    program = pricing.program
     receipt = self.parse_row_to_receipt(row, rate: pricing.vendor_service_rate)
     receipt.trip.set(
-      member: registration.account.member,
+      member:,
       vendor_service: pricing.vendor_service,
       vendor_service_rate: pricing.vendor_service_rate,
     )

--- a/lib/suma/program/pricing.rb
+++ b/lib/suma/program/pricing.rb
@@ -12,16 +12,17 @@ class Suma::Program::Pricing < Suma::Postgres::Model(:program_pricings)
   many_to_one :vendor_service, class: "Suma::Vendor::Service"
   many_to_one :vendor_service_rate, class: "Suma::Vendor::ServiceRate"
 
-  dataset_module do
-    # Limit the result such that the same vendor service is not repeated.
-    # The row chosen from among duplicates is the row with the lowest vendor service rate ordinal.
-    def compress
-      ds = self.
-        distinct(:vendor_service_id).
-        association_join(:vendor_service_rate).
-        reselect.
-        order(:vendor_service_id, Sequel[:vendor_service_rate][:ordinal], Sequel[:vendor_service_rate][:id])
-      return ds
+  class << self
+    # Fetch the program pricings available to the member.
+    # The result is sorted by vendor service rate ordinal, higher-first.
+    # This means that if there are multiple rates for the same service,
+    # the first one that appears should take precedence.
+    def fetch_eligible_to(member, as_of:, dataset: nil)
+      ds = dataset || self.dataset
+      ds = ds.where(vendor_service: Suma::Vendor::Service.dataset.available_at(as_of))
+      rows = ds.fetch_eligible_to(member, as_of:)
+      rows.sort_by! { |pri| pri.vendor_service_rate.ordinal }
+      return rows
     end
   end
 

--- a/spec/suma/api/mobility_spec.rb
+++ b/spec/suma/api/mobility_spec.rb
@@ -40,31 +40,6 @@ RSpec.describe Suma::API::Mobility, :db do
         )
     end
 
-    it "is limited to vendor services active and available to the user" do
-      program = vendor_service.program_pricings.first.program
-      attr = Suma::Fixtures.eligibility_attribute.create
-      Suma::Fixtures.eligibility_requirement.attribute(attr).of(program).create
-
-      vehicle_fac.loc(20, 120).escooter.create
-
-      get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
-
-      expect(last_response).to have_status(200)
-      expect(last_response_json_body).to_not include(:escooter, :ebike)
-
-      Suma::Fixtures.eligibility_assignment.create(member:, attribute: attr)
-      get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
-
-      expect(last_response).to have_status(200)
-      expect(last_response).to have_json_body.that_includes(escooter: have_length(1))
-
-      vendor_service.update(period_end: 2.days.ago)
-      get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
-
-      expect(last_response).to have_status(200)
-      expect(last_response_json_body).to_not include(:escooter, :ebike)
-    end
-
     it "handles coordinate precision" do
       vehicle_fac.loc(-0.5, 100).escooter.create
 
@@ -213,6 +188,66 @@ RSpec.describe Suma::API::Mobility, :db do
               include(o: [32, -24]),
             ),
           )
+      end
+    end
+
+    describe "providers and rates" do
+      it "is limited to vendor services active and available to the user" do
+        pricing = vendor_service.program_pricings.first
+        program = pricing.program
+        attr = Suma::Fixtures.eligibility_attribute.create
+        Suma::Fixtures.eligibility_requirement.attribute(attr).of(program).create
+        vehicle_fac.loc(20, 120).escooter.create
+
+        get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
+
+        expect(last_response).to have_status(200)
+        expect(last_response_json_body).to include(providers: [])
+
+        Suma::Fixtures.eligibility_assignment.create(member:, attribute: attr)
+        get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
+
+        expect(last_response).to have_status(200)
+        expect(last_response_json_body).to include(providers: have_same_ids_as(pricing))
+
+        vendor_service.update(period_end: 2.days.ago)
+        get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
+
+        expect(last_response).to have_status(200)
+        expect(last_response_json_body).to include(providers: [])
+      end
+
+      it "collapses multiple pricings for the same service (see #fetch_pricings)" do
+        vendor_service.program_pricings_dataset.delete
+
+        # Create 5 pricings:
+        # - Index 0 and 4 are for programs ineligible to the user, so shouldn't be considered.
+        # - Indexes 1 and 3 are eligible, but their vendor service rate ordinals are low.
+        # - Index 2 is eligible, and should be chosen for its high rate ordinal.
+        pricing_fac = Suma::Fixtures.program_pricing(vendor_service:)
+        rate_fac = Suma::Fixtures.vendor_service_rate
+        pricing1 = pricing_fac.create(vendor_service_rate: rate_fac.create(surcharge_cents: 10))
+        pricing2 = pricing_fac.create(vendor_service_rate: rate_fac.create(surcharge_cents: 11, ordinal: 10))
+        pricing3 = pricing_fac.create(vendor_service_rate: rate_fac.create(surcharge_cents: 12, ordinal: 30))
+        pricing4 = pricing_fac.create(vendor_service_rate: rate_fac.create(surcharge_cents: 13, ordinal: 20))
+        pricing5 = pricing_fac.create(vendor_service_rate: rate_fac.create(surcharge_cents: 14))
+
+        ineligible_attr = Suma::Fixtures.eligibility_attribute.create
+        [pricing1, pricing5].each do |pri|
+          Suma::Fixtures.eligibility_requirement.attribute(ineligible_attr).of(pri.program).create
+        end
+        eligible_attr = Suma::Fixtures.eligibility_attribute.create
+        [pricing2, pricing3, pricing4].each do |pri|
+          Suma::Fixtures.eligibility_requirement.attribute(eligible_attr).of(pri.program).create
+        end
+
+        vehicle_fac.loc(20, 120).escooter.create
+        Suma::Fixtures.eligibility_assignment.create(member:, attribute: eligible_attr)
+
+        get "/v1/mobility/map", sw: [15, 110], ne: [25, 125]
+
+        expect(last_response).to have_status(200)
+        expect(last_response_json_body).to include(providers: have_same_ids_as(pricing3))
       end
     end
 

--- a/spec/suma/lime/sync_trips_from_report_spec.rb
+++ b/spec/suma/lime/sync_trips_from_report_spec.rb
@@ -225,17 +225,6 @@ RSpec.describe Suma::Lime::SyncTripsFromReport, :db, reset_configuration: Suma::
       expect(Suma::Mobility::Trip.all).to be_empty
     end
 
-    it "errors if there is not only 1 program for the configuration, so we cannot figure out which one to use" do
-      va.configuration.add_program(Suma::Fixtures.program.create)
-      txt = <<~CSV
-        TRIP_TOKEN,CONSEQUENCE,START_TIME,END_TIME,START_LATITUDE,START_LONGITUDE,END_LATITUDE,END_LONGITUDE,REGION_NAME,USER_TOKEN,USER_EMAIL,TRIP_DURATION_MINUTES,TRIP_DISTANCE_MILES,COST_TO_SUMA,UNLOCK_COST,DURATION_COST,COST_PER_MINUTE,LIME_ACCESS_COST,STANDARD_FEE,PERCENT_DISCOUNT_RATE,REFUNDED_FLAG,,,,,,
-        RTOKEN1,,09/16/2025 12:01 AM,09/16/2025 12:43 AM,45.464916,-122.647268,45.465336,-122.647118,Portland,6TWQPKZDTVI44,m1@in.mysuma.org,15.00,0.23,$1.00,$0.50,$1.05,$0.07,$1.55,$6.88,77,N,,,,,,
-      CSV
-      expect do
-        described_class.new.run_for_report(txt)
-      end.to raise_error(/have exactly 1 item/)
-    end
-
     it "errors if the associated program does not have pricing" do
       program.pricings.first.destroy
       txt = <<~CSV
@@ -244,7 +233,17 @@ RSpec.describe Suma::Lime::SyncTripsFromReport, :db, reset_configuration: Suma::
       CSV
       expect do
         described_class.new.run_for_report(txt)
-      end.to raise_error(ArgumentError, /must have exactly 1 item/)
+      end.to raise_error(Suma::InvalidPrecondition, /No pricing found/)
+    end
+
+    it "uses the first eligible available program pricing" do
+      Suma::Fixtures.program_pricing.create(program: program)
+      txt = <<~CSV
+        TRIP_TOKEN,CONSEQUENCE,START_TIME,END_TIME,START_LATITUDE,START_LONGITUDE,END_LATITUDE,END_LONGITUDE,REGION_NAME,USER_TOKEN,USER_EMAIL,TRIP_DURATION_MINUTES,TRIP_DISTANCE_MILES,COST_TO_SUMA,UNLOCK_COST,DURATION_COST,COST_PER_MINUTE,LIME_ACCESS_COST,STANDARD_FEE,PERCENT_DISCOUNT_RATE,REFUNDED_FLAG,,,,,,
+        RTOKEN1,,09/16/2025 12:01 AM,09/16/2025 12:43 AM,45.464916,-122.647268,45.465336,-122.647118,Portland,6TWQPKZDTVI44,m1@in.mysuma.org,15.00,0.23,$1.00,$0.50,$1.05,$0.07,$1.55,$6.88,77,N,,,,,,
+      CSV
+      described_class.new.run_for_report(txt)
+      expect(Suma::Mobility::Trip.all).to contain_exactly(have_attributes(vendor_service_rate: be === rate))
     end
 
     it "does not create duplicate trips" do

--- a/spec/suma/program/pricing_spec.rb
+++ b/spec/suma/program/pricing_spec.rb
@@ -14,18 +14,4 @@ RSpec.describe "Suma::Program::Pricing", :db do
     expect(pvs.vendor_service.program_pricings).to contain_exactly(be === pvs)
     expect(pvs.vendor_service_rate.program_pricings).to contain_exactly(be === pvs)
   end
-
-  describe "datasets" do
-    it "can compress program pricing so that the pricing with the lowest rate ordinal is chosen" do
-      vs = Suma::Fixtures.vendor_service.create
-      rate2 = Suma::Fixtures.vendor_service_rate.create(ordinal: 2)
-      rate1 = Suma::Fixtures.vendor_service_rate.create(ordinal: 1)
-      rate3 = Suma::Fixtures.vendor_service_rate.create(ordinal: 3)
-      pp2 = Suma::Fixtures.program_pricing.create(vendor_service: vs, vendor_service_rate: rate2)
-      pp1 = Suma::Fixtures.program_pricing.create(vendor_service: vs, vendor_service_rate: rate1)
-      pp3 = Suma::Fixtures.program_pricing.create(vendor_service: vs, vendor_service_rate: rate3)
-
-      expect(described_class.compress.all).to have_same_ids_as(pp1)
-    end
-  end
 end


### PR DESCRIPTION
Lime trip sync: Use the first pricing available

---

Mobility fix: select correct pricing

We were collapsing multiple programs for the same vendor service
BEFORE filtering eligibility; we need to collapse it after.

Also switch to using the highest-rate ordinal since that is
easier to modify for precedence.

---

Add missing require to early-loaded lib