### PR TITLE
Support and fixes to prepare for registration links

### DIFF
--- a/adminapp/src/components/AdminLink.jsx
+++ b/adminapp/src/components/AdminLink.jsx
@@ -8,7 +8,7 @@ const AdminLink = React.forwardRef(function AdminLink(
   ref
 ) {
   const [newTo, isRelative] = relativeLink(model?.adminLink || href || to || "");
-  const newProps = { ...rest, ref, children: children || model?.id };
+  const newProps = { ...rest, ref, children: children || model?.label || model?.id };
   if (isRelative) {
     newProps.component = RouterLink;
     newProps.to = newTo;

--- a/adminapp/src/components/SafeDateTimePicker.jsx
+++ b/adminapp/src/components/SafeDateTimePicker.jsx
@@ -22,7 +22,7 @@ export default function SafeDateTimePicker({ value, seconds, views, sx, ...rest 
   }
   value = dayjsOrNull(value);
   if (!views.includes("seconds")) {
-    value = value?.second(0);
+    value = value?.second(0) || null;
   }
   return (
     <DateTimePicker

--- a/lib/rack/utm_capture.rb
+++ b/lib/rack/utm_capture.rb
@@ -18,9 +18,16 @@ class Rack::UtmCapture
   ].freeze
 
   COOKIE_EXPIRES = 30.days.to_i
+  DEFAULT_OPTS = {
+    params: UTM_KEYS,
+    expires: COOKIE_EXPIRES,
+  }.freeze
 
-  def initialize(app)
+  def initialize(app, opts={})
+    opts = DEFAULT_OPTS.merge(opts)
     @app = app
+    @capture_params = opts.fetch(:params).map(&:to_s)
+    @expires = opts.fetch(:expires)
   end
 
   def call(env)
@@ -38,9 +45,11 @@ class Rack::UtmCapture
   end
 
   private def extract_utm_params(req)
-    return UTM_KEYS.each_with_object({}) do |key, acc|
+    return @capture_params.each_with_object({}) do |key, acc|
       acc[key] = req.params[key] if req.params[key]
     end
+  rescue Rack::Multipart::EmptyContentError
+    nil
   end
 
   # Build Set-Cookie headers (but avoid overwriting existing cookie if not needed)
@@ -52,7 +61,7 @@ class Rack::UtmCapture
       next if existing_cookies[key] == value
 
       cookie_value = Rack::Utils.escape(value)
-      expires = Time.now + COOKIE_EXPIRES
+      expires = Time.now + @expires
 
       "#{key}=#{cookie_value}; path=/; expires=#{expires.httpdate}; SameSite=Lax"
     end

--- a/lib/suma/admin_api/eligibility_assignments.rb
+++ b/lib/suma/admin_api/eligibility_assignments.rb
@@ -9,7 +9,6 @@ class Suma::AdminAPI::EligibilityAssignments < Suma::AdminAPI::V1
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
 
-    expose :created_by, with: AuditMemberEntity
     expose :member, with: MemberEntity
     expose :organization, with: OrganizationEntity
     expose :role, with: RoleEntity

--- a/lib/suma/admin_api/eligibility_requirements.rb
+++ b/lib/suma/admin_api/eligibility_requirements.rb
@@ -9,7 +9,6 @@ class Suma::AdminAPI::EligibilityRequirements < Suma::AdminAPI::V1
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
 
-    expose :created_by, with: AuditMemberEntity
     expose :programs, with: ProgramEntity
     expose :payment_triggers, with: PaymentTriggerEntity
     expose :expression, &self.delegate_to(:expression, :serialize)

--- a/lib/suma/admin_api/entities.rb
+++ b/lib/suma/admin_api/entities.rb
@@ -54,6 +54,9 @@ module Suma::AdminAPI::Entities
       ctx.expose :updated_at, if: ->(o) { o.respond_to?(:updated_at) } do |inst|
         inst.updated_at || inst.created_at
       end
+      ctx.expose :created_by, with: AuditMemberEntity, if: ->(o) { o.respond_to?(:created_by) } do
+        inst.created_by
+      end
       # Always expose an external links array when we mix this in
       ctx.expose :external_links do |inst|
         inst.respond_to?(:external_links) ? inst.external_links.map(&:as_json) : []
@@ -99,6 +102,7 @@ module Suma::AdminAPI::Entities
 
   class AuditMemberEntity < BaseEntity
     expose :id
+    expose :admin_label, as: :label
     expose :email
     expose :name
     expose :admin_link

--- a/lib/suma/admin_api/marketing_sms_broadcasts.rb
+++ b/lib/suma/admin_api/marketing_sms_broadcasts.rb
@@ -10,7 +10,6 @@ class Suma::AdminAPI::MarketingSmsBroadcasts < Suma::AdminAPI::V1
     include Suma::AdminAPI::Entities
     include AutoExposeDetail
 
-    expose :created_by, with: MemberEntity
     expose :body, with: TranslatedTextEntity
     expose :sending_number
     expose :sending_number_formatted

--- a/lib/suma/autoscaler.rb
+++ b/lib/suma/autoscaler.rb
@@ -76,7 +76,7 @@ module Suma::Autoscaler
         log_message: "high_latency_requests",
         checker: Amigo::Autoscaler::Checkers::Chain.new(
           [
-            Amigo::Autoscaler::Checkers::WebLatency.new(redis: Suma::Redis.cache),
+            Amigo::Autoscaler::Checkers::WebLatency.new(redis: Suma::Redis.durable),
             self.puma_pool_usage_checker,
           ],
         ),
@@ -90,7 +90,7 @@ module Suma::Autoscaler
     end
 
     def puma_pool_usage_checker
-      @puma_pool_usage_checker ||= Amigo::Autoscaler::Checkers::PumaPoolUsage.new(redis: Suma::Redis.cache)
+      @puma_pool_usage_checker ||= Amigo::Autoscaler::Checkers::PumaPoolUsage.new(redis: Suma::Redis.durable)
       return @puma_pool_usage_checker
     end
 

--- a/lib/suma/organization/membership/verification.rb
+++ b/lib/suma/organization/membership/verification.rb
@@ -95,6 +95,7 @@ class Suma::Organization::Membership::Verification < Suma::Postgres::Model(:orga
       transition in_progress: :ineligible
     end
     event :approve do
+      transition created: :verified, if: :can_approve?
       transition in_progress: :verified, if: :can_approve?
     end
     after_transition on: :approve, do: :approve!

--- a/lib/suma/redis.rb
+++ b/lib/suma/redis.rb
@@ -8,7 +8,12 @@ module Suma::Redis
   include Appydays::Configurable
 
   class << self
+    # Redis client for caching only.
+    # Cache servers may evict old keys under pressure.
     attr_accessor :cache
+    # Redis client for durable use.
+    # Keys are not evicted under pressure (Sidekiq job servers are like this).
+    attr_accessor :durable
 
     def conn_params(url, **kw)
       params = {url:}
@@ -48,8 +53,12 @@ module Suma::Redis
     setting :cache_url, ""
     setting :cache_url_provider, "REDIS_URL"
 
+    setting :durable_url, ""
+    setting :durable_url_provider, "REDIS_URL"
+
     after_configured do
       self.cache = self.create_pool(self.cache_url_provider, self.cache_url)
+      self.durable = self.create_pool(self.durable_url_provider, self.durable_url)
     end
   end
 

--- a/lib/suma/service/entities.rb
+++ b/lib/suma/service/entities.rb
@@ -16,6 +16,16 @@ module Suma::Service::Entities
     expose :end
   end
 
+  # Render the TranslatedText instance using the current language.
+  # See i18n system for explanation of the format (include hidden formatter flag).
+  # @param [Suma::TranslatedText,nil] txt
+  # @return [String]
+  def self.render_translated_text(txt)
+    s = txt&.string || ""
+    i18n_fmt = Suma::I18n::Formatter.for(s)
+    return "#{i18n_fmt.flag}#{s}"
+  end
+
   class Base < Grape::Entity
     def current_time = self.options.fetch(:env).fetch("now")
     def current_member = self.options.fetch(:env).fetch("yosoy").authenticated_object!.public_user
@@ -60,9 +70,7 @@ module Suma::Service::Entities
     def self.expose_translated(name, *, &block)
       self.expose(name, *) do |instance, options|
         txt = self.evaluate_exposure(name, block, instance, options)
-        s = txt&.string || ""
-        i18n_fmt = Suma::I18n::Formatter.for(s)
-        "#{i18n_fmt.flag}#{s}"
+        Suma::Service::Entities.render_translated_text(txt)
       end
     end
   end

--- a/lib/suma/service/helpers.rb
+++ b/lib/suma/service/helpers.rb
@@ -88,8 +88,8 @@ module Suma::Service::Helpers
     yosoy.set_authenticated_object(session)
   end
 
-  def unauthenticated!
-    yosoy.unauthenticated!
+  def unauthenticated!(**kw)
+    yosoy.unauthenticated!(**kw)
   end
 
   def check_role_access!(member, rw, key)

--- a/lib/suma/webhookdb.rb
+++ b/lib/suma/webhookdb.rb
@@ -45,16 +45,16 @@ module Suma::Webhookdb
     end
 
     def each(dataset, &)
-      last_synced_pk = Suma::Redis.cache.with { |c| c.call("GET", @pk_key) }.to_i
+      last_synced_pk = Suma::Redis.durable.with { |c| c.call("GET", @pk_key) }.to_i
       rows = dataset.order(:pk).where { pk > last_synced_pk }.all
       return 0 if rows.empty?
       rows.each(&)
-      Suma::Redis.cache.with { |c| c.call("SET", @pk_key, rows.last.fetch(:pk).to_s) }
+      Suma::Redis.durable.with { |c| c.call("SET", @pk_key, rows.last.fetch(:pk).to_s) }
       return rows.size
     end
 
     def reset
-      Suma::Redis.cache.with { |c| c.call("DEL", @pk_key) }
+      Suma::Redis.durable.with { |c| c.call("DEL", @pk_key) }
     end
   end
 end

--- a/lib/suma/yosoy.rb
+++ b/lib/suma/yosoy.rb
@@ -91,7 +91,7 @@ class Suma::Yosoy
           extra = {}
           reason = result
       else
-          return result
+          return self._inject_headers(proxy, result)
       end
       unless self.respond_to?(reason)
         msg = "#{self.class.name || 'Your custom Yosoy middleware'} does not support the thrown reason :#{reason}. " \
@@ -100,7 +100,16 @@ class Suma::Yosoy
         raise UnhandledReason, msg
       end
       response = self.send(reason, **extra)
+      response = self._inject_headers(proxy, response)
       return response
+    end
+
+    def _inject_headers(proxy, resp)
+      return resp unless resp.is_a?(Array) && resp.length == 3
+      return resp if proxy.headers.empty?
+      st, hd, bod = resp
+      hd = (hd || {}).merge(proxy.headers)
+      return st, hd, bod
     end
 
     def response(status_code, extra={})
@@ -127,6 +136,7 @@ class Suma::Yosoy
       @auth_ran = false
       @auth_obj = nil
       @last_access_set = false
+      @headers = {}
     end
 
     def rack_session
@@ -137,6 +147,7 @@ class Suma::Yosoy
       @auth_ran = false
       @auth_obj = nil
       @last_access_set = false
+      @headers.clear
     end
 
     # @return [nil,Object]
@@ -165,6 +176,13 @@ class Suma::Yosoy
 
     def unauthenticated!(**kw)
       self.throw!(:unauthenticated, **kw)
+    end
+
+    attr_reader :headers
+
+    # Set the headers included in an error response.
+    def set_header(h, v)
+      @headers[h] = v
     end
 
     def throw!(reason, **kw)

--- a/spec/rack/utm_capture_spec.rb
+++ b/spec/rack/utm_capture_spec.rb
@@ -53,4 +53,10 @@ RSpec.describe Rack::UtmCapture do
     mw = described_class.new(app)
     expect(mw.call(Rack::MockRequest.env_for("/a"))).to eq([200, {}, []])
   end
+
+  it "does not add the header if there are no utm params (POST)" do
+    app = ->(_env) { [200, {}, []] }
+    mw = described_class.new(app)
+    expect(mw.call(Rack::MockRequest.env_for("/a"))).to eq([200, {}, []])
+  end
 end

--- a/spec/suma/yosoy_spec.rb
+++ b/spec/suma/yosoy_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe Suma::Yosoy do
     )
   end
 
+  it "can set headers" do
+    mw = create_mw do |env|
+      yosoy = env.fetch("yosoytest")
+      yosoy.set_header("x", "y")
+      throw(:yosoytest)
+    end
+
+    st, h, _b = mw.call(req)
+    expect(st).to eq(401)
+    expect(h).to include("x" => "y")
+  end
+
   it "can use an explicit throw with a symbol" do
     mw = create_mw do |*|
       throw(:yosoytest, :custom_reason)


### PR DESCRIPTION
See #919 for original work.

---

Redis: Add 'durable' instance connection

---

yosoy: Support setting headers

Callers may need to set additional headers in
auth responses. Ended up not using it in the end,
but it may be useful for later.

---

Entity: Add render_translated_text helper

---

Verifications: Add created->verified transition

No reason to disallow this.

---

AdminAPI: Expose created_by automatically

---

UtmCapture: Support expires params

Instead of hard-coding to 30 days,
support passing in a custom expiration time.

Also support passing in the params,
and try to handle an empty body error we see sometimes.

---

DateTimePicker: Avoid turning null into undefined

If the value passed to SafeDateTimePicker is null,
and seconds are not used, it'd turn into undefined
(`value?.second(0)`). Instead, add `|| null`.

---

AdminLink: Use label if available