### PR TITLE
Fixes to payment system

### DIFF
--- a/lib/suma/async/ledger_balance_charger.rb
+++ b/lib/suma/async/ledger_balance_charger.rb
@@ -2,7 +2,7 @@
 
 require "amigo/scheduled_job"
 
-require "suma/payment/platform_status"
+require "suma/payment/ledger/balance_charger"
 
 # Each morning, try charging ledgers with non-zero balances.
 class Suma::Async::LedgerBalanceCharger
@@ -15,23 +15,7 @@ class Suma::Async::LedgerBalanceCharger
   splay 60.seconds
 
   def _perform
-    unbalanced = Suma::Payment::PlatformStatus.new.unbalanced_ledgers_dataset.all
-    unbalanced.select! { |led| led.balance.negative? }
-    unbalanced.select! { |led| led === led.account.cash_ledger }
-    unbalanced.each do |led|
-      instrument = led.account.member.default_payment_instrument
-      next unless instrument
-      begin
-        Suma::Payment::FundingTransaction.start_new(
-          led.account,
-          amount: -led.balance,
-          instrument:,
-          memo: Suma::I18n::StaticString.find_text("backend", "funding_transaction_charge_balance"),
-          collect: :must,
-        )
-      rescue StateMachines::Sequel::FailedTransition
-        nil
-      end
-    end
+    return if Suma::Payment.charge_negative_balances_disabled
+    Suma::Payment::Ledger::BalanceCharger.new.run
   end
 end

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -60,6 +60,8 @@ module Suma::Payment
     # How many hours to charge the outstanding balance of members with negative ledgers.
     setting :charge_negative_balances_hour_interval, 3
 
+    setting :charge_negative_balances_disabled, false
+
     # Disable methods if not set up with the relevant partners/processors.
     setting :supported_methods, ["bank_account", "card"], convert: lambda(&:split)
   end

--- a/lib/suma/payment/funding_transaction.rb
+++ b/lib/suma/payment/funding_transaction.rb
@@ -112,7 +112,7 @@ class Suma::Payment::FundingTransaction < Suma::Postgres::Model(:payment_funding
       if strategy.nil?
         strategy = @fake_strategy.respond_to?(:call) ? @fake_strategy.call : @fake_strategy
       end
-      self.db.transaction do
+      self.db.transaction(savepoint: true) do
         platform_ledger = Suma::Payment.ensure_cash_ledger(Suma::Payment::Account.lookup_platform_account)
         if strategy.nil?
           raise ArgumentError, ":instrument must be provided if :strategy is not" if instrument.nil?

--- a/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
+++ b/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
@@ -74,18 +74,21 @@ class Suma::Payment::FundingTransaction::StripeCardStrategy <
     begin
       charge = Stripe::Charge.capture(self.charge_id)
     rescue Stripe::InvalidRequestError => e
-      if e.code == "charge_already_refunded"
+      case e.code
+        when "charge_already_captured"
+        # This is fine; just re-fetch it.
+        when "charge_already_refunded"
         # It's possible for the charge to be refunded before it is captured,
         # in which case, we can pull a fresh version of the charge and see it's refunded,
         # and the funding transaction will be canceled.
-      elsif e.code == "charge_expired_for_capture"
-        # This should never happen, but it could if the payment processor is offline
-        # for a long time. We always want to know about these,
-        # but we'll probably just move them to 'canceled' manually.
-        self.flag_for_review
-        return false
+        when "charge_expired_for_capture"
+          # This should never happen, but it could if the payment processor is offline
+          # for a long time. We always want to know about these,
+          # but we'll probably just move them to 'canceled' manually.
+          self.flag_for_review
+          return false
       else
-        raise e
+          raise e
       end
       charge = Stripe::Charge.retrieve(self.charge_id)
     end

--- a/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
+++ b/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
@@ -52,7 +52,7 @@ class Suma::Payment::FundingTransaction::StripeCardStrategy <
         amount: self.funding_transaction.amount,
         memo: "#{Suma.operator_name} charge",
         idempotency_key: Suma.idempotency_key(self, "charge"),
-        params: {capture: false},
+        params: {capture: true},
         metadata: {suma_funding_transaction_id: self.funding_transaction.id},
       )
     rescue Stripe::CardError => e

--- a/lib/suma/payment/ledger/balance_charger.rb
+++ b/lib/suma/payment/ledger/balance_charger.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "suma/payment/ledger"
+require "suma/payment/platform_status"
+
+class Suma::Payment::Ledger::BalanceCharger
+  def run
+    self.find_ledgers.each do |ledger|
+      self.charge_ledger(ledger)
+    end
+  end
+
+  # Find all the unbalanced ledgers in the system
+  def find_ledgers
+    unbalanced = Suma::Payment::PlatformStatus.new.unbalanced_ledgers_dataset.all
+    unbalanced.select! { |led| led.balance.negative? }
+    unbalanced.select! { |led| led === led.account.cash_ledger }
+    return unbalanced
+  end
+
+  # Find the instruments to charge the owner of the ledger,
+  # in their preferred order.
+  def instruments_to_charge(ledger)
+    default = ledger.account.member.default_payment_instrument
+    return [] if default.nil?
+    others = ledger.account.member.public_payment_instruments.
+      select { |pi| pi.status == :ok }.
+      reject { |pi| pi === default }
+    return [default] + others
+  end
+
+  # Charge the ledger its balance, using the instruments to charge.
+  # Return the first successful funding transaction, or nil if none worked.
+  def charge_ledger(ledger)
+    instruments = instruments_to_charge(ledger)
+    instruments.each do |instrument|
+      fx = self.charge_instrument(ledger, instrument)
+      return fx if fx
+    end
+    return nil
+  end
+
+  # Return the funding transaction, or nil if it failed.
+  def charge_instrument(ledger, instrument)
+    ledger.db.transaction do
+      ledger.account.lock!
+      ledger.refresh
+      return nil unless ledger.balance.negative?
+      begin
+        fx = Suma::Payment::FundingTransaction.start_new(
+          ledger.account,
+          amount: -ledger.balance,
+          instrument:,
+          memo: self.memo,
+          collect: :must,
+        )
+        return fx
+      rescue StateMachines::Sequel::FailedTransition, Suma::Payment::FundingTransaction::CollectFundsFailed
+        # We don't care about failures here; we'll try again later.
+        # We can report long-term negative balances separately.
+        return nil
+      end
+    end
+  end
+
+  def memo = @memo ||= Suma::I18n::StaticString.find_text("backend", "funding_transaction_charge_balance")
+end

--- a/lib/suma/payment/payout_transaction.rb
+++ b/lib/suma/payment/payout_transaction.rb
@@ -87,7 +87,7 @@ class Suma::Payment::PayoutTransaction < Suma::Postgres::Model(:payment_payout_t
     #   (like exists in `FundingStrategy::start_new`).
     # @return [Suma::Payment::PayoutTransaction]
     def start_new(payment_account, amount:, strategy:, memo:)
-      self.db.transaction do
+      self.db.transaction(savepoint: true) do
         platform_ledger = Suma::Payment.ensure_cash_ledger(Suma::Payment::Account.lookup_platform_account)
         strategy.check_validity!
         xaction = self.new(

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -399,62 +399,33 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
   end
 
   describe "LedgerBalanceCharger" do
-    let(:negative_member_account) {}
-    let(:positive_member_account) { Suma::Fixtures.member.create.payment_account! }
-    let(:ba) { Suma::Fixtures.bank_account.verified.member(member).create }
+    let(:platform_account) { Suma::Payment::Account.lookup_platform_account }
+    let(:platform_cash) { platform_account.ensure_cash_ledger }
 
     it "charges cash ledgers with negative balance", :i18n do
-      food = Suma::Fixtures.vendor_service_category.create(name: "food")
-
-      platform_account = Suma::Payment::Account.lookup_platform_account
-      platform_cash = platform_account.ensure_cash_ledger
-      platform_food = platform_account.ensure_ledger_with_category(food)
-
-      account1 = Suma::Fixtures.payment_account.create
-      account2 = Suma::Fixtures.payment_account.create
-      account3 = Suma::Fixtures.payment_account.create
-      account4 = Suma::Fixtures.payment_account.create
-      [account1, account2, account3, account4].each do |account|
-        Suma::Fixtures.card.member(account.member).create
-      end
-
-      positive_cash = account1.ensure_cash_ledger
-      negative_cash = account2.ensure_cash_ledger
-      zero_cash = account3.ensure_cash_ledger
-      negative_food = account4.ensure_ledger_with_category(food)
-
-      Suma::Fixtures.book_transaction.from(platform_cash).to(positive_cash).create(amount: money("$5"))
-      Suma::Fixtures.book_transaction.from(negative_cash).to(platform_cash).create(amount: money("$50"))
-      Suma::Fixtures.book_transaction.from(negative_food).to(platform_food).create(amount: money("$500"))
+      account = Suma::Fixtures.payment_account.create
+      Suma::Fixtures.card.member(account.member).create
+      cash = account.ensure_cash_ledger
+      Suma::Fixtures.book_transaction.from(cash).to(platform_cash).create(amount: money("$5"))
 
       Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.ready) do
         Suma::Async::LedgerBalanceCharger.new.perform(true)
       end
 
       expect(Suma::Payment::FundingTransaction.all).to contain_exactly(
-        have_attributes(amount: cost("$50"), originating_payment_account: be === negative_cash.account),
+        have_attributes(amount: cost("$5"), originating_payment_account: be === account),
       )
     end
 
-    it "skips failed collections and those without a default instrument", :i18n do
-      platform_account = Suma::Payment::Account.lookup_platform_account
-      platform_cash = platform_account.ensure_cash_ledger
+    it "noops if not enabled", :i18n, reset_configuration: Suma::Payment do
+      Suma::Payment.charge_negative_balances_disabled = true
 
-      account1 = Suma::Fixtures.payment_account.create
-      Suma::Fixtures.card.member(account1.member).create
-      account2 = Suma::Fixtures.payment_account.create
+      account = Suma::Fixtures.payment_account.create
+      Suma::Fixtures.card.member(account.member).create
+      cash = account.ensure_cash_ledger
+      Suma::Fixtures.book_transaction.from(cash).to(platform_cash).create(amount: money("$5"))
 
-      # Skipped because the strategy is not ready
-      account1_cash = account1.ensure_cash_ledger
-      # Skipped since account2 has no instrument
-      account2_cash = account2.ensure_cash_ledger
-
-      Suma::Fixtures.book_transaction.from(account1_cash).to(platform_cash).create(amount: money("$10"))
-      Suma::Fixtures.book_transaction.from(account2_cash).to(platform_cash).create(amount: money("$20"))
-
-      Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.not_ready) do
-        Suma::Async::LedgerBalanceCharger.new.perform(true)
-      end
+      Suma::Async::LedgerBalanceCharger.new.perform(true)
 
       expect(Suma::Payment::FundingTransaction.all).to be_empty
     end

--- a/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
+++ b/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
@@ -109,6 +109,23 @@ RSpec.describe "Suma::Payment::FundingTransaction::StripeCardStrategy", :db do
       expect(strategy).to be_funds_canceled
     end
 
+    it "re-fetches the charge if Stripe says it has been captured" do
+      strategy.charge_json = {"id" => "ch_123", "captured" => false}
+
+      error_body = load_fixture_data("stripe/charge_error")
+      error_body["error"]["code"] = "charge_already_captured"
+      capture_req = stub_request(:post, "https://api.stripe.com/v1/charges/ch_123/capture").
+        to_return(fixture_response(body: error_body.to_json, status: 400))
+
+      get_req = stub_request(:get, "https://api.stripe.com/v1/charges/ch_123").
+        to_return(fixture_response("stripe/charge"))
+
+      expect(strategy).to be_funds_cleared
+      expect(capture_req).to have_been_made
+      expect(get_req).to have_been_made
+      expect(strategy.charge_json.as_json).to include("status" => "succeeded")
+    end
+
     it "puts a payment into needs_review if it has expired" do
       strategy.charge_json = {"id" => "ch_123", "captured" => false}
 

--- a/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
+++ b/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe "Suma::Payment::FundingTransaction::StripeCardStrategy", :db do
   end
 
   describe "collect_funds" do
-    it "preauthorizes a change" do
+    it "captures a change" do
       xaction.update(amount_cents: 2000)
       req = stub_request(:post, "https://api.stripe.com/v1/charges").
         with(
           body: hash_including(
             "amount" => "2000",
-            "capture" => "false",
+            "capture" => "true",
             "currency" => "USD",
             "customer" => member.stripe.customer_id,
             "description" => "suma charge",

--- a/spec/suma/payment/funding_transaction_spec.rb
+++ b/spec/suma/payment/funding_transaction_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe "Suma::Payment::FundingTransaction", :db, reset_configuration: Su
       )
     end
 
+    it "rolls back on error" do
+      strategy = Suma::Payment::FakeStrategy.create.not_ready
+      strategy.db.transaction do
+        described_class.start_new(pacct, amount:, memo:, strategy:, collect: :must)
+      rescue StateMachines::Sequel::FailedTransition
+        expect(Suma::Payment::FundingTransaction.all).to be_empty
+      end
+    end
+
     describe "collect param" do
       describe "false" do
         it "does not try to collect", :i18n do

--- a/spec/suma/payment/ledger/balance_charger_spec.rb
+++ b/spec/suma/payment/ledger/balance_charger_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "suma/payment/ledger/balance_charger"
+
+RSpec.describe Suma::Payment::Ledger::BalanceCharger, :db do
+  let(:negative_member_account) {}
+  let(:positive_member_account) { Suma::Fixtures.member.create.payment_account! }
+  let(:ba) { Suma::Fixtures.bank_account.verified.member(member).create }
+  let(:platform_account) { Suma::Payment::Account.lookup_platform_account }
+  let(:platform_cash) { platform_account.ensure_cash_ledger }
+
+  it "charges cash ledgers with negative balance", :i18n do
+    food = Suma::Fixtures.vendor_service_category.create(name: "food")
+
+    platform_food = platform_account.ensure_ledger_with_category(food)
+
+    account1 = Suma::Fixtures.payment_account.create
+    account2 = Suma::Fixtures.payment_account.create
+    account3 = Suma::Fixtures.payment_account.create
+    account4 = Suma::Fixtures.payment_account.create
+    [account1, account2, account3, account4].each do |account|
+      Suma::Fixtures.card.member(account.member).create
+    end
+
+    positive_cash = account1.ensure_cash_ledger
+    negative_cash = account2.ensure_cash_ledger
+    zero_cash = account3.ensure_cash_ledger
+    negative_food = account4.ensure_ledger_with_category(food)
+
+    Suma::Fixtures.book_transaction.from(platform_cash).to(positive_cash).create(amount: money("$5"))
+    Suma::Fixtures.book_transaction.from(negative_cash).to(platform_cash).create(amount: money("$50"))
+    Suma::Fixtures.book_transaction.from(negative_food).to(platform_food).create(amount: money("$500"))
+
+    Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.ready) do
+      described_class.new.run
+    end
+
+    expect(Suma::Payment::FundingTransaction.all).to contain_exactly(
+      have_attributes(amount: cost("$50"), originating_payment_account: be === negative_cash.account),
+    )
+  end
+
+  it "skips failed collections", :i18n do
+    account1 = Suma::Fixtures.payment_account.create
+    Suma::Fixtures.card.member(account1.member).create
+    account2 = Suma::Fixtures.payment_account.create
+
+    # Skipped because the strategy is not ready
+    account1_cash = account1.ensure_cash_ledger
+    # Skipped since account2 has no instrument
+    account2_cash = account2.ensure_cash_ledger
+
+    Suma::Fixtures.book_transaction.from(account1_cash).to(platform_cash).create(amount: money("$10"))
+    Suma::Fixtures.book_transaction.from(account2_cash).to(platform_cash).create(amount: money("$20"))
+
+    Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.not_ready) do
+      described_class.new.run
+    end
+
+    expect(Suma::Payment::FundingTransaction.all).to be_empty
+  end
+
+  it "tries all cards linked to the account, starting with the default instrument", :i18n do
+    account1 = Suma::Fixtures.payment_account.create
+    Suma::Fixtures.card.member(account1.member).create
+    account2 = Suma::Fixtures.payment_account.create
+
+    # Skipped because the strategy is not ready
+    account1_cash = account1.ensure_cash_ledger
+    # Skipped since account2 has no instrument
+    account2_cash = account2.ensure_cash_ledger
+
+    Suma::Fixtures.book_transaction.from(account1_cash).to(platform_cash).create(amount: money("$10"))
+    Suma::Fixtures.book_transaction.from(account2_cash).to(platform_cash).create(amount: money("$20"))
+
+    Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.not_ready) do
+      described_class.new.run
+    end
+
+    expect(Suma::Payment::FundingTransaction.all).to be_empty
+  end
+end


### PR DESCRIPTION
Stripe charge: Handle already-captured charges

---

Stripe: capture charges immediately

I don't know why we didn't do this in the first place;
we don't really need async capture for credit cards.

---

Move/improve Ledger::BalanceCharger

Pull it out of the async job, into its own class.

---

Use savepoints when creating funding/payout transactions