### PR TITLE
Various payment system fixes

### DIFF
--- a/adminapp/src/pages/CardDetailPage.jsx
+++ b/adminapp/src/pages/CardDetailPage.jsx
@@ -2,8 +2,11 @@ import api from "../api";
 import AdminLink from "../components/AdminLink";
 import ExternalLinks from "../components/ExternalLinks";
 import LegalEntity from "../components/LegalEntity";
+import RelatedList from "../components/RelatedList";
 import ResourceDetail, { ResourceSummary } from "../components/ResourceDetail";
 import { dayjs } from "../modules/dayConfig";
+import formatDate from "../modules/formatDate";
+import Money from "../shared/react/Money";
 import React from "react";
 
 export default function CardDetailPage() {
@@ -35,6 +38,21 @@ export default function CardDetailPage() {
           <LegalEntity legalEntity={model.legalEntity} />
         </ResourceSummary>,
         <ExternalLinks externalLinks={model.externalLinks} />,
+        <RelatedList
+          title="Funding Transactions"
+          rows={model.originatedFundingTransactions}
+          headers={["Id", "Created", "Status", "Amount", "Originating Account"]}
+          keyRowAttr="id"
+          toCells={(row) => [
+            <AdminLink key="id" model={row} />,
+            formatDate(row.createdAt),
+            row.status,
+            <Money key="amt">{row.amount}</Money>,
+            <AdminLink model={row.originatingPaymentAccount}>
+              {row.originatingPaymentAccount.displayName}
+            </AdminLink>,
+          ]}
+        />,
       ]}
     </ResourceDetail>
   );

--- a/adminapp/src/pages/MemberDetailPage.jsx
+++ b/adminapp/src/pages/MemberDetailPage.jsx
@@ -5,6 +5,7 @@ import BoolCheckmark from "../components/BoolCheckmark";
 import Copyable from "../components/Copyable";
 import DetailGrid from "../components/DetailGrid";
 import EligibilityAssignmentsRelatedList from "../components/EligibilityAssignmentsRelatedList";
+import ExternalLinks from "../components/ExternalLinks";
 import InlineEditField from "../components/InlineEditField";
 import OrganizationMembership from "../components/OrganizationMembership";
 import PaymentAccountRelatedLists from "../components/PaymentAccountRelatedLists";
@@ -156,6 +157,7 @@ export default function MemberDetailPage() {
               />
             </ResourceSummary>
           ),
+          <ExternalLinks externalLinks={model.externalLinks} />,
           <Notes notes={model.notes} model={model} setModel={setModel} />,
           <OrganizationMemberships
             memberships={model.organizationMemberships}

--- a/db/migrations/109_missing_card_strategy_index.rb
+++ b/db/migrations/109_missing_card_strategy_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:payment_funding_transaction_stripe_card_strategies) do
+      add_index :originating_card_id
+    end
+  end
+end

--- a/lib/suma/admin_api/cards.rb
+++ b/lib/suma/admin_api/cards.rb
@@ -18,6 +18,7 @@ class Suma::AdminAPI::Cards < Suma::AdminAPI::V1
 
     expose :stripe_id
     expose :member, with: MemberEntity
+    expose :originated_funding_transactions, with: FundingTransactionEntity
   end
 
   resource :cards do

--- a/lib/suma/async/funding_transaction_processor.rb
+++ b/lib/suma/async/funding_transaction_processor.rb
@@ -19,6 +19,6 @@ class Suma::Async::FundingTransactionProcessor
   def collect(tx)
     member = tx.originating_payment_account.member
     tags = {member_id: member&.id, member_name: member&.name, funding_transaction_id: tx.id}
-    self.with_log_tags(tags) { tx.process(:collect_funds, on_failure: :review) }
+    self.with_log_tags(tags) { tx.process(:collect_funds, on_failed: :review) }
   end
 end

--- a/lib/suma/member.rb
+++ b/lib/suma/member.rb
@@ -5,6 +5,7 @@ require "bcrypt"
 require "openssl"
 
 require "suma/admin_linked"
+require "suma/external_links"
 require "suma/has_activity_audit"
 require "suma/payment/has_account"
 require "suma/postgres/model"
@@ -16,6 +17,7 @@ class Suma::Member < Suma::Postgres::Model(:members)
   include Appydays::Configurable
   include Suma::Payment::HasAccount
   include Suma::AdminLinked
+  include Suma::ExternalLinks
   include Suma::Postgres::HybridSearch
   include Suma::HasActivityAudit
 
@@ -213,6 +215,16 @@ class Suma::Member < Suma::Postgres::Model(:members)
   end
 
   def rel_admin_link = "/member/#{self.id}"
+
+  def _external_links_self
+    stripe_customer_id = self.stripe.customer_id || "abcd"
+    return [
+      stripe_customer_id && self._external_link(
+        "Stripe Customer",
+        "#{Suma::Stripe.app_url}/customers/#{stripe_customer_id}",
+      ),
+    ]
+  end
 
   def onboarded?
     return self.name.present? && self.legal_entity.address_id.present?

--- a/lib/suma/payment.rb
+++ b/lib/suma/payment.rb
@@ -44,6 +44,15 @@ module Suma::Payment
     # See also +Suma::Payment.can_use_services?+.
     setting :minimum_cash_balance_for_services_cents, 0
 
+    # Users sometimes use goods which cost a very small amount,
+    # but we're unable to charge a sufficiently small amount with our payment providers.
+    # For example, if someone takes a $0.45 scooter ride,
+    # we can't charge them through Stripoe, which requires a $0.50 minimum charge.
+    #
+    # This value is that which can basically be considered "$0" for most purposes;
+    # that is, services are available and their balance is not considered problematic.
+    setting :minimum_cash_balance_grace_cents, 0
+
     # When a member creates a funding transaction to add money to their cash ledger,
     # it must be at least this much. Be careful using too-low amounts,
     # which incur proportionally large fees.
@@ -82,6 +91,7 @@ module Suma::Payment
   class << self
     def minimum_funding_amount = Money.new(self.minimum_funding_amount_cents)
     def minimum_cash_balance_for_services = Money.new(self.minimum_cash_balance_for_services_cents)
+    def minimum_cash_balance_grace = Money.new(self.minimum_cash_balance_grace_cents)
 
     # Return true if +service_usage_prohibited_reason+ is nil.
     def can_use_services?(payment_account, now: Time.now)
@@ -104,11 +114,15 @@ module Suma::Payment
       ledger = payment_account.cash_ledger!
       # We're below the minimum, so this is never ok.
       return "usage_prohibited_cash_balance" if ledger.balance < self.minimum_cash_balance_for_services
+      # Consider this the "zero" amount. It's okay to be this negative,
+      # since we can't charge ledgers when this or less of a balance
+      # (so ledgers in this zone are that way due to not fault of the user).
+      zero = self.minimum_cash_balance_grace
       # We've above the minimum, and the minimum is zero or higher, so we are okay and do not need
       # to worry about grace period.
-      return nil if self.minimum_cash_balance_for_services >= 0
+      return nil if self.minimum_cash_balance_for_services >= zero
       # The minimum is negative, but our balance is ok, so we don't need to check the grace period.
-      return nil if ledger.balance >= 0
+      return nil if ledger.balance >= zero
       # We have a negative balance that is higher than the minimum.
       # So now we need to see if the ledger has been brought out of the red at any point
       # during the grace period (if it has, the grace period would start over).
@@ -122,7 +136,7 @@ module Suma::Payment
       has_been_positive_during_grace_period = false
       ledger.combined_book_transactions_raw.reverse_each do |row|
         balance += row.fetch(:amount_cents)
-        if row.fetch(:apply_at) > grace_start && balance >= 0
+        if row.fetch(:apply_at) > grace_start && balance >= zero
           has_been_positive_during_grace_period = true
           break
         end

--- a/lib/suma/payment/account.rb
+++ b/lib/suma/payment/account.rb
@@ -24,9 +24,7 @@ class Suma::Payment::Account < Suma::Postgres::Model(:payment_accounts)
               order: order_desc,
               read_only: true
   one_to_many :ledgers, class: "Suma::Payment::Ledger", order: order_assoc(:asc)
-  one_to_one :cash_ledger, class: "Suma::Payment::Ledger", read_only: true do |ds|
-    ds.where(vendor_service_categories: Suma::Vendor::ServiceCategory.where(slug: "cash"))
-  end
+  one_to_one :cash_ledger, class: "Suma::Payment::Ledger", read_only: true, &:cash
   many_through_many :all_book_transactions,
                     [
                       [:payment_ledgers, :account_id, :id],

--- a/lib/suma/payment/card.rb
+++ b/lib/suma/payment/card.rb
@@ -14,6 +14,10 @@ class Suma::Payment::Card < Suma::Postgres::Model(:payment_cards)
   plugin :timestamps
   plugin :soft_deletes
 
+  one_to_many :originated_funding_stripe_card_strategies,
+              key: :originating_card_id,
+              class: "Suma::Payment::FundingTransaction::StripeCardStrategy"
+
   dataset_module do
     def usable_for_funding = self.unexpired_as_of(Time.now)
     def usable_for_payout = self.where(1 => 0)
@@ -58,6 +62,9 @@ class Suma::Payment::Card < Suma::Postgres::Model(:payment_cards)
     self.stripe_json = existing.as_json
     @stripe_data = nil
   end
+
+  # Could move this to an association later
+  def originated_funding_transactions = self.originated_funding_stripe_card_strategies.map(&:funding_transaction)
 
   def _external_links_self
     return [

--- a/lib/suma/payment/instrument.rb
+++ b/lib/suma/payment/instrument.rb
@@ -41,6 +41,7 @@ class Suma::Payment::Instrument < Suma::Postgres::Model(:payment_instruments)
     def status
       return :expired if expired?
       return :unverified unless verified?
+      return :deleted if soft_deleted?
       return :ok
     end
 

--- a/lib/suma/payment/ledger.rb
+++ b/lib/suma/payment/ledger.rb
@@ -19,6 +19,10 @@ class Suma::Payment::Ledger < Suma::Postgres::Model(:payment_ledgers)
     ]
   end
 
+  dataset_module do
+    def cash = self.where(vendor_service_categories: Suma::Vendor::ServiceCategory.where(slug: "cash"))
+  end
+
   many_to_one :account, class: "Suma::Payment::Account"
   one_to_one :balance_view, class: "Suma::Payment::Ledger::Balance", key: :ledger_id
   many_to_many :vendor_service_categories,

--- a/lib/suma/payment/ledger/balance_charger.rb
+++ b/lib/suma/payment/ledger/balance_charger.rb
@@ -12,9 +12,14 @@ class Suma::Payment::Ledger::BalanceCharger
 
   # Find all the unbalanced ledgers in the system
   def find_ledgers
-    unbalanced = Suma::Payment::PlatformStatus.new.unbalanced_ledgers_dataset.all
-    unbalanced.select! { |led| led.balance.negative? }
-    unbalanced.select! { |led| led === led.account.cash_ledger }
+    balance_view = Suma::Payment::Ledger::Balance.
+      dataset.
+      where { balance_cents < Suma::Payment.minimum_cash_balance_grace_cents }
+    unbalanced = Suma::Payment::PlatformStatus.new.
+      unbalanced_ledgers_dataset.
+      cash.
+      where(balance_view:).
+      all
     return unbalanced
   end
 

--- a/lib/suma/payment/ledger/balance_charger.rb
+++ b/lib/suma/payment/ledger/balance_charger.rb
@@ -46,21 +46,20 @@ class Suma::Payment::Ledger::BalanceCharger
       ledger.account.lock!
       ledger.refresh
       return nil unless ledger.balance.negative?
-      begin
-        fx = Suma::Payment::FundingTransaction.start_new(
-          ledger.account,
-          amount: -ledger.balance,
-          instrument:,
-          memo: self.memo,
-          collect: :must,
-        )
-        return fx
-      rescue StateMachines::Sequel::FailedTransition, Suma::Payment::FundingTransaction::CollectFundsFailed
-        # We don't care about failures here; we'll try again later.
-        # We can report long-term negative balances separately.
-        return nil
-      end
+      fx = Suma::Payment::FundingTransaction.start_new(
+        ledger.account,
+        amount: -ledger.balance,
+        instrument:,
+        memo: self.memo,
+        collect: :must,
+      )
+      return fx
     end
+  rescue StateMachines::Sequel::FailedTransition, Suma::Payment::FundingTransaction::CollectFundsFailed
+    # Must be OUTSIDE the db transaction.
+    # We don't care about failures here; we'll try again later.
+    # We can report long-term negative balances separately.
+    return nil
   end
 
   def memo = @memo ||= Suma::I18n::StaticString.find_text("backend", "funding_transaction_charge_balance")

--- a/lib/suma/postgres.rb
+++ b/lib/suma/postgres.rb
@@ -247,10 +247,10 @@ module Suma::Postgres
   end
 
   # Call block immediately if not deferring events; otherwise call it after db commit.
-  def self.defer_after_commit(db, &block)
+  def self.defer_after_commit(db, **kw, &block)
     raise LocalJumpError unless block
     return yield if self.do_not_defer_events?
-    return db.after_commit(&block)
+    return db.after_commit(**kw, &block)
   end
 end
 

--- a/lib/suma/postgres/model_pubsub.rb
+++ b/lib/suma/postgres/model_pubsub.rb
@@ -56,7 +56,7 @@ module Suma::Postgres::ModelPubsub
 
     # Publish an event in the current db's/transaction's +after_commit+ hook.
     def publish_deferred(type, *payload)
-      Suma::Postgres.defer_after_commit(self.db) do
+      Suma::Postgres.defer_after_commit(self.db, savepoint: true) do
         self.publish_immediate(type, *payload)
       end
     end

--- a/spec/suma/payment/ledger/balance_charger_spec.rb
+++ b/spec/suma/payment/ledger/balance_charger_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Suma::Payment::Ledger::BalanceCharger, :db do
   let(:platform_account) { Suma::Payment::Account.lookup_platform_account }
   let(:platform_cash) { platform_account.ensure_cash_ledger }
 
-  it "charges cash ledgers with negative balance", :i18n do
+  it "charges cash ledgers with negative balance", :i18n, reset_configuration: Suma::Payment do
     food = Suma::Fixtures.vendor_service_category.create(name: "food")
 
     platform_food = platform_account.ensure_ledger_with_category(food)
@@ -18,7 +18,8 @@ RSpec.describe Suma::Payment::Ledger::BalanceCharger, :db do
     account2 = Suma::Fixtures.payment_account.create
     account3 = Suma::Fixtures.payment_account.create
     account4 = Suma::Fixtures.payment_account.create
-    [account1, account2, account3, account4].each do |account|
+    account5 = Suma::Fixtures.payment_account.create
+    [account1, account2, account3, account4, account5].each do |account|
       Suma::Fixtures.card.member(account.member).create
     end
 
@@ -26,10 +27,14 @@ RSpec.describe Suma::Payment::Ledger::BalanceCharger, :db do
     negative_cash = account2.ensure_cash_ledger
     zero_cash = account3.ensure_cash_ledger
     negative_food = account4.ensure_ledger_with_category(food)
+    # Skipped due to a balance above the grace threshold
+    Suma::Payment.minimum_cash_balance_grace_cents = -75
+    slightly_negative_cash = account3.ensure_cash_ledger
 
     Suma::Fixtures.book_transaction.from(platform_cash).to(positive_cash).create(amount: money("$5"))
     Suma::Fixtures.book_transaction.from(negative_cash).to(platform_cash).create(amount: money("$50"))
     Suma::Fixtures.book_transaction.from(negative_food).to(platform_food).create(amount: money("$500"))
+    Suma::Fixtures.book_transaction.from(slightly_negative_cash).to(platform_cash).create(amount: money("$0.50"))
 
     Suma::Payment::FundingTransaction.force_fake(Suma::Payment::FakeStrategy.create.ready) do
       described_class.new.run

--- a/spec/suma/payment_spec.rb
+++ b/spec/suma/payment_spec.rb
@@ -70,6 +70,21 @@ RSpec.describe Suma::Payment, :db do
       expect(described_class.service_usage_prohibited_reason(account)).to be_nil
     end
 
+    it "is nil when the cash balance is negative but above the grace amount" do
+      described_class.minimum_cash_balance_for_services_cents = -20_00
+      expect(described_class.service_usage_prohibited_reason(account)).to be_nil
+
+      fixtures.book_transaction.from(ledger).create(apply_at: 40.hours.ago, amount: money("$3"))
+      account.refresh
+      expect(described_class.service_usage_prohibited_reason(account)).to eq("usage_prohibited_cash_balance")
+
+      described_class.minimum_cash_balance_grace_cents = -4_00
+      expect(described_class.service_usage_prohibited_reason(account)).to be_nil
+
+      described_class.minimum_cash_balance_grace_cents = -2_00
+      expect(described_class.service_usage_prohibited_reason(account)).to eq("usage_prohibited_cash_balance")
+    end
+
     it "has a can_use_services? predicate" do
       described_class.minimum_cash_balance_for_services_cents = 0
       expect(described_class).to be_can_use_services(account)

--- a/spec/suma/postgres/model_spec.rb
+++ b/spec/suma/postgres/model_spec.rb
@@ -280,6 +280,64 @@ RSpec.describe "Suma::Postgres::Model", :db do
       )
     end
 
+    describe "when the event is published within a savepointed" do
+      before(:each) do
+        @o = Suma::Postgres::TestingPixie.create
+        @calls = []
+        @subscriber = Amigo.register_subscriber { |*args| @calls << args }
+      end
+
+      after(:each) do
+        Amigo.unregister_subscriber(@subscriber)
+      end
+
+      let(:calls) { @calls }
+      let(:o) { @o }
+      let(:err) { RuntimeError.new }
+
+      it "is published when the outer transaction commits" do
+        o.db.transaction do
+          o.update(name: "a")
+          o.db.transaction(savepoint: true) do
+            o.update(name: "b")
+          end
+          o.update(name: "c")
+        end
+        expect(calls).to have_length(3)
+      end
+
+      it "it does not publish if the savepoint errors and it bubbles past the outer transaction" do
+        expect(calls).to be_empty
+        expect do
+          o.db.transaction do
+            o.update(name: "a")
+            o.db.transaction(savepoint: true) do
+              o.update(name: "b")
+              raise err
+            end
+          end
+        end.to raise_error(err)
+        expect(calls).to be_empty
+      end
+
+      it "does not publish what happens within the savepoint, if it errors but the transaction eventually commits" do
+        o.db.transaction do
+          o.update(name: "a")
+          expect do
+            o.db.transaction(savepoint: true) do
+              o.update(name: "b") # This gets rolled back
+              raise err
+            end
+          end.to raise_error(err)
+          o.db.transaction(savepoint: true) do
+            o.update(name: "c")
+          end
+          o.update(name: "d")
+        end
+        expect(calls).to have_length(3)
+      end
+    end
+
     describe "model_for_event_topic" do
       it "can find the class constant for a topic" do
         cls = Suma::Postgres::TestingPixie


### PR DESCRIPTION
Expose more info in admin

- Stripe customer on member page
- Funding transactions on card page

---

Do not try to charge ledgers above a min balance

Ledgers with a $-0.45 balance cannot be charged,
since Stripe's minimum charge is $0.50.

Add a new PAYMENT_MINIMUM_CASH_BALANCE_GRACE_CENTS setting
to avoid charging these ledgers.

---

Fix transaction bugs in model pubsub

When using model events inside a transaction with a savepoint,
we need to pass `savepoint: true`, so that the hooks
registered with a savepoint don't run if the savepoint rolls back.

---

Add :deleted status for payment instruments

---

Fix incorrect transaction scoping in balance charger

---

Fix on_failure->on_failed typo in FundingTransactionProcessor