### PR TITLE
Add 'platform payment never required' flag to vendor config

### DIFF
--- a/adminapp/src/pages/VendorConfigurationDetailPage.jsx
+++ b/adminapp/src/pages/VendorConfigurationDetailPage.jsx
@@ -30,6 +30,10 @@ export default function VendorConfigurationDetailPage() {
         },
         { label: "Auth-to-Vendor", value: model.authToVendorKey },
         { label: "Enabled", value: <BoolCheckmark>{model.enabled}</BoolCheckmark> },
+        {
+          label: "Platform Payment Never Required",
+          value: <BoolCheckmark>{model.platformPaymentNeverRequired}</BoolCheckmark>,
+        },
         { label: "Description (En)", value: model.descriptionText.en },
         { label: "Description (Es)", value: model.descriptionText.es },
         { label: "Help (En)", value: model.helpText.en },

--- a/adminapp/src/pages/VendorConfigurationForm.jsx
+++ b/adminapp/src/pages/VendorConfigurationForm.jsx
@@ -43,6 +43,13 @@ export default function VendorConfigurationForm({
           checked={resource.enabled}
           onChange={setFieldFromInput}
         />
+        <FormControlLabel
+          control={<Switch />}
+          label="Platform Payment Never Required"
+          name="platformPaymentNeverRequired"
+          checked={resource.platformPaymentNeverRequired}
+          onChange={setFieldFromInput}
+        />
         <FormLabel>Description</FormLabel>
         <ResponsiveStack>
           <MultiLingualText

--- a/db/migrations/112_vendor_config_platform_payment.rb
+++ b/db/migrations/112_vendor_config_platform_payment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:anon_proxy_vendor_configurations) do
+      add_column :platform_payment_never_required, :boolean, null: false, default: false
+    end
+  end
+end

--- a/lib/suma/admin_api/anon_proxy_vendor_configurations.rb
+++ b/lib/suma/admin_api/anon_proxy_vendor_configurations.rb
@@ -12,6 +12,7 @@ class Suma::AdminAPI::AnonProxyVendorConfigurations < Suma::AdminAPI::V1
 
     expose_related :audit_activities, with: ActivityEntity, inherit_permissions: true
     expose_related :programs, with: ProgramEntity
+    expose :platform_payment_never_required
     expose :description_text, with: TranslatedTextEntity
     expose :help_text, with: TranslatedTextEntity
     expose :terms_text, with: TranslatedTextEntity
@@ -38,6 +39,7 @@ class Suma::AdminAPI::AnonProxyVendorConfigurations < Suma::AdminAPI::V1
     ) do
       params do
         optional :enabled, type: Boolean
+        optional :platform_payment_never_required, type: Boolean
         optional :app_install_link, type: String
         optional(:description_text, type: JSON) { use :translated_text }
         optional(:help_text, type: JSON) { use :translated_text }

--- a/lib/suma/anon_proxy/vendor_account.rb
+++ b/lib/suma/anon_proxy/vendor_account.rb
@@ -77,6 +77,7 @@ class Suma::AnonProxy::VendorAccount < Suma::Postgres::Model(:anon_proxy_vendor_
   # If we have any results from this, we probably need pricing,
   # and can ask the user to set up payment before provisioning/linking a vendor account.
   def require_payment_instrument?(as_of:)
+    return false if self.configuration.platform_payment_never_required?
     programs = self.configuration.programs_eligible_to(self.member, as_of:)
     nonzero_same_vendor_programs = Suma::Program.where(id: programs.map(&:id)).
       where(
@@ -149,7 +150,11 @@ class Suma::AnonProxy::VendorAccount < Suma::Postgres::Model(:anon_proxy_vendor_
                         :relink
                       end
     cash_ledger = self.member.payment_account&.cash_ledger!
-    balance_payoff_needed = has_payment_method && cash_ledger && Suma::Payment.chargeable_balance?(cash_ledger.balance)
+    balance_payoff_needed =
+      requires_payment_method &&
+      has_payment_method &&
+      cash_ledger &&
+      Suma::Payment.chargeable_balance?(cash_ledger.balance)
     return UIStateV1.new(
       index_card_mode:,
       needs_linking:,

--- a/lib/suma/anon_proxy/vendor_configuration.rb
+++ b/lib/suma/anon_proxy/vendor_configuration.rb
@@ -32,6 +32,12 @@ class Suma::AnonProxy::VendorConfiguration < Suma::Postgres::Model(:anon_proxy_v
   # True if the instance is enabled/should show in the UI.
   def enabled? = self.enabled
 
+  # True if this vendor configuration will never process payments over Suma;
+  # that is, the integration has the member pay natively in the 3rd party app,
+  # NOT through suma. Vendor service rates end up describing the off-platform cost
+  # but can otherwise be ignored (for example, we would not limit service access).
+  def platform_payment_never_required? = self.platform_payment_never_required
+
   def rel_admin_link = "/vendor-configuration/#{self.id}"
 
   def hybrid_search_fields

--- a/lib/suma/api/anon_proxy.rb
+++ b/lib/suma/api/anon_proxy.rb
@@ -38,6 +38,7 @@ class Suma::API::AnonProxy < Suma::API::V1
         post :make_auth_request do
           apva = lookup
           if (code = Suma::Payment.service_usage_prohibited_reason(apva.member.payment_account))
+            if code == "usage_prohibited_cash_balance" &&
             merror!(402, "Account cannot use services", code:)
           end
           apva.auth_to_vendor.auth(now: current_time)

--- a/spec/suma/anon_proxy/vendor_account_spec.rb
+++ b/spec/suma/anon_proxy/vendor_account_spec.rb
@@ -198,6 +198,11 @@ RSpec.describe "Suma::AnonProxy::VendorAccount", :db do
           Suma::Eligibility::Assignment.dataset.delete
           expect(va).to_not be_require_payment_instrument(as_of:)
         end
+
+        it "the vendor config never uses platform payments" do
+          vc.update(platform_payment_never_required: true)
+          expect(va).to_not be_require_payment_instrument(as_of:)
+        end
       end
     end
 
@@ -265,6 +270,17 @@ RSpec.describe "Suma::AnonProxy::VendorAccount", :db do
             needs_linking: true,
             requires_payment_method: true,
             has_payment_method: false,
+            balance_payoff_needed: false,
+          )
+        end
+
+        it "does not require a balance payoff if the vendor config does not use platform payments" do
+          va.configuration.update(platform_payment_never_required: true)
+          expect(va.ui_state_v1(now: as_of)).to have_attributes(
+            index_card_mode: :link,
+            needs_linking: true,
+            requires_payment_method: false,
+            has_payment_method: true,
             balance_payoff_needed: false,
           )
         end

--- a/spec/suma/api/anon_proxy_spec.rb
+++ b/spec/suma/api/anon_proxy_spec.rb
@@ -151,13 +151,26 @@ RSpec.describe Suma::API::AnonProxy, :db do
       expect(last_response).to have_json_body.that_includes(error: include(message: match(/config is not enabled/)))
     end
 
-    it "402s if the member cannot use services" do
-      Suma::Payment.minimum_cash_balance_for_services_cents = 5
-      expect(Suma::Payment).to_not be_can_use_services(member.payment_account)
+    describe "when the member cannot use services due to balance" do
+      before(:each) do
+        Suma::Payment.minimum_cash_balance_for_services_cents = 5
+        expect(Suma::Payment).to_not be_can_use_services(member.payment_account)
+      end
 
-      post "/v1/anon_proxy/vendor_accounts/#{va.id}/make_auth_request"
+      it "402s" do
+        post "/v1/anon_proxy/vendor_accounts/#{va.id}/make_auth_request"
 
-      expect(last_response).to have_status(402)
+        expect(last_response).to have_status(402)
+      end
+
+      it "succeeds if the configuration does not use off-platform payments" do
+        va.configuration.update(platform_payment_never_required: true)
+
+        post "/v1/anon_proxy/vendor_accounts/#{va.id}/make_auth_request"
+
+        expect(last_response).to have_status(200)
+        expect(Suma::AnonProxy::AuthToVendor::Fake.calls).to eq(1)
+      end
     end
 
     it "auths to vendor and marks the code as requested" do


### PR DESCRIPTION
We decided against doing this, since it gets pretty gnarly with edge cases and is only useful for particular situations we probably want to avoid (and just fixed by zeroing out ledgers).