### PR TITLE
Do not destroy anon proxy vendor registrations

### DIFF
--- a/adminapp/src/pages/VendorAccountDetailPage.jsx
+++ b/adminapp/src/pages/VendorAccountDetailPage.jsx
@@ -101,13 +101,14 @@ export default function VendorAccountDetailPage() {
         <RelatedListRemote
           title="Registrations"
           collection={model.registrations}
-          headers={["Id", "Created", "Program Id", "External Id"]}
+          headers={["Id", "Created", "Program Id", "External Id", "Unregistered"]}
           keyRowAttr="id"
           toCells={(row) => [
             row.id,
             formatDate(row.createdAt),
             row.externalProgramId,
             row.externalRegistrationId,
+            formatDate(row.unregisteredAt),
           ]}
         />,
         <RelatedListRemote

--- a/db/migrations/113_vendor_account_registration_unregistered.rb
+++ b/db/migrations/113_vendor_account_registration_unregistered.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:anon_proxy_vendor_account_registrations) do
+      add_column :unregistered_at, :timestamptz
+    end
+  end
+end

--- a/lib/suma/admin_api/anon_proxy_vendor_accounts.rb
+++ b/lib/suma/admin_api/anon_proxy_vendor_accounts.rb
@@ -14,6 +14,7 @@ class Suma::AdminAPI::AnonProxyVendorAccounts < Suma::AdminAPI::V1
 
     expose :external_program_id
     expose :external_registration_id
+    expose :unregistered_at
   end
 
   class VendorAccountMessageEntity < BaseModelEntity

--- a/lib/suma/anon_proxy/auth_to_vendor/lyft_pass.rb
+++ b/lib/suma/anon_proxy/auth_to_vendor/lyft_pass.rb
@@ -24,7 +24,7 @@ class Suma::AnonProxy::AuthToVendor::LyftPass < Suma::AnonProxy::AuthToVendor
   # - There is a lyft program id on its program
   # - The lyft program id is not part of this vendor account's registrations
   def programs_requiring_attention(now:)
-    registered_ids = self.vendor_account.registrations.map(&:external_program_id)
+    registered_ids = self.vendor_account.registrations.reject(&:unregistered?).map(&:external_program_id)
     unregistered_programs = Suma::Lyft::Pass.programs_dataset.exclude(lyft_pass_program_id: registered_ids)
     rows = unregistered_programs.fetch_eligible_to(self.vendor_account.member, as_of: now)
     return rows

--- a/lib/suma/anon_proxy/vendor_account_registration.rb
+++ b/lib/suma/anon_proxy/vendor_account_registration.rb
@@ -11,6 +11,8 @@ class Suma::AnonProxy::VendorAccountRegistration < Suma::Postgres::Model(:anon_p
 
   many_to_one :account, class: "Suma::AnonProxy::VendorAccount"
 
+  def unregistered? = !self.unregistered_at.nil?
+
   # The account this registration belongs to.
   # @!attribute account
   # @return [Suma::AnonProxy::VendorAccount]

--- a/lib/suma/program/service_revoker.rb
+++ b/lib/suma/program/service_revoker.rb
@@ -17,9 +17,12 @@ class Suma::Program::ServiceRevoker
     )
   end
 
-  def initialize(dry_run: Suma::Program.service_revoker_dry_run)
+  def initialize(dry_run: Suma::Program.service_revoker_dry_run, now: Time.now)
     @dry_run = dry_run
+    @now = now
   end
+
+  attr_reader :now
 
   def dry_run? = @dry_run
   def do_dry_run(event, kw) = self.logger.warn(event, **kw)
@@ -42,7 +45,8 @@ class Suma::Program::ServiceRevoker
     ].max
     balances = balances.where { balance_cents < ok_balance }
     # which have changed recently (assume we've acted on things older than this)
-    balances = balances.where { latest_transaction_at > (Time.now - Suma::Program.service_revoker_lookback) }
+    now = self.now
+    balances = balances.where { latest_transaction_at > (now - Suma::Program.service_revoker_lookback) }
     balances = balances.all
     balances.each do |balance|
       self.run_for(balance.ledger)
@@ -157,7 +161,7 @@ class Suma::Program::ServiceRevoker
         )
       else
         lp.revoke_member(r.account.member, program_id: r.external_program_id, phone:) if phone
-        r.destroy
+        r.update(unregistered_at: self.now)
       end
     end
   end

--- a/spec/suma/anon_proxy/auth_to_vendor_spec.rb
+++ b/spec/suma/anon_proxy/auth_to_vendor_spec.rb
@@ -196,6 +196,11 @@ RSpec.describe Suma::AnonProxy::AuthToVendor, :db do
 
       Suma::Fixtures.program.create(lyft_pass_program_id: "1234")
       expect(va.auth_to_vendor).to be_needs_linking(now:)
+      reg2 = va.add_registration(external_program_id: "1234")
+      expect(va.auth_to_vendor).to_not be_needs_linking(now:)
+
+      reg2.update(unregistered_at: Time.now)
+      expect(va.auth_to_vendor).to be_needs_linking(now:)
     end
   end
 end

--- a/spec/suma/program/service_revoker_spec.rb
+++ b/spec/suma/program/service_revoker_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Suma::Program::ServiceRevoker, :db, :no_transaction_check do
       Suma::Lyft.pass_org_id = "1234"
     end
 
-    it "revokes lyft pass and destroys registrations for lyft pass program ids" do
+    it "revokes lyft pass and unregisters registrations for lyft pass program ids" do
       lyft_pass_config = Suma::Fixtures.anon_proxy_vendor_configuration.create(auth_to_vendor_key: "lyft_pass")
       lyft_pass_vendor_acct = Suma::Fixtures.anon_proxy_vendor_account.create(configuration: lyft_pass_config, member:)
       reg1 = lyft_pass_vendor_acct.add_registration(external_program_id: "111")
@@ -82,8 +82,8 @@ RSpec.describe Suma::Program::ServiceRevoker, :db, :no_transaction_check do
 
       expect(req1).to have_been_made
       expect(req2).to have_been_made
-      expect(reg1).to be_destroyed
-      expect(reg2).to be_destroyed
+      expect(reg1.refresh).to be_unregistered
+      expect(reg2.refresh).to be_unregistered
     end
 
     it "logs and skips idempotency with dry run" do
@@ -95,7 +95,7 @@ RSpec.describe Suma::Program::ServiceRevoker, :db, :no_transaction_check do
         described_class.new(dry_run: true).revoke_all_lyft_passes(member)
       end
       expect(logs).to have_a_line_matching(/service_revoker_dry_run/)
-      expect(reg1).to_not be_destroyed
+      expect(reg1.refresh).to have_attributes(unregistered_at: nil)
     end
 
     describe "when a member is soft deleted" do
@@ -116,7 +116,7 @@ RSpec.describe Suma::Program::ServiceRevoker, :db, :no_transaction_check do
         described_class.new.revoke_all_lyft_passes(member)
 
         expect(req).to have_been_made
-        expect(reg).to be_destroyed
+        expect(reg.refresh).to be_unregistered
       end
 
       it "does not revoke if there is no previous number" do
@@ -128,7 +128,7 @@ RSpec.describe Suma::Program::ServiceRevoker, :db, :no_transaction_check do
 
         described_class.new.revoke_all_lyft_passes(member)
 
-        expect(reg).to be_destroyed
+        expect(reg.refresh).to be_unregistered
       end
     end
   end


### PR DESCRIPTION
We need these to keep track of what program a user is in so we can charge them for rides. When we revoke lyft passes, we were destroying the registration to allow for future re-registration.

Instead, there is now an 'unregistered_at' column
which is set when we revoke lyft passes.
Checking 'needs attention' ignores unregistered registrations.