### PR TITLE
Refund stripe charges unassociated with funding

### DIFF
--- a/db/migrations/114_stripe_broken_charge_reunder.rb
+++ b/db/migrations/114_stripe_broken_charge_reunder.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    if ENV["RACK_ENV"] == "test"
+      run <<~SQL
+        CREATE TABLE stripe_charge_v1_fixture (
+          pk bigserial PRIMARY KEY,
+          stripe_id text UNIQUE NOT NULL,
+          amount integer,
+          balance_transaction text,
+          billing_email text,
+          created timestamptz,
+          customer text,
+          invoice text,
+          payment_type text,
+          receipt_email text,
+          status text,
+          updated timestamptz,
+          data jsonb NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS svi_fixture_amount_idx ON stripe_charge_v1_fixture (amount);
+        CREATE INDEX IF NOT EXISTS svi_fixture_balance_transaction_idx ON stripe_charge_v1_fixture (balance_transaction);
+        CREATE INDEX IF NOT EXISTS svi_fixture_billing_email_idx ON stripe_charge_v1_fixture (billing_email);
+        CREATE INDEX IF NOT EXISTS svi_fixture_created_idx ON stripe_charge_v1_fixture (created);
+        CREATE INDEX IF NOT EXISTS svi_fixture_customer_idx ON stripe_charge_v1_fixture (customer);
+        CREATE INDEX IF NOT EXISTS svi_fixture_invoice_idx ON stripe_charge_v1_fixture (invoice);
+        CREATE INDEX IF NOT EXISTS svi_fixture_receipt_email_idx ON stripe_charge_v1_fixture (receipt_email);
+        CREATE INDEX IF NOT EXISTS svi_fixture_status_idx ON stripe_charge_v1_fixture (status);
+        CREATE INDEX IF NOT EXISTS svi_fixture_updated_idx ON stripe_charge_v1_fixture (updated);
+      SQL
+    end
+  end
+
+  down do
+    run("DROP TABLE stripe_charge_v1_fixture") if ENV["RACK_ENV"] == "test"
+  end
+end

--- a/lib/sequel/plugins/efficient_each.rb
+++ b/lib/sequel/plugins/efficient_each.rb
@@ -36,26 +36,31 @@ module Sequel::Plugins::EfficientEach
     #   Helpful when bulk processing.
     #
     # (Note that paged_each does not do eager loading, which makes enumerating model associations very slow)
-    def each_cursor_page(page_size: nil, order: nil, yield_page: false, &block)
-      raise LocalJumpError unless block
-      raise "dataset requires a use_cursor method, class may need `extension(:pagination)`" unless
-        self.respond_to?(:use_cursor)
+    def each_cursor_page(page_size: nil, order: nil, yield_page: false, &)
       model = self.model
       page_size ||= model.efficient_each_page_size
       pk = model.primary_key
       order ||= pk
-      current_chunk_pks = []
-      order = [order] unless order.respond_to?(:to_ary)
-      self.naked.select(pk).order(*order).use_cursor(rows_per_fetch: page_size, hold: true).each do |row|
-        current_chunk_pks << row[pk]
-        next if current_chunk_pks.length < page_size
-        page = model.where(pk => current_chunk_pks).order(*order).all
-        current_chunk_pks.clear
-        yield_page ? yield(page) : page.each(&block)
-      end
-      remainder = model.where(pk => current_chunk_pks).order(*order).all
-      yield_page && !remainder.empty? ? yield(remainder) : remainder.each(&block)
+      Sequel::Plugins::EfficientEach.each_cursor_page(self, pk:, page_size:, yield_page:, order:, &)
     end
+  end
+
+  def self.each_cursor_page(dataset, pk:, page_size:, yield_page:, order: nil, &block)
+    raise LocalJumpError unless block
+    raise "dataset requires a use_cursor method, class may need `extension(:pagination)`" unless
+      dataset.respond_to?(:use_cursor)
+    order ||= pk
+    current_chunk_pks = []
+    order = [order] unless order.respond_to?(:to_ary)
+    dataset.naked.select(pk).order(*order).use_cursor(rows_per_fetch: page_size, hold: true).each do |row|
+      current_chunk_pks << row[pk]
+      next if current_chunk_pks.length < page_size
+      page = dataset.where(pk => current_chunk_pks).order(*order).all
+      current_chunk_pks.clear
+      yield_page ? yield(page) : page.each(&block)
+    end
+    remainder = dataset.where(pk => current_chunk_pks).order(*order).all
+    yield_page && !remainder.empty? ? yield(remainder) : remainder.each(&block)
   end
 
   module InstanceMethods

--- a/lib/suma/api/webhookdb.rb
+++ b/lib/suma/api/webhookdb.rb
@@ -3,7 +3,7 @@
 require "suma/api"
 
 require "suma/async/signalwire_process_optouts"
-require "suma/async/stripe_refunds_backfiller"
+require "suma/async/stripe_book_keeping"
 
 class Suma::API::Webhookdb < Suma::API::V1
   include Suma::API::Entities
@@ -12,7 +12,7 @@ class Suma::API::Webhookdb < Suma::API::V1
     post :stripe_refund_v1 do
       h = env["HTTP_WHDB_WEBHOOK_SECRET"]
       unauthenticated! unless h == Suma::Webhookdb.stripe_refunds_secret
-      Suma::Async::StripeRefundsBackfiller.perform_async
+      Suma::Async::StripeBookKeeping.perform_async
       status 202
       present({o: "k"})
     end

--- a/lib/suma/async/deprecated_jobs.rb
+++ b/lib/suma/async/deprecated_jobs.rb
@@ -18,6 +18,7 @@ Amigo::DeprecatedJobs.install(
   "Async::PaymentInstrumentChargeBalance",
   "Async::UpsertFrontappContact",
   "Async::ServiceRevokerRunner",
+  "Async::StripeRefundsBackfiller",
   "Async::SyncLimeFreeBikeStatusGbfs",
   "Async::SyncLimeGeofencingZonesGbfs",
   "Async::SyncLyftFreeBikeStatusGbfs",

--- a/lib/suma/async/stripe_book_keeping.rb
+++ b/lib/suma/async/stripe_book_keeping.rb
@@ -4,7 +4,7 @@ require "amigo/scheduled_job"
 require "suma/async"
 require "suma/webhookdb"
 
-class Suma::Async::StripeRefundsBackfiller
+class Suma::Async::StripeBookKeeping
   extend Amigo::ScheduledJob
 
   sidekiq_options(Suma::Async.cron_job_options)
@@ -13,5 +13,6 @@ class Suma::Async::StripeRefundsBackfiller
 
   def _perform
     Suma::Payment::PayoutTransaction::StripeChargeRefundStrategy.backfill_payouts_from_webhookdb
+    Suma::Payment::FundingTransaction::StripeCardStrategy.refund_unassociated_charges
   end
 end

--- a/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
+++ b/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
@@ -122,6 +122,93 @@ class Suma::Payment::FundingTransaction::StripeCardStrategy <
   def _external_link_deps
     return [self.originating_card]
   end
+
+  class UnassociatedChargeRefunder
+    attr_reader :row_iterator
+
+    def initialize(newer_than: 2.weeks, older_than: 2.hours)
+      @newer_than = newer_than # Do not look back indefinitely
+      @older_than = older_than # In theory this could be 30 seconds
+      @row_iterator = Suma::Webhookdb::RowIterator.new("stripe/unassociatedchargerefunder/pk")
+    end
+
+    # Yield each row in the dataset that we need to process.
+    # Since the webhookdb table is in a separate DB from the funding transactions,
+    # we cannot do this with a simple query in the dataset.
+    # So we pull all the rows,
+    # so we need to run this check here.
+    def each
+      ds = self.dataset
+      @row_iterator.each_page(ds) do |page|
+        fx_ids_from_stripe = page.to_set do |r|
+          r.fetch(:data).fetch("metadata").fetch("suma_funding_transaction_id").to_i
+        end
+        fx_ids_in_suma = Suma::Payment::FundingTransaction.where(id: fx_ids_from_stripe).select_map(:id)
+        page.each do |row|
+          fx_id = row.fetch(:data).fetch("metadata").fetch("suma_funding_transaction_id").to_i
+          yield(row) unless fx_ids_in_suma.include?(fx_id)
+        end
+      end
+    end
+
+    def run
+      self.each do |row|
+        stripe_charge_id = row.fetch(:stripe_id)
+        Suma::Idempotency.once_ever.under_key("refund-unassociated-stripe-charge-#{stripe_charge_id}") do
+          member_name = row.fetch(:data).fetch("source").fetch("name", "")
+          member_id = row.fetch(:data).fetch("source").fetch("metadata", {})["suma_member_id"] || "<unknown>"
+          body_lines = [
+            "Suma charged a member, but an error in the backend caused the charge to be lost.",
+            "We have refunded the charge, and it will take about 5 business days to appear.",
+            "No action is necessary, but please let the member know if they contact support.",
+            "See this charge in Stripe: #{Suma::Stripe.app_url}/payments/#{stripe_charge_id}",
+            "Member Name: #{member_name}",
+            "Suma Member Id: #{member_id}",
+          ]
+          Suma::Support::Ticket.create(
+            subject: "Refunding Unassociated Stripe Charge",
+            body: body_lines.join("\n"),
+            external_id: "refund-#{stripe_charge_id}",
+          )
+          Stripe::Refund.create(charge: row.fetch(:stripe_id))
+        end
+      end
+    end
+
+    def dataset
+      data = Sequel.pg_jsonb(:data)
+      newer_than = @newer_than.ago
+      older_than = @older_than.ago
+      # rubocop:disable Style/PreferredHashMethods
+      ds = Suma::Webhookdb.stripe_charges_dataset.
+        where(status: "succeeded").
+        where { created > newer_than }.
+        where { created < older_than }.
+        where(
+          data.get("metadata").has_key?("suma_funding_transaction_id") &
+            Sequel[data.get_text("captured") => "true"] &
+            Sequel[data.get_text("refunded") => "false"],
+        )
+      # rubocop:enable Style/PreferredHashMethods
+      return ds
+    end
+  end
+
+  # It is possible that we create captured Stripe charges,
+  # but the transaction fails due to a database outage or other error,
+  # and the suma side never commits.
+  #
+  # We can detect this has happened by looking for charges which:
+  # - Are captured,
+  # - Have the expected metadata ('suma_funding_transaction_id'),
+  # - Do not have a corresponding strategy row.
+  #
+  # These charges can be refunded. We track where this happens with a support ticket,
+  # both to make sure it isn't common,
+  # and because a user may reach out about the charge in the meantime.
+  def self.refund_unassociated_charges
+    UnassociatedChargeRefunder.new.run
+  end
 end
 
 # Table: payment_funding_transaction_stripe_card_strategies

--- a/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
+++ b/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
@@ -46,6 +46,12 @@ class Suma::Payment::FundingTransaction::StripeCardStrategy <
 
   def collect_funds
     return if self.charge_id.present?
+    if (lost_charge = self._find_existing_lost_charge)
+      self.charge_json = lost_charge.fetch(:data).as_json
+      charge_id_set!(Suma::InvalidPostcondition)
+      return
+    end
+
     begin
       charge = self.originating_card.member.stripe.charge_card(
         card: self.originating_card,
@@ -64,8 +70,42 @@ class Suma::Payment::FundingTransaction::StripeCardStrategy <
         localized_error_code: Suma::Stripe.localized_error_code(e),
       )
     end
+
     self.charge_json = charge.as_json
     charge_id_set!(Suma::InvalidPostcondition)
+  end
+
+  # It's possible we already charged this user but lost a reference to the charge
+  # due to a DB outage (see UnassociatedChargeRefunder).
+  # In this case, let's find recent candidate charges from this card;
+  # if any of them are unassociated, use it instead of a new charge.
+  #
+  # NOTE: We cannot use idempotency since that key is based on the strategy identity;
+  # but we never committed the strategy because of the DB error.
+  def _find_existing_lost_charge
+    cutoff = 1.hour.ago
+    data = Sequel.pg_jsonb(:data)
+    # rubocop:disable Style/PreferredHashMethods
+    ds = Suma::Webhookdb.stripe_charges_dataset.
+      where(
+        status: "succeeded",
+        amount: self.funding_transaction.amount.cents,
+        customer: self.originating_card.member.stripe.customer_id,
+      ).
+      where { created > cutoff }.
+      where(
+        data.get("metadata").has_key?("suma_funding_transaction_id") &
+        Sequel[data.get_text("captured") => "true"] &
+        Sequel[data.get_text("refunded") => "false"] &
+        Sequel[data.get("source").get_text("id") => self.originating_card.stripe_id],
+      )
+    # rubocop:enable Style/PreferredHashMethods
+    ds.each do |row|
+      fx_id = row.fetch(:data).fetch("metadata").fetch("suma_funding_transaction_id").to_i
+      next unless Suma::Payment::FundingTransaction.where(id: fx_id).empty?
+      return row
+    end
+    return nil
   end
 
   def funds_cleared?

--- a/lib/suma/webhookdb.rb
+++ b/lib/suma/webhookdb.rb
@@ -11,6 +11,7 @@ module Suma::Webhookdb
     def dataset_for_table(table) = self.connection[Sequel[self.schema][table]]
 
     def postmark_inbound_messages_dataset = self.dataset_for_table(self.postmark_inbound_messages_table)
+    def stripe_charges_dataset = self.dataset_for_table(self.stripe_charges_table)
     def stripe_refunds_dataset = self.dataset_for_table(self.stripe_refunds_table)
     def signalwire_messages_dataset = self.dataset_for_table(self.signalwire_messages_table)
   end
@@ -24,6 +25,7 @@ module Suma::Webhookdb
     setting :front_messages_table, :front_message_v1_fixture
     setting :postmark_inbound_messages_table, :postmark_inbound_message_v1_fixture
     setting :postmark_inbound_messages_secret, "fakesecret-#{SecureRandom.hex(3)}"
+    setting :stripe_charges_table, :stripe_charge_v1_fixture
     setting :stripe_refunds_table, :stripe_refund_v1_fixture
     setting :stripe_refunds_secret, "fakesecret-#{SecureRandom.hex(3)}"
     setting :signalwire_messages_table, :signalwire_message_v1_fixture
@@ -45,13 +47,24 @@ module Suma::Webhookdb
     end
 
     def each(dataset, &)
-      last_synced_pk = Suma::Redis.durable.with { |c| c.call("GET", @pk_key) }.to_i
+      last_synced_pk = self._last_synced_pk
       rows = dataset.order(:pk).where { pk > last_synced_pk }.all
       return 0 if rows.empty?
       rows.each(&)
       Suma::Redis.durable.with { |c| c.call("SET", @pk_key, rows.last.fetch(:pk).to_s) }
       return rows.size
     end
+
+    def each_page(dataset)
+      last_synced_pk = self._last_synced_pk
+      dataset = dataset.where { pk > last_synced_pk }
+      Sequel::Plugins::EfficientEach.each_cursor_page(dataset, page_size: 200, pk: :pk, yield_page: true) do |page|
+        yield(page)
+        Suma::Redis.durable.with { |c| c.call("SET", @pk_key, page.last.fetch(:pk).to_s) }
+      end
+    end
+
+    protected def _last_synced_pk = Suma::Redis.durable.with { |c| c.call("GET", @pk_key) }.to_i
 
     def reset
       Suma::Redis.durable.with { |c| c.call("DEL", @pk_key) }

--- a/spec/suma/api/webhookdb_spec.rb
+++ b/spec/suma/api/webhookdb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Suma::API::Webhookdb, :db do
       post "/v1/webhookdb/stripe_refund_v1", {x: 1}
 
       expect(last_response).to have_status(202)
-      expect(Suma::Async::StripeRefundsBackfiller.jobs).to have_length(1)
+      expect(Suma::Async::StripeBookKeeping.jobs).to have_length(1)
     end
 
     it "errors if the webhook header does not match" do

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -713,7 +713,7 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
     end
   end
 
-  describe "StripeRefundsBackfiller" do
+  describe "StripeBookKeeping" do
     it "syncs refunds" do
       Suma::Webhookdb.stripe_refunds_dataset.insert(
         stripe_id: "re_abc",
@@ -728,7 +728,7 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
         charge_json: {id: "ch_abc"}.to_json,
       )
       Suma::Fixtures.funding_transaction(strategy: funding_strategy).create
-      Suma::Async::StripeRefundsBackfiller.new.perform
+      Suma::Async::StripeBookKeeping.new.perform
       expect(Suma::Payment::PayoutTransaction::StripeChargeRefundStrategy.all).to contain_exactly(
         have_attributes(stripe_charge_id: "ch_abc"),
       )

--- a/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
+++ b/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
@@ -180,4 +180,52 @@ RSpec.describe "Suma::Payment::FundingTransaction::StripeCardStrategy", :db do
       )
     end
   end
+
+  describe "refund_unassociated_charges" do
+    def insert(
+      stripe_id,
+      metadata: {},
+      created: 5.hours.ago,
+      status: "succeeded",
+      funding_transaction_id: 0,
+      captured: true,
+      refunded: false,
+      **more_data
+    )
+      data = {}
+      data.merge!(more_data)
+      data[:id] = stripe_id
+      data[:created] = created.to_i
+      data[:status] = status
+      data[:captured] = captured
+      data[:refunded] = refunded
+      metadata[:suma_funding_transaction_id] = funding_transaction_id.to_s
+      data[:metadata] = metadata
+      data[:source] = {}
+      kw = {stripe_id: stripe_id, status:, created:, data: data.to_json}
+      Suma::Webhookdb.stripe_charges_dataset.insert(kw)
+    end
+
+    it "refunds charges which meet the selection criteria", :no_transaction_check do
+      insert("ch_needsrefund")
+      fx = Suma::Fixtures.funding_transaction.with_fake_strategy.create
+      insert("ch_hasfunding", funding_transaction_id: fx.id.to_s)
+      insert("ch_uncaptured", captured: false)
+      insert("ch_failed", status: "failed")
+      insert("ch_refunded", refunded: true)
+      insert("ch_old", created: 4.weeks.ago)
+      insert("ch_new", created: 2.minutes.ago)
+
+      req = stub_request(:post, "https://api.stripe.com/v1/refunds").
+        with(body: {"charge" => "ch_needsrefund"}).
+        to_return(fixture_response("stripe/charge"))
+
+      described_class.refund_unassociated_charges
+
+      expect(req).to have_been_made
+      expect(Suma::Support::Ticket.all).to contain_exactly(
+        have_attributes(subject: "Refunding Unassociated Stripe Charge"),
+      )
+    end
+  end
 end

--- a/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
+++ b/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Suma::Payment::FundingTransaction::StripeCardStrategy", :db do
   end
 
   describe "collect_funds" do
-    it "captures a change" do
+    it "creates a captured charge" do
       xaction.update(amount_cents: 2000)
       req = stub_request(:post, "https://api.stripe.com/v1/charges").
         with(
@@ -65,6 +65,59 @@ RSpec.describe "Suma::Payment::FundingTransaction::StripeCardStrategy", :db do
       end.to raise_error(Suma::Payment::FundingTransaction::CollectFundsFailed, "Your card was declined.")
       expect(req).to have_been_made
       expect(strategy.charge_id).to be_nil
+    end
+
+    describe "with charges in webhookdb" do
+      let(:amount) { 2000 }
+
+      def insert_charge(id, **kw)
+        charge = load_fixture_data("stripe/charge").deep_symbolize_keys
+        charge[:id] = id.to_s
+        charge[:amount] = amount
+        charge[:customer] = member.stripe.customer_id
+        charge[:created] = Time.now
+        charge[:metadata]["suma_funding_transaction_id"] = "0"
+        charge[:captured] = true
+        charge[:refunded] = false
+        charge[:source][:id] = "card_123"
+        charge.merge!(kw)
+        Suma::Webhookdb.stripe_charges_dataset.
+          insert(
+            stripe_id: charge.fetch(:id),
+            status: charge[:status],
+            amount: charge[:amount],
+            customer: charge[:customer],
+            created: charge[:created],
+            data: charge.to_json,
+          )
+      end
+
+      it "reuses a recent, unassociated charge for the same amount if found" do
+        xaction.update(amount_cents: amount)
+        insert_charge("ch_1")
+        strategy.collect_funds
+        expect(strategy.charge_id).to eq("ch_1")
+      end
+
+      it "does not find false-positive unassociated charges" do
+        xaction.update(amount_cents: amount)
+        insert_charge("failed", status: "failed")
+        insert_charge("wrong_amt", amount: 1999)
+        insert_charge("wrong_customer", customer: "abcdcustomer")
+        insert_charge("old", created: 2.hours.ago)
+        insert_charge("refunded", refunded: true)
+        insert_charge("captured", captured: false)
+        insert_charge("wrong_card", source: {id: "card_another"})
+        other_fx = Suma::Fixtures.funding_transaction.with_fake_strategy.create
+        insert_charge("associated_fx", metadata: {suma_funding_transaction_id: other_fx.id.to_s})
+
+        req = stub_request(:post, "https://api.stripe.com/v1/charges").
+          to_return(**fixture_response("stripe/charge"))
+
+        strategy.collect_funds
+        expect(req).to have_been_made
+        expect(strategy.charge_id).to eq("ch_1Cgkfs2eZvKYlo2CVPsK4I3f")
+      end
     end
   end
 

--- a/spec/suma/webhookdb_spec.rb
+++ b/spec/suma/webhookdb_spec.rb
@@ -15,4 +15,39 @@ RSpec.describe Suma::Webhookdb do
       Suma::Webhookdb.models_enabled = true
     end
   end
+
+  describe "RowIterator", :db do
+    let(:ds) { described_class.stripe_charges_dataset }
+    let(:iterator) do
+      iter = described_class::RowIterator.new("test-rowiterator")
+      iter.reset
+      iter
+    end
+
+    it "iterates through unprocessed rows" do
+      ds.insert(stripe_id: "x1", data: "{}")
+      ds.insert(stripe_id: "x2", data: "{}")
+      arr = []
+      iterator.each(ds) { |r| arr << r[:stripe_id] }
+      expect(arr).to eq(["x1", "x2"])
+      iterator.each(ds) { |r| arr << r[:stripe_id] }
+      expect(arr).to eq(["x1", "x2"])
+      ds.insert(stripe_id: "x3", data: "{}")
+      iterator.each(ds) { |r| arr << r[:stripe_id] }
+      expect(arr).to eq(["x1", "x2", "x3"])
+    end
+
+    it "iterates through pages" do
+      ds.insert(stripe_id: "x1", data: "{}")
+      ds.insert(stripe_id: "x2", data: "{}")
+      arr = []
+      iterator.each_page(ds) { |page| page.each { |r| arr << r[:stripe_id] } }
+      expect(arr).to eq(["x1", "x2"])
+      iterator.each_page(ds) { |page| page.each { |r| arr << r[:stripe_id] } }
+      expect(arr).to eq(["x1", "x2"])
+      ds.insert(stripe_id: "x3", data: "{}")
+      iterator.each_page(ds) { |page| page.each { |r| arr << r[:stripe_id] } }
+      expect(arr).to eq(["x1", "x2", "x3"])
+    end
+  end
 end


### PR DESCRIPTION
It is possible that we create captured Stripe charges, but the transaction fails due to a database outage or other error, and the suma side never commits.

We can detect this has happened by looking for charges which:
- Are captured,
- Have the expected metadata ('suma_funding_transaction_id'),
- Do not have a corresponding strategy row.

These charges can be refunded.
We track where this happens with a support ticket, both to make sure it isn't common,
and because a user may reach out about the charge in the meantime.