### PR TITLE
Fix bug with multiple triggers pulling from the same ledger

### DIFF
--- a/lib/suma/commerce/cart.rb
+++ b/lib/suma/commerce/cart.rb
@@ -185,6 +185,12 @@ class Suma::Commerce::Cart < Suma::Postgres::Model(:commerce_carts)
       @context = context
     end
 
+    # Return the subsidies for this offering product.
+    # NOTE: The subsidies here may DUPLICATE those in other products;
+    # this is because cart products need to show as subsidized independently
+    # so we can show them in the UI for example on product pages.
+    # Only their total subsidy (#noncash_ledger_contribution_amount) will be correct,
+    # as will it be correct during checkout.
     def product_noncash_ledger_contribution_amount(offering_product)
       contribs = Suma::Payment::ChargeContribution.find_ideal_cash_contribution(
         @context,

--- a/lib/suma/commerce/priced_item.rb
+++ b/lib/suma/commerce/priced_item.rb
@@ -24,8 +24,9 @@ module Suma::Commerce::PricedItem
   # @param context [Suma::Payment::CalculationContext]
   # @return [Suma::Payment::ChargeContribution::Collection]
   def self.ledger_charge_contributions(context, payment_account:, priced_items:, mode:)
+    calc_ctx = context
     collections = priced_items.map do |item|
-      args = [context, payment_account, item.offering_product.product, item.customer_cost]
+      args = [calc_ctx, payment_account, item.offering_product.product, item.customer_cost]
       coll = case mode
         when :ideal
           Suma::Payment::ChargeContribution.find_ideal_cash_contribution(*args)
@@ -34,7 +35,21 @@ module Suma::Commerce::PricedItem
         else
           raise ArgumentError, "invalid mode: #{mode}"
       end
-      context = context.apply_debits(*coll.all)
+      calc_ctx = calc_ctx.apply_debits(*coll.all)
+      calc_ctx = calc_ctx.record_trigger_step_contributions(coll.relevant_trigger_steps)
+      # This is tricky. When we are processing multiple items,
+      # and there are trigger subsidies, we will add the subsidy to a ledger.
+      # But then the next items will see this positive balance and try to use it.
+      # Instead, we need to debit *only the added subsidy* for future subsidy calculations.
+      # We want to make sure:
+      # 1) existing subsidy (not due to a trigger) is used,
+      # 2) added subsidy due to a trigger is not used for future steps,
+      # 3) figuring out the subsidy keeps track of what was subsidized
+      #   (see #record_trigger_step_contributions).
+      subsidy_readjustments = coll.relevant_trigger_steps.map do |step|
+        {ledger: step.receiving_ledger, amount: step.amount, trigger: step.trigger}
+      end
+      calc_ctx = calc_ctx.apply_credits(*subsidy_readjustments)
       coll
     end
     consolidated_contributions = Suma::Payment::ChargeContribution::Collection.consolidate(context, collections)

--- a/lib/suma/fixtures/payment_triggers.rb
+++ b/lib/suma/fixtures/payment_triggers.rb
@@ -33,6 +33,7 @@ module Suma::Fixtures::PaymentTriggers
   end
 
   decorator :up_to do |m|
+    m = Suma::SpecHelpers.money(m)
     self.maximum_cumulative_subsidy_cents = m.cents
   end
 

--- a/lib/suma/payment/calculation_context.rb
+++ b/lib/suma/payment/calculation_context.rb
@@ -86,6 +86,12 @@ class Suma::Payment::CalculationContext
     return self.class.new(self.apply_at, adjustments:, adjustments_computed:)
   end
 
+  def inspect
+    return "#<%p %s>" % [self.class, @adjustments]
+  end
+
+  alias to_s inspect if ENV["DEBUGGER_HOST"]
+
   class Adjustment < Suma::TypedStruct
     attr_accessor :ledger, :amount, :trigger, :type
 

--- a/lib/suma/payment/calculation_context.rb
+++ b/lib/suma/payment/calculation_context.rb
@@ -15,21 +15,49 @@
 # if we mutated the context, it would make running the same calculation code
 # non-idempotent.
 class Suma::Payment::CalculationContext
-  def initialize(apply_at, adjustments: {}, adjustments_computed: {})
+  EMPTY_HASH = {}.freeze
+
+  def initialize(apply_at)
     @apply_at = apply_at
-    @adjustments = adjustments.freeze
-    @adjustments_computed = adjustments_computed.freeze
+    @adjustments = EMPTY_HASH
+    @adjustments_computed = EMPTY_HASH
+    @trigger_contributions = EMPTY_HASH
     @cache = {}
   end
 
   # @return [Time]
   attr_reader :apply_at
 
+  # Return an instance using the new fields.
+  # Mutable fields (like the cache) as shared.
+  def duplicate_with(adjustments: nil, adjustments_computed: nil, trigger_contributions: nil)
+    d = self.class.new(self.apply_at)
+    adjustments ||= @adjustments
+    adjustments_computed ||= @adjustments_computed
+    trigger_contributions ||= @trigger_contributions
+    d.instance_variable_set(:@adjustments, adjustments.freeze)
+    d.instance_variable_set(:@adjustments_computed, adjustments_computed.freeze)
+    d.instance_variable_set(:@trigger_contributions, trigger_contributions.freeze)
+    d.instance_variable_set(:@cache, @cache)
+    return d
+  end
+
+  # Return each of the adjusted ledgers.
+  # @return [Array<Suma::Payment::Ledger]
+  def ledgers = @adjustments.values.map { |adjs| adjs.first.ledger }
+
   # Invoke the yielded block to get the value stored at key,
-  # and then return that value for the lifetime of the context.
+  # and then return that value for the lifetime of the context,
+  # and all spawned contexts.
+  #
   # Can be used to avoid re-querying the database when the same database-querying method
   # needs to be called many times.
-  def cached_get(key, &)
+  #
+  # IMPORTANT: This must only be used for queries that do not change over the context
+  # (or child context) lifetimes, since the cache is shared.
+  # That is, it should not be used for things like balances, or in calculations that vary
+  # during the calculation (like payment trigger contributions via executions).
+  def nonvarying_cached_get(key, &)
     return @cache[key] if @cache.include?(key)
     v = yield
     @cache[key] = v
@@ -47,9 +75,7 @@ class Suma::Payment::CalculationContext
     return balance
   end
 
-  def adjustments_for(ledger)
-    return @adjustments.fetch(ledger.id, [])
-  end
+  def adjustments_for(ledger) = @adjustments.fetch(ledger.id, [])
 
   # Apply an adjustment so that when calculating the balance for the given +contrib.ledger+,
   # the given +contrib.amount+ is taken from the ledger's balance. For example, if +ledger+ has a balance of $0,
@@ -83,7 +109,25 @@ class Suma::Payment::CalculationContext
       these_adj = adjustments[ledger_id] ||= []
       these_adj << adj
     end
-    return self.class.new(self.apply_at, adjustments:, adjustments_computed:)
+    return self.duplicate_with(adjustments:, adjustments_computed:)
+  end
+
+  def contributions_from_trigger(trigger, ledger)
+    contrib = @trigger_contributions[trigger.id]
+    return Money.zero if contrib.nil?
+    return contrib.fetch(ledger.id, Money.zero)
+  end
+
+  # Record trigger executions in-memory so they can be used later when figuring out trigger plans.
+  # @param [Array<Suma::Payment::Trigger::PlanStep>] steps
+  def record_trigger_step_contributions(steps)
+    d = @trigger_contributions.dup
+    steps.each do |step|
+      d[step.trigger.id] ||= {}
+      d[step.trigger.id][step.ledger.id] ||= Money.zero
+      d[step.trigger.id][step.ledger.id] += step.amount
+    end
+    return self.duplicate_with(trigger_contributions: d)
   end
 
   def inspect

--- a/lib/suma/payment/calculation_context.rb
+++ b/lib/suma/payment/calculation_context.rb
@@ -124,8 +124,8 @@ class Suma::Payment::CalculationContext
     d = @trigger_contributions.dup
     steps.each do |step|
       d[step.trigger.id] ||= {}
-      d[step.trigger.id][step.ledger.id] ||= Money.zero
-      d[step.trigger.id][step.ledger.id] += step.amount
+      d[step.trigger.id][step.receiving_ledger.id] ||= Money.zero
+      d[step.trigger.id][step.receiving_ledger.id] += step.amount
     end
     return self.duplicate_with(trigger_contributions: d)
   end

--- a/lib/suma/payment/charge_contribution.rb
+++ b/lib/suma/payment/charge_contribution.rb
@@ -103,7 +103,7 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
 
     # If, when calculating the collection, payment trigger contributions were used,
     # these were the steps relating to the contributions.
-    # @return [Array<Suma::Payment::Trigger::Step>]
+    # @return [Array<Suma::Payment::Trigger::PlanStep>]
     attr_accessor :relevant_trigger_steps
 
     # @param [Suma::Payment::Trigger::Plan] funding_plan
@@ -177,6 +177,7 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
           end
         end
       end
+      result.relevant_trigger_steps.reject! { |step| step.amount.zero? }
       return result
     end
   end
@@ -225,7 +226,7 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
     charges_using_existing_ledgers = self.find_actual_contributions(context, account, has_vnd_svc_categories, amount)
     return charges_using_existing_ledgers unless charges_using_existing_ledgers.remainder?
 
-    # We do not worry about existing negative balances on the ledger.
+    # We do not worry about existing negative balances on the cash ledger.
     # See _nonnegative_balance above.
     # This is especially important here, because we may call find_ideal_cash_contribution
     # for each product in a cart; the contributions for the first product create a negative ledger balance.
@@ -236,9 +237,11 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
     #
     # Get the original balance, and if it's negative, treat it as a 'credit' so we don't calculate it.
     original_cash_balance = [context.balance(cash), Money.new(0, amount.currency)].min
+    context = context.apply_credits({ledger: cash, amount: -original_cash_balance}) if
+      original_cash_balance.negative?
 
     # We'll need to run triggers to calculate subsidy.
-    triggers = context.cached_get("triggers-#{account.id}") do
+    triggers = context.nonvarying_cached_get("triggers-#{account.id}") do
       Suma::Payment::Trigger.gather(account, active_as_of: context.apply_at)
     end
     # Bisect until we find a funding amount that results in no remainder,
@@ -251,7 +254,7 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
       subsidy_plan = triggers.funding_plan(context, amount: candidate, up_to: amount)
       candidate_charges = self.find_actual_contributions(
         context.apply_credits(
-          {ledger: cash, amount: candidate + -original_cash_balance},
+          {ledger: cash, amount: candidate},
           *subsidy_plan.steps.map { |st| {ledger: st.receiving_ledger, amount: st.amount, trigger: st.trigger} },
         ),
         account,
@@ -293,6 +296,7 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
   end
 
   # Helper to maintain signature parity with +find_ideal_cash_contribution+.
+  # @return [Suma::Payment::ChargeContribution::Collection]
   def self.find_actual_contributions(context, account, has_vnd_svc_categories, amount)
     return account.calculate_charge_contributions(context, has_vnd_svc_categories, amount)
   end

--- a/lib/suma/payment/charge_contribution.rb
+++ b/lib/suma/payment/charge_contribution.rb
@@ -258,15 +258,18 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
         has_vnd_svc_categories,
         amount,
       )
-      candidate_charges.set_relevant_trigger_steps_from(subsidy_plan)
-      # Figure out how much 'additional' cash is needed, by taking the amount we need to cover the bill,
-      # and subtracting what we'd contribute without any additional funds (this is normally the balance).
+
       # If the additional funds we need to charge, is equal to the candidate, then this is ideal, because:
       # - If the additional funds to charge is less than the candidate, we added too much cash,
       #   and we have extra balance on our cash ledger, which we don't want.
       # - If we need more funds (there is a remainder), the candidate was not high enough.
-      additional_cash = candidate_charges.cash.amount - charges_using_existing_ledgers.cash.amount
-      return candidate_charges if !candidate_charges.remainder? && candidate == additional_cash
+      # Note that (for now) we WANT to include existing cash funds in what we calculate a subsidy against;
+      # we call this "cash is cash" (that is, if it's on the cash ledger, it's as good as cash coming in).
+      additional_cash = candidate_charges.cash.amount
+      if !candidate_charges.remainder? && candidate == additional_cash
+        candidate_charges.set_relevant_trigger_steps_from(subsidy_plan)
+        return candidate_charges
+      end
       step = amount / (2**loop_number)
       if step.zero?
         # It may be that there is no whole cent cash contribution that will yield amount exactly.
@@ -275,6 +278,7 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
         #   $3 + $x + ($x * 3.8) = $24
         # In this case, we just use whatever we tried last. In testing,
         # this seems to work, but we should in the future try some more mathematical proofs.
+        candidate_charges.set_relevant_trigger_steps_from(subsidy_plan)
         return candidate_charges
       end
       needs_more_cash = candidate_charges.remainder?

--- a/lib/suma/payment/charge_contribution.rb
+++ b/lib/suma/payment/charge_contribution.rb
@@ -49,7 +49,7 @@ class Suma::Payment::ChargeContribution < Suma::TypedStruct
   # for example, if you have a -$5 balance on your cash ledger,
   # we could calculate the cost of your cart with an additional $5 'cash product' ("existing ledger balance")
   # you'd have to pay for.
-  private def _nonnegative_balance = [Money.new(0, self.amount.currency), self.ledger.balance].max
+  private def _nonnegative_balance = Money.new([0, self.ledger&.balance&.cents || 0].max, self.amount.currency)
 
   def amount? = !self.amount.zero?
 

--- a/lib/suma/payment/trigger.rb
+++ b/lib/suma/payment/trigger.rb
@@ -169,18 +169,22 @@ class Suma::Payment::Trigger < Suma::Postgres::Model(:payment_triggers)
     )
     if self.maximum_cumulative_subsidy_cents.positive?
       max_subsidy_cents = self.maximum_cumulative_subsidy_cents
-      cents_received_already = context.cached_get("trigger-funded-amt-from-#{self.id}-to-#{receiving.id}") do
+      funded_cache_key = "trigger-funded-amt-from-#{self.id}-to-#{receiving.id}"
+      money_received_already_db = context.nonvarying_cached_get(funded_cache_key) do
         # We want to total only funds received for the CURRENT 'active during' window.
         # Each window 'resets' the max subsidy received.
         current_window = self.current_active_during(now: context.apply_at)
-        Suma::Payment::Trigger::Execution.where(trigger: self).
+        cents = Suma::Payment::Trigger::Execution.where(trigger: self).
           where(Sequel.pg_range(current_window).op.contains(:apply_execution_at)).
           join(
             Suma::Payment::BookTransaction.where(receiving_ledger: receiving),
             {id: :book_transaction_id},
           ).sum(:amount_cents)
+        Money.new(cents || 0)
       end
-      max_subsidy_cents -= cents_received_already if cents_received_already
+      money_received_already_ctx = context.contributions_from_trigger(self, receiving)
+      money_received_already = money_received_already_db + money_received_already_ctx
+      max_subsidy_cents -= money_received_already.cents
       max_subsidy = Money.new(max_subsidy_cents, subsidy.currency)
       subsidy = [subsidy, max_subsidy].min
     end

--- a/lib/suma/postgres/model_utilities.rb
+++ b/lib/suma/postgres/model_utilities.rb
@@ -192,6 +192,8 @@ module Suma::Postgres::ModelUtilities
     end
   end
 
+  INSPECT_KEY_PRIORITY = [:id, :name, :label, :title].freeze
+
   module InstanceMethods
     # Return a human-readable representation of the object as a String suitable for debugging.
     def inspect
@@ -208,7 +210,12 @@ module Suma::Postgres::ModelUtilities
       rescue NoMethodError
         nil
       end
-      values = values.map do |(k, v)|
+      keys = values.keys.sort_by do |(k, _v)|
+        idx = INSPECT_KEY_PRIORITY.index(k)
+        [idx || INSPECT_KEY_PRIORITY.length, k]
+      end
+      values = keys.map do |k|
+        v = values[k]
         k = k.to_s
         v = if v.is_a?(Time)
               self.inspect_time(v)

--- a/lib/suma/typed_struct.rb
+++ b/lib/suma/typed_struct.rb
@@ -76,7 +76,15 @@ class Suma::TypedStruct
   end
 
   def inspect
-    kvps = self.class._accessors.map { |m| "#{m}: #{self.send(m).inspect}" }.join(", ")
+    kvps = self.class._accessors.map do |m|
+      v = self.send(m)
+      s = if v.is_a?(Money)
+            v.format
+        else
+          v.inspect
+        end
+      "#{m}: #{s}"
+    end.join(", ")
     return "#<#{self.class.name} #{kvps}>"
   end
 

--- a/lib/suma/typed_struct.rb
+++ b/lib/suma/typed_struct.rb
@@ -77,8 +77,10 @@ class Suma::TypedStruct
 
   def inspect
     kvps = self.class._accessors.map { |m| "#{m}: #{self.send(m).inspect}" }.join(", ")
-    return "#{self.class.name}(#{kvps})"
+    return "#<#{self.class.name} #{kvps}>"
   end
+
+  alias to_s inspect if ENV["DEBUGGER_HOST"]
 
   def to_h = self.class._accessors.to_h { |k| [k, self[k]] }
   def as_json = self.to_h.as_json

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -408,6 +408,42 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       end
     end
 
+    it "handles a bug" do
+      member = Suma::Fixtures.member.onboarding_verified.create
+
+      cash_vsc = Suma::Vendor::ServiceCategory.cash
+      food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
+
+      cash_ledger = Suma::Payment.ensure_cash_ledger(member)
+      food_ledger = Suma::Fixtures.ledger.member(member).
+        with_categories(food_vsc).
+        create(name: "food")
+
+      Suma::Payment::Account.lookup_platform_account.ensure_cash_ledger
+      platform_food_ledger = Suma::Fixtures.ledger.
+        with_categories(food_vsc).
+        create(name: "food", account: Suma::Payment::Account.lookup_platform_account)
+
+      offering = Suma::Fixtures.offering.create
+      product1 = Suma::Fixtures.product.with_categories(food_vsc).create
+      op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+      product2 = Suma::Fixtures.product.with_categories(food_vsc).create
+      op2 = Suma::Fixtures.offering_product(product: product2, offering:).costing("$50", "$50").create
+      trigger = Suma::Fixtures.payment_trigger.matching(1).
+        from(platform_food_ledger).
+        create
+
+      cart = Suma::Fixtures.cart(offering:, member:).
+        with_product(product1, 1).
+        with_product(product2, 1).
+        create
+      ctx = Suma::Payment::CalculationContext.new(Time.now)
+      ci = cart.cost_info(ctx)
+      expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost('$25')
+      expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost('$25')
+      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost('$50'))
+    end
+
     describe "inventory behavior" do
       it "errors if the order quantity exceeds the maximum allowed on the offering" do
         offering.update(max_ordered_items_cumulative: 1)

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     let(:cart) { Suma::Fixtures.cart(offering:, member:).with_product(product, 2).create }
     let(:card) { Suma::Fixtures.card.member(member).create }
     let(:checkout) { Suma::Fixtures.checkout(cart:, card:).populate_items.create }
+    let(:apply_at) { Time.now }
 
     let(:member) { Suma::Fixtures.member.onboarding_verified.registered_as_stripe_customer.create }
     let(:ledger_fac) { Suma::Fixtures.ledger.member(member) }
@@ -288,9 +289,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
           with_product(holiday_product, 1). # $40
           with_product(cash_product, 1). # #4
           create
-        checkout = Suma::Fixtures.checkout(cart:, card: Suma::Fixtures.card.member(member).create).
-          populate_items.
-          create
+        checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
 
         # See above for how we get this
         customer_cost = money("$1244")
@@ -349,9 +348,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
           with_product(intro_product, 1).
           with_product(match_product, 15).
           create
-        checkout = Suma::Fixtures.checkout(cart:, card: Suma::Fixtures.card.member(member).create).
-          populate_items.
-          create
+        checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
 
         # $54 total = $30 in match vouchers + $24 in intro vouchers
         # $20 charge = $15 match voucher cash cost + $5 into voucher cash cost
@@ -384,9 +381,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         cart = Suma::Fixtures.cart(offering:, member:).
           with_product(low_product, 1).
           create
-        checkout = Suma::Fixtures.checkout(cart:, card: Suma::Fixtures.card.member(member).create).
-          populate_items.
-          create
+        checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
 
         order = create_order(checkout_: checkout)
         expect(order.charge).to have_attributes(
@@ -418,10 +413,14 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
           with_product(product2, 1).
           create
         ctx = Suma::Payment::CalculationContext.new(Time.now)
-        ci = cart.cost_info(ctx)
-        expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$50"))
-        expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
-        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
+        cart_costinfo = cart.cost_info(ctx)
+        expect(cart_costinfo).to have_attributes(noncash_ledger_contribution_amount: cost("$50"))
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
+        checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+        contribs = checkout.predicted_charge_contributions(apply_at:)
+        expect(contribs.cash.amount).to cost("$50")
+        expect(contribs.rest.sum(&:amount)).to cost("$50")
       end
 
       it "applies maximum trigger match properly (hit on first item)" do
@@ -439,12 +438,14 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
           with_product(product2, 1).
           create
         ctx = Suma::Payment::CalculationContext.new(Time.now)
-        ci = cart.cost_info(ctx)
-        expect(ci).to have_attributes(cash_cost: cost("80"), noncash_ledger_contribution_amount: cost("$20"))
-        expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$20")
-        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$20")
-        # TODO: This method is unsafe, rename it
-        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$20")
+        cart_costinfo = cart.cost_info(ctx)
+        expect(cart_costinfo).to have_attributes(cash_cost: cost("80"), noncash_ledger_contribution_amount: cost("$20"))
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op1)).to cost("$20")
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op2)).to cost("$20")
+        checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+        contribs = checkout.predicted_charge_contributions(apply_at:)
+        expect(contribs.cash.amount).to cost("$80")
+        expect(contribs.rest.sum(&:amount)).to cost("$20")
       end
 
       it "applies maximum trigger match properly (hit on later items)" do
@@ -465,12 +466,15 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
           with_product(product3, 1).
           create
         ctx = Suma::Payment::CalculationContext.new(Time.now)
-        ci = cart.cost_info(ctx)
-        expect(ci).to have_attributes(cash_cost: cost("90"), noncash_ledger_contribution_amount: cost("$60"))
-        # TODO: This method is unsafe, rename it
-        expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
-        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
-        expect(ci.product_noncash_ledger_contribution_amount(op3)).to cost("$25")
+        cart_costinfo = cart.cost_info(ctx)
+        expect(cart_costinfo).to have_attributes(cash_cost: cost("90"), noncash_ledger_contribution_amount: cost("$60"))
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op3)).to cost("$25")
+        checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+        contribs = checkout.predicted_charge_contributions(apply_at:)
+        expect(contribs.cash.amount).to cost("$90")
+        expect(contribs.rest.sum(&:amount)).to cost("$60")
       end
 
       it "uses what is available on the subsidy ledger" do
@@ -489,10 +493,16 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
           with_product(product2, 1).
           create
         ctx = Suma::Payment::CalculationContext.new(Time.now)
-        ci = cart.cost_info(ctx)
-        expect(ci).to have_attributes(cash_cost: cost("$60"), noncash_ledger_contribution_amount: cost("$40"))
-        # TODO: This method is unsafe, rename it
-        # expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
+        cart_costinfo = cart.cost_info(ctx)
+        expect(cart_costinfo).to have_attributes(
+          cash_cost: cost("$60"), noncash_ledger_contribution_amount: cost("$40"),
+        )
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op1)).to cost("$30")
+        expect(cart_costinfo.product_noncash_ledger_contribution_amount(op2)).to cost("$30")
+        checkout = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+        contribs = checkout.predicted_charge_contributions(apply_at:)
+        expect(contribs.cash.amount).to cost("$60")
+        expect(contribs.rest.sum(&:amount)).to cost("$40")
       end
     end
 

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -133,16 +133,30 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
   end
 
   describe "create_order", :i18n do
-    let(:member) { Suma::Fixtures.member.onboarding_verified.registered_as_stripe_customer.create }
-    let(:offering) { Suma::Fixtures.offering.create }
-    let!(:fulfillment) { Suma::Fixtures.offering_fulfillment_option(offering:).create }
+    let(:cash_vsc) { Suma::Vendor::ServiceCategory.cash }
+    let(:food_vsc) { Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create }
+
+    let(:offering) { Suma::Fixtures.offering.with_fulfillment.create }
     let(:product) { Suma::Fixtures.product.category(:food).create }
     let!(:offering_product) { Suma::Fixtures.offering_product(product:, offering:).costing("$20", "$30").create }
     let(:cart) { Suma::Fixtures.cart(offering:, member:).with_product(product, 2).create }
     let(:card) { Suma::Fixtures.card.member(member).create }
     let(:checkout) { Suma::Fixtures.checkout(cart:, card:).populate_items.create }
-    let!(:cash_ledger) { Suma::Fixtures.ledger.member(member).category(:cash).create }
+
+    let(:member) { Suma::Fixtures.member.onboarding_verified.registered_as_stripe_customer.create }
+    let(:ledger_fac) { Suma::Fixtures.ledger.member(member) }
+    let!(:cash_ledger) { ledger_fac.category(:cash).create }
+    let(:food_ledger) do
+      member.payment_account.ledgers_dataset[name: "food"] || ledger_fac.with_categories(food_vsc).create(name: "food")
+    end
+
+    let(:platform_account) { Suma::Payment::Account.lookup_platform_account }
     let!(:platform_cash_ledger) { Suma::Fixtures::Ledgers.ensure_platform_cash }
+    let(:platform_food_ledger) do
+      platform_account.ledgers_dataset[name: "food"] || Suma::Fixtures.ledger.
+        with_categories(food_vsc).
+        create(name: "food", account: platform_account)
+    end
 
     around(:each) do |ex|
       Suma::Payment::FundingTransaction.force_fake(proc { Suma::Payment::FakeStrategy.create.ready }) do
@@ -221,15 +235,10 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     end
 
     it "creates payment trigger transactions only for those that factor into contributions" do
-      food = checkout.items.first.cart_item.product.vendor_service_categories.first
-      sending_food_ledger = Suma::Fixtures.ledger.with_categories(food).
-        create(name: "Food", account: platform_cash_ledger.account)
-      receiving_food_ledger = Suma::Fixtures.ledger.with_categories(food).
-        create(name: "Food", account: checkout.cart.member.payment_account)
       other_ledger = Suma::Fixtures.ledger.with_categories.create
 
-      matched_trigger1 = Suma::Fixtures.payment_trigger.matching(1).from(sending_food_ledger).create
-      matched_trigger2 = Suma::Fixtures.payment_trigger.matching(0.5).from(sending_food_ledger).create
+      matched_trigger1 = Suma::Fixtures.payment_trigger.matching(1).from(platform_food_ledger).create
+      matched_trigger2 = Suma::Fixtures.payment_trigger.matching(0.5).from(platform_food_ledger).create
       unmatched_trigger = Suma::Fixtures.payment_trigger.matching(0.1).from(other_ledger).create
 
       # $16 cash should generate $24 in subsidy ($16 from 1-to-1 and $8 from 0.5 match)
@@ -239,12 +248,12 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       )
       expect(matched_trigger1.executions).to contain_exactly(
         have_attributes(
-          book_transaction: have_attributes(amount: cost("$16"), receiving_ledger: be === receiving_food_ledger),
+          book_transaction: have_attributes(amount: cost("$16"), receiving_ledger: be === food_ledger),
         ),
       )
       expect(matched_trigger2.executions).to contain_exactly(
         have_attributes(
-          book_transaction: have_attributes(amount: cost("$8"), receiving_ledger: be === receiving_food_ledger),
+          book_transaction: have_attributes(amount: cost("$8"), receiving_ledger: be === food_ledger),
         ),
       )
       expect(unmatched_trigger.executions).to be_empty
@@ -252,14 +261,8 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
 
     describe "with a complex, multi-product, multi-ledger product and payment setup" do
       it "generates the right funding and book transaction, as per the documentation" do
-        cash_vsc = Suma::Vendor::ServiceCategory.cash
-        food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
         holidaymeal_vsc = Suma::Fixtures.vendor_service_category(name: "Holiday Special", parent: food_vsc).create
-        member = Suma::Fixtures.member.onboarding_verified.create
 
-        cash_ledger = Suma::Payment.ensure_cash_ledger(member)
-        ledger_fac = Suma::Fixtures.ledger.member(member)
-        food_ledger = ledger_fac.with_categories(food_vsc).create(name: "food")
         holidaymeal_ledger = ledger_fac.with_categories(holidaymeal_vsc).create(name: "holidays")
 
         # Make sure we debit existing ledgers properly
@@ -267,7 +270,6 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         book_food = Suma::Fixtures.book_transaction.to(food_ledger).create(amount: money("$3"))
         book_holiday = Suma::Fixtures.book_transaction.to(holidaymeal_ledger).create(amount: money("$0.30"))
 
-        offering = Suma::Fixtures.offering.create
         food_product1 = Suma::Fixtures.product.with_categories(food_vsc).create
         food_op1 = Suma::Fixtures.offering_product(product: food_product1, offering:).costing("$400", "$500").create
 
@@ -321,13 +323,9 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       end
 
       it "charges the correct amount when dealing with multiple triggers" do
-        cash_vsc = Suma::Vendor::ServiceCategory.cash
         fm_intro_vsc = Suma::Fixtures.vendor_service_category(name: "FM Intro", parent: cash_vsc).create
         fm_match_vsc = Suma::Fixtures.vendor_service_category(name: "FM Match", parent: cash_vsc).create
 
-        member = Suma::Fixtures.member.onboarding_verified.create
-        cash_ledger = Suma::Payment.ensure_cash_ledger(member)
-        ledger_fac = Suma::Fixtures.ledger.member(member)
         intro_ledger = ledger_fac.with_categories(fm_intro_vsc).create(name: "intro")
         match_ledger = ledger_fac.with_categories(fm_match_vsc).create(name: "match")
 
@@ -336,7 +334,6 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         match_platform_led = Suma::Fixtures.ledger.with_categories(fm_match_vsc).
           create(name: "match", account: platform_cash_ledger.account)
 
-        offering = Suma::Fixtures.offering.create
         intro_product = Suma::Fixtures.product.with_categories(fm_intro_vsc).create
         intro_op = Suma::Fixtures.offering_product(product: intro_product, offering:).costing("$24", "24").create
         match_product = Suma::Fixtures.product.with_categories(fm_match_vsc).create
@@ -374,14 +371,10 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         top_vsc = Suma::Fixtures.vendor_service_category(name: "Everything").create
         mid_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: top_vsc).create
         low_vsc = Suma::Fixtures.vendor_service_category(name: "Organic", parent: mid_vsc).create
-        member = Suma::Fixtures.member.onboarding_verified.create
 
-        cash_ledger = Suma::Payment.ensure_cash_ledger(member)
         top_ledger = Suma::Fixtures.ledger.member(member).with_categories(top_vsc).create
         mid_ledger = Suma::Fixtures.ledger.member(member).with_categories(mid_vsc).create
         low_ledger = Suma::Fixtures.ledger.member(member).with_categories(low_vsc).create
-
-        offering = Suma::Fixtures.offering.create
 
         low_product = Suma::Fixtures.product.with_categories(low_vsc).create
         low_op = Suma::Fixtures.offering_product(product: low_product, offering:).costing("$40", "$50").create
@@ -409,22 +402,6 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     end
 
     it "calculates the correct subsidy for multiple products from the same subsidy" do
-      member = Suma::Fixtures.member.onboarding_verified.create
-
-      cash_vsc = Suma::Vendor::ServiceCategory.cash
-      food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
-
-      cash_ledger = Suma::Payment.ensure_cash_ledger(member)
-      food_ledger = Suma::Fixtures.ledger.member(member).
-        with_categories(food_vsc).
-        create(name: "food")
-
-      Suma::Payment::Account.lookup_platform_account.ensure_cash_ledger
-      platform_food_ledger = Suma::Fixtures.ledger.
-        with_categories(food_vsc).
-        create(name: "food", account: Suma::Payment::Account.lookup_platform_account)
-
-      offering = Suma::Fixtures.offering.create
       product1 = Suma::Fixtures.product.with_categories(food_vsc).create
       op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
       product2 = Suma::Fixtures.product.with_categories(food_vsc).create
@@ -445,24 +422,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     end
 
     it "does not include a negative cash ledger balance in subsidy matching or charging" do
-      member = Suma::Fixtures.member.onboarding_verified.create
-
-      cash_vsc = Suma::Vendor::ServiceCategory.cash
-      food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
-
-      cash_ledger = Suma::Payment.ensure_cash_ledger(member)
-      food_ledger = Suma::Fixtures.ledger.member(member).
-        with_categories(food_vsc).
-        create(name: "food")
-
-      Suma::Payment::Account.lookup_platform_account.ensure_cash_ledger
-      platform_food_ledger = Suma::Fixtures.ledger.
-        with_categories(food_vsc).
-        create(name: "food", account: Suma::Payment::Account.lookup_platform_account)
-
-      offering = Suma::Fixtures.offering.create
-      product1 = Suma::Fixtures.product.with_categories(food_vsc).create
-      op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+      op1 = offering_product.with_changes(customer_price: money("$50"), undiscounted_price: money("$66"))
       trigger = Suma::Fixtures.payment_trigger.matching(1).
         from(platform_food_ledger).
         create
@@ -470,7 +430,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       Suma::Fixtures.book_transaction.from(cash_ledger).create(amount: money("$10"))
 
       cart = Suma::Fixtures.cart(offering:, member:).
-        with_product(product1, 1).
+        with_product(product, 1).
         create
       ctx = Suma::Payment::CalculationContext.new(Time.now)
       ci = cart.cost_info(ctx)
@@ -479,7 +439,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       order = create_order(money("$25"), checkout_: ch)
       expect(order.charge).to have_attributes(
         discounted_subtotal: cost("$50"),
-        undiscounted_subtotal: cost("$50"),
+        undiscounted_subtotal: cost("$66"),
       )
       expect(order.charge.contributing_book_transactions).to contain_exactly(
         have_attributes(originating_ledger: be === cash_ledger, amount: cost("$25")),
@@ -493,24 +453,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
     end
 
     it "does match subsidies against a postive cash ledger balance" do
-      member = Suma::Fixtures.member.onboarding_verified.create
-
-      cash_vsc = Suma::Vendor::ServiceCategory.cash
-      food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
-
-      cash_ledger = Suma::Payment.ensure_cash_ledger(member)
-      food_ledger = Suma::Fixtures.ledger.member(member).
-        with_categories(food_vsc).
-        create(name: "food")
-
-      Suma::Payment::Account.lookup_platform_account.ensure_cash_ledger
-      platform_food_ledger = Suma::Fixtures.ledger.
-        with_categories(food_vsc).
-        create(name: "food", account: Suma::Payment::Account.lookup_platform_account)
-
-      offering = Suma::Fixtures.offering.create
-      product1 = Suma::Fixtures.product.with_categories(food_vsc).create
-      op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+      op1 = offering_product.with_changes(customer_price: money("$50"), undiscounted_price: money("$66"))
       trigger = Suma::Fixtures.payment_trigger.matching(1).
         from(platform_food_ledger).
         create
@@ -518,7 +461,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$10"))
 
       cart = Suma::Fixtures.cart(offering:, member:).
-        with_product(product1, 1).
+        with_product(product, 1).
         create
       ctx = Suma::Payment::CalculationContext.new(Time.now)
       ci = cart.cost_info(ctx)
@@ -527,7 +470,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       order = create_order(money("$15"), checkout_: ch)
       expect(order.charge).to have_attributes(
         discounted_subtotal: cost("$50"),
-        undiscounted_subtotal: cost("$50"),
+        undiscounted_subtotal: cost("$66"),
       )
       expect(order.charge.contributing_book_transactions).to contain_exactly(
         have_attributes(originating_ledger: be === cash_ledger, amount: cost("$25")),

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       end
     end
 
-    it "handles a bug" do
+    it "calculates the correct subsidy for multiple products from the same subsidy" do
       member = Suma::Fixtures.member.onboarding_verified.create
 
       cash_vsc = Suma::Vendor::ServiceCategory.cash
@@ -439,9 +439,9 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         create
       ctx = Suma::Payment::CalculationContext.new(Time.now)
       ci = cart.cost_info(ctx)
-      expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost('$25')
-      expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost('$25')
-      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost('$50'))
+      expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
+      expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
+      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$50"))
     end
 
     describe "inventory behavior" do

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -439,9 +439,105 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         create
       ctx = Suma::Payment::CalculationContext.new(Time.now)
       ci = cart.cost_info(ctx)
+      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$50"))
       expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
       expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
-      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$50"))
+    end
+
+    it "does not include a negative cash ledger balance in subsidy matching or charging" do
+      member = Suma::Fixtures.member.onboarding_verified.create
+
+      cash_vsc = Suma::Vendor::ServiceCategory.cash
+      food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
+
+      cash_ledger = Suma::Payment.ensure_cash_ledger(member)
+      food_ledger = Suma::Fixtures.ledger.member(member).
+        with_categories(food_vsc).
+        create(name: "food")
+
+      Suma::Payment::Account.lookup_platform_account.ensure_cash_ledger
+      platform_food_ledger = Suma::Fixtures.ledger.
+        with_categories(food_vsc).
+        create(name: "food", account: Suma::Payment::Account.lookup_platform_account)
+
+      offering = Suma::Fixtures.offering.create
+      product1 = Suma::Fixtures.product.with_categories(food_vsc).create
+      op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+      trigger = Suma::Fixtures.payment_trigger.matching(1).
+        from(platform_food_ledger).
+        create
+
+      Suma::Fixtures.book_transaction.from(cash_ledger).create(amount: money("$10"))
+
+      cart = Suma::Fixtures.cart(offering:, member:).
+        with_product(product1, 1).
+        create
+      ctx = Suma::Payment::CalculationContext.new(Time.now)
+      ci = cart.cost_info(ctx)
+      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$25"), cash_cost: cost("$25"))
+      ch = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+      order = create_order(money("$25"), checkout_: ch)
+      expect(order.charge).to have_attributes(
+        discounted_subtotal: cost("$50"),
+        undiscounted_subtotal: cost("$50"),
+      )
+      expect(order.charge.contributing_book_transactions).to contain_exactly(
+        have_attributes(originating_ledger: be === cash_ledger, amount: cost("$25")),
+        have_attributes(originating_ledger: be === food_ledger, amount: cost("$25")),
+      )
+      expect(order.charge.associated_funding_transactions).to contain_exactly(
+        have_attributes(amount: cost("$25"), status: "collecting"),
+      )
+      expect(food_ledger.refresh).to(have_attributes(balance: be_zero))
+      expect(cash_ledger.refresh).to(have_attributes(balance: cost("-$10")))
+    end
+
+    it "does match subsidies against a postive cash ledger balance" do
+      member = Suma::Fixtures.member.onboarding_verified.create
+
+      cash_vsc = Suma::Vendor::ServiceCategory.cash
+      food_vsc = Suma::Fixtures.vendor_service_category(name: "Food", parent: cash_vsc).create
+
+      cash_ledger = Suma::Payment.ensure_cash_ledger(member)
+      food_ledger = Suma::Fixtures.ledger.member(member).
+        with_categories(food_vsc).
+        create(name: "food")
+
+      Suma::Payment::Account.lookup_platform_account.ensure_cash_ledger
+      platform_food_ledger = Suma::Fixtures.ledger.
+        with_categories(food_vsc).
+        create(name: "food", account: Suma::Payment::Account.lookup_platform_account)
+
+      offering = Suma::Fixtures.offering.create
+      product1 = Suma::Fixtures.product.with_categories(food_vsc).create
+      op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+      trigger = Suma::Fixtures.payment_trigger.matching(1).
+        from(platform_food_ledger).
+        create
+
+      Suma::Fixtures.book_transaction.to(cash_ledger).create(amount: money("$10"))
+
+      cart = Suma::Fixtures.cart(offering:, member:).
+        with_product(product1, 1).
+        create
+      ctx = Suma::Payment::CalculationContext.new(Time.now)
+      ci = cart.cost_info(ctx)
+      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$25"), cash_cost: cost("$25"))
+      ch = Suma::Fixtures.checkout(cart:, card:).populate_items.create
+      order = create_order(money("$15"), checkout_: ch)
+      expect(order.charge).to have_attributes(
+        discounted_subtotal: cost("$50"),
+        undiscounted_subtotal: cost("$50"),
+      )
+      expect(order.charge.contributing_book_transactions).to contain_exactly(
+        have_attributes(originating_ledger: be === cash_ledger, amount: cost("$25")),
+        have_attributes(originating_ledger: be === food_ledger, amount: cost("$25")),
+      )
+      expect(order.charge.associated_funding_transactions).to contain_exactly(
+        have_attributes(amount: cost("$15"), status: "collecting"),
+      )
+      expect(food_ledger.refresh).to(have_attributes(balance: be_zero))
+      expect(cash_ledger.refresh).to(have_attributes(balance: be_zero))
     end
 
     describe "inventory behavior" do

--- a/spec/suma/commerce/checkout_spec.rb
+++ b/spec/suma/commerce/checkout_spec.rb
@@ -283,16 +283,18 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
         cash_op = Suma::Fixtures.offering_product(product: cash_product, offering:).costing("$4", "$5").create
 
         cart = Suma::Fixtures.cart(offering:, member:).
-          with_product(food_product1, 2).
-          with_product(food_product2, 1).
-          with_product(holiday_product, 1).
-          with_product(cash_product, 1).
+          with_product(food_product1, 2). # $800
+          with_product(food_product2, 1). # $400
+          with_product(holiday_product, 1). # $40
+          with_product(cash_product, 1). # #4
           create
         checkout = Suma::Fixtures.checkout(cart:, card: Suma::Fixtures.card.member(member).create).
           populate_items.
           create
 
+        # See above for how we get this
         customer_cost = money("$1244")
+        # Cost minus what is on their ledgers, which should be used first.
         chargeable_total = customer_cost - book_cash.amount - book_food.amount - book_holiday.amount
         order = create_order(chargeable_total, checkout_: checkout)
         expect(order.charge).to have_attributes(
@@ -401,24 +403,97 @@ RSpec.describe "Suma::Commerce::Checkout", :db do
       end
     end
 
-    it "calculates the correct subsidy for multiple products from the same subsidy" do
-      product1 = Suma::Fixtures.product.with_categories(food_vsc).create
-      op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
-      product2 = Suma::Fixtures.product.with_categories(food_vsc).create
-      op2 = Suma::Fixtures.offering_product(product: product2, offering:).costing("$50", "$50").create
-      trigger = Suma::Fixtures.payment_trigger.matching(1).
-        from(platform_food_ledger).
-        create
+    describe "with multiple products from the same subsidy ledger" do
+      it "calculates the correct subsidy from triggers" do
+        product1 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+        product2 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op2 = Suma::Fixtures.offering_product(product: product2, offering:).costing("$50", "$50").create
+        trigger = Suma::Fixtures.payment_trigger.matching(1).
+          from(platform_food_ledger).
+          create
 
-      cart = Suma::Fixtures.cart(offering:, member:).
-        with_product(product1, 1).
-        with_product(product2, 1).
-        create
-      ctx = Suma::Payment::CalculationContext.new(Time.now)
-      ci = cart.cost_info(ctx)
-      expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$50"))
-      expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
-      expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
+        cart = Suma::Fixtures.cart(offering:, member:).
+          with_product(product1, 1).
+          with_product(product2, 1).
+          create
+        ctx = Suma::Payment::CalculationContext.new(Time.now)
+        ci = cart.cost_info(ctx)
+        expect(ci).to have_attributes(noncash_ledger_contribution_amount: cost("$50"))
+        expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
+        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
+      end
+
+      it "applies maximum trigger match properly (hit on first item)" do
+        product1 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+        product2 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op2 = Suma::Fixtures.offering_product(product: product2, offering:).costing("$50", "$50").create
+        trigger = Suma::Fixtures.payment_trigger.matching(1).
+          up_to("$20").
+          from(platform_food_ledger).
+          create
+
+        cart = Suma::Fixtures.cart(offering:, member:).
+          with_product(product1, 1).
+          with_product(product2, 1).
+          create
+        ctx = Suma::Payment::CalculationContext.new(Time.now)
+        ci = cart.cost_info(ctx)
+        expect(ci).to have_attributes(cash_cost: cost("80"), noncash_ledger_contribution_amount: cost("$20"))
+        expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$20")
+        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$20")
+        # TODO: This method is unsafe, rename it
+        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$20")
+      end
+
+      it "applies maximum trigger match properly (hit on later items)" do
+        product1 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+        product2 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op2 = Suma::Fixtures.offering_product(product: product2, offering:).costing("$50", "$50").create
+        product3 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op3 = Suma::Fixtures.offering_product(product: product3, offering:).costing("$50", "$50").create
+        trigger = Suma::Fixtures.payment_trigger.matching(1).
+          up_to("$60").
+          from(platform_food_ledger).
+          create
+
+        cart = Suma::Fixtures.cart(offering:, member:).
+          with_product(product1, 1).
+          with_product(product2, 1).
+          with_product(product3, 1).
+          create
+        ctx = Suma::Payment::CalculationContext.new(Time.now)
+        ci = cart.cost_info(ctx)
+        expect(ci).to have_attributes(cash_cost: cost("90"), noncash_ledger_contribution_amount: cost("$60"))
+        # TODO: This method is unsafe, rename it
+        expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
+        expect(ci.product_noncash_ledger_contribution_amount(op2)).to cost("$25")
+        expect(ci.product_noncash_ledger_contribution_amount(op3)).to cost("$25")
+      end
+
+      it "uses what is available on the subsidy ledger" do
+        product1 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op1 = Suma::Fixtures.offering_product(product: product1, offering:).costing("50", "$50").create
+        product2 = Suma::Fixtures.product.with_categories(food_vsc).create
+        op2 = Suma::Fixtures.offering_product(product: product2, offering:).costing("$50", "$50").create
+        trigger = Suma::Fixtures.payment_trigger.matching(1).
+          up_to("$30").
+          from(platform_food_ledger).
+          create
+        Suma::Fixtures.book_transaction.to(food_ledger).create(amount: money("$10"))
+
+        cart = Suma::Fixtures.cart(offering:, member:).
+          with_product(product1, 1).
+          with_product(product2, 1).
+          create
+        ctx = Suma::Payment::CalculationContext.new(Time.now)
+        ci = cart.cost_info(ctx)
+        expect(ci).to have_attributes(cash_cost: cost("$60"), noncash_ledger_contribution_amount: cost("$40"))
+        # TODO: This method is unsafe, rename it
+        # expect(ci.product_noncash_ledger_contribution_amount(op1)).to cost("$25")
+      end
     end
 
     it "does not include a negative cash ledger balance in subsidy matching or charging" do

--- a/spec/suma/payment/calculation_context_spec.rb
+++ b/spec/suma/payment/calculation_context_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Suma::Payment::CalculationContext, :db do
+  it "can be inspected" do
+    expect(described_class.new(Time.now).inspect).to(eq("#<Suma::Payment::CalculationContext {}>"))
+  end
   it "can return adjusted and unadjusted ledger balances" do
     l1, l2 = "ab".chars.map { |c| Suma::Fixtures.ledger.create(name: c) }
     ctx = described_class.new(Time.now)

--- a/spec/suma/payment/charge_contribution_spec.rb
+++ b/spec/suma/payment/charge_contribution_spec.rb
@@ -3,6 +3,9 @@
 RSpec.describe Suma::Payment::ChargeContribution, :db do
   it "has defaults" do
     expect(described_class.new).to have_attributes(amount: Money.new(0))
+    expect(described_class.new.inspect).to start_with(
+      "#<Suma::Payment::ChargeContribution amount: $0.00, apply_at: nil, category: nil",
+    )
   end
 
   it "calculates outstanding and from_balance from its balance" do

--- a/spec/suma/postgres/model_spec.rb
+++ b/spec/suma/postgres/model_spec.rb
@@ -464,6 +464,11 @@ RSpec.describe "Suma::Postgres::Model", :db do
       state.values[:foo_base64] = Base64.strict_encode64("abc")
       expect(state.inspect).to include("foo_base64: (4)")
     end
+
+    it "puts a name/label/title fields first" do
+      m = Suma::Fixtures.member.create(name: "hi")
+      expect(m.inspect).to start_with("#<Suma::Member id: #{m.id}, name: \"hi\"")
+    end
   end
 
   describe "resource_lock!" do

--- a/spec/suma/typed_struct_spec.rb
+++ b/spec/suma/typed_struct_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe Suma::TypedStruct do
       expect(t.new(x: 1).x).to eq(1)
       expect(t.new(x: 1)[:x]).to eq(1)
     end
+
+    it "has some special-case value formats" do
+      t = Class.new(described_class) do
+        def m = Money.new(23)
+        def t = Time.at(1).utc
+      end
+      expect(t.new.inspect).to eq("#< m: $0.23, t: 1970-01-01 00:00:01 UTC>")
+    end
   end
 
   describe "as_json" do

--- a/spec/suma/typed_struct_spec.rb
+++ b/spec/suma/typed_struct_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Suma::TypedStruct do
 
         def x? = true
       end
-      expect(t.new(x: "x", y: :y).inspect).to eq('(a: :a, x: "x", y: :y, z: :z)')
+      expect(t.new(x: "x", y: :y).inspect).to eq('#< a: :a, x: "x", y: :y, z: :z>')
       t.new.z = 5 # Used to hit coverage on the z= method
       expect(t.new(x: 1).x).to eq(1)
       expect(t.new(x: 1)[:x]).to eq(1)


### PR DESCRIPTION
If we had multiple products with the same category,
using a trigger from the same ledger,
the first gets discounted properly, but the second does not.

For example, 1x $50 and 1x $50, should be the same as 2x $50;
with a 50% discount; but 2x $50 has a cost of $50 (correct),
but 1x$50 and 1x$50 has a cost of $62.50 ($25 discount on the first;
then a 50% of $25 discount on the second).

Mechanically what was happening was ProductA would get a trigger
and add $25 in subsidy to the ledger. The next iteration,
calculating ProductB, would pull this $25 from the ledger.

The solution is obvious in hindsight- after we calculate
how much we're adding (via trigger) to subsidize ProductA,
we need to debit that amount to 'zero out' the balance
for the next iteration (note that the ledger
could have had an existing subsidy we pull from first,
that isn't a problem as it gets consumed via the running
'CalculationContext', but we don't literally zero out
the balance).

This was really gnarly to figure out the fix for,
so there are a handful of coincident improvements:

- More docs and fixed typing
- Small refactors for clarity
- Better inspection format for models (name first)
- Better inspection format for typed structs
- Typed structs alias to_s if under the debugger
