### PR TITLE
Fix ledger balance bug causing incorrect charges on order creation

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -26,3 +26,4 @@ SERVICE_ENFORCE_SSL=false
 STRIPE_API_KEY=get-this-from-https://dashboard.stripe.com/test/apikeys-and-put-in-.env.development.local
 SUMA_LOG_FORMAT=color
 SUMA_USE_GLOBALS_CACHE=true
+WEBHOOKDB_INTEGRATION_ENABLED=false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -39,7 +39,7 @@ jobs:
           bundle exec rake db:migrate
           bundle exec rspec spec/
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: lithictech/suma

--- a/db/migrations/116_ledger_balances_fix.rb
+++ b/db/migrations/116_ledger_balances_fix.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+def from(x) = Suma::Member.db[x]
+Sequel.migration do
+  up do
+    drop_view :payment_ledger_balances
+    directional_book_transactions = from(:payment_book_transactions).
+      # Select all book transaction rows as negative,
+      # coming from their originating ledger.
+      select(
+        Sequel[:originating_ledger_id].as(:ledger_id),
+        (Sequel[:amount_cents] * -1).as(:cents),
+        :apply_at,
+      ).union(
+        # Add all book transaction rows as positive,
+        # going to their receiving ledger.
+        from(:payment_book_transactions).
+          select(
+            Sequel[:receiving_ledger_id].as(:ledger_id),
+            Sequel[:amount_cents].as(:cents),
+            :apply_at,
+          ),
+        all: true,
+      )
+
+    ledger_balances = from(directional_book_transactions).
+      select(
+        Sequel[:ledger_id],
+        Sequel.function(:sum, :cents).as(:balance_cents),
+        Sequel.function(:max, :apply_at).as(:latest_transaction_at),
+      ).group_by(:ledger_id)
+
+    create_view :payment_ledger_balances,
+                from(:payment_ledgers).
+                  select(
+                    Sequel[:payment_ledgers][:id].as(:ledger_id),
+                    Sequel[:payment_ledgers][:name].as(:ledger_name),
+                    Sequel[:payment_ledgers][:currency].as(:balance_currency),
+                    Sequel.function(:coalesce, :balance_cents, 0).as(:balance_cents),
+                    :latest_transaction_at,
+                  ).
+                  left_join(ledger_balances, ledger_id: :id)
+  end
+
+  down do
+    drop_view :payment_ledger_balances
+    # BUGGY query from migration 099
+    directional_book_transactions = from(:payment_book_transactions).
+      select(
+        Sequel[:originating_ledger_id].as(:ledger_id),
+        (Sequel[:amount_cents] * -1).as(:cents),
+        :apply_at,
+      ).union(
+        from(:payment_book_transactions).
+          select(
+            Sequel[:receiving_ledger_id].as(:ledger_id),
+            Sequel[:amount_cents].as(:cents),
+            :apply_at,
+          ),
+      ).union(
+        from(:payment_ledgers).
+          select(
+            Sequel[:id].as(:ledger_id),
+            Sequel[0].as(:cents),
+            Sequel[nil].as(:apply_at),
+          ),
+      ).join(
+        from(:payment_ledgers).select(:id, :currency, :name),
+        {id: :ledger_id},
+      )
+
+    create_view :payment_ledger_balances,
+                from(directional_book_transactions).
+                  select(
+                    Sequel[:ledger_id],
+                    Sequel.function(:max, :name).as(:ledger_name),
+                    Sequel.function(:sum, :cents).as(:balance_cents),
+                    Sequel.function(:max, :currency).as(:balance_currency),
+                    Sequel.function(:max, :apply_at).as(:latest_transaction_at),
+                  ).group_by(:ledger_id)
+  end
+end

--- a/lib/suma/async/process_anon_proxy_inbound_webhookdb_relays.rb
+++ b/lib/suma/async/process_anon_proxy_inbound_webhookdb_relays.rb
@@ -26,6 +26,7 @@ class Suma::Async::ProcessAnonProxyInboundWebhookdbRelays
   def _perform
     Suma::AnonProxy::Relay.registry_each do |relay|
       next unless relay.webhookdb_dataset
+      next unless Suma::Webhookdb.integration_enabled
       self.relay_row_iterator(relay).each(relay.webhookdb_dataset) do |row|
         message = relay.parse_message(row)
         Suma::AnonProxy::MessageHandler.handle(relay, message)

--- a/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
+++ b/lib/suma/payment/funding_transaction/stripe_card_strategy.rb
@@ -83,6 +83,7 @@ class Suma::Payment::FundingTransaction::StripeCardStrategy <
   # NOTE: We cannot use idempotency since that key is based on the strategy identity;
   # but we never committed the strategy because of the DB error.
   def _find_existing_lost_charge
+    return nil unless Suma::Webhookdb.integration_enabled
     cutoff = 1.hour.ago
     data = Sequel.pg_jsonb(:data)
     # rubocop:disable Style/PreferredHashMethods
@@ -192,6 +193,7 @@ class Suma::Payment::FundingTransaction::StripeCardStrategy <
     end
 
     def run
+      return unless Suma::Webhookdb.integration_enabled
       self.each do |row|
         stripe_charge_id = row.fetch(:stripe_id)
         Suma::Idempotency.once_ever.under_key("refund-unassociated-stripe-charge-#{stripe_charge_id}") do

--- a/lib/suma/payment/ledger.rb
+++ b/lib/suma/payment/ledger.rb
@@ -170,6 +170,20 @@ class Suma::Payment::Ledger < Suma::Postgres::Model(:payment_ledgers)
 
   def balance = self.balance_view.balance
 
+  def debug_balances
+    view_balance = self.balance_view.balance
+    stats_balance = self.total_receiving - self.total_originating
+    combined_balance = self.combined_book_transactions.sum(Money.new(0)) do |bx|
+      bx.receiving_ledger === self ? bx.amount : -bx.amount
+    end
+    associations_balance = self.received_book_transactions.sum(Money.new(0), &:amount) -
+      self.originated_book_transactions.sum(Money.new(0), &:amount)
+    in_sync = view_balance == stats_balance &&
+      view_balance == combined_balance &&
+      view_balance == associations_balance
+    return {view_balance:, stats_balance:, combined_balance:, associations_balance:, in_sync:}
+  end
+
   # Return true if this ledger can be used to purchase the given service.
   # This is done by comparing the vendor service categories on each.
   # If any of the VSCs for the service appear in ledger's VSC graph

--- a/lib/suma/payment/payout_transaction/stripe_charge_refund_strategy.rb
+++ b/lib/suma/payment/payout_transaction/stripe_charge_refund_strategy.rb
@@ -93,6 +93,7 @@ class Suma::Payment::PayoutTransaction::StripeChargeRefundStrategy <
   # - Checkout without the right subsidy (partial credit and refund)
   # - Checkout but never get their stuff (full credit and refund)
   def self.backfill_payouts_from_webhookdb
+    return unless Suma::Webhookdb.integration_enabled
     last_ran_at = self.dataset.max(:created_at) || Time.at(0)
     # Apply some buffer, we never want to miss a refund, and processing the same row
     # multiple times is fine.

--- a/lib/suma/webhookdb.rb
+++ b/lib/suma/webhookdb.rb
@@ -21,6 +21,11 @@ module Suma::Webhookdb
     setting :schema, :public
     # See +Suma::Webhookdb::Model+ for more information.
     setting :models_enabled, false
+    # If false, do not try to interact with WebhookDB tables.
+    # Generally webhookdb is configured in production (uses real server),
+    # and unit tests (uses fixtures), and sometimes staging (using a test environment),
+    # but usually not local development.
+    setting :integration_enabled, true
     setting :front_conversations_table, :front_conversation_v1_fixture
     setting :front_messages_table, :front_message_v1_fixture
     setting :postmark_inbound_messages_table, :postmark_inbound_message_v1_fixture

--- a/spec/suma/async/jobs_spec.rb
+++ b/spec/suma/async/jobs_spec.rb
@@ -941,6 +941,20 @@ RSpec.describe "suma async jobs", :async, :db, :do_not_defer_events, :no_transac
       Suma::Async::ProcessAnonProxyInboundWebhookdbRelays.new.perform(true)
       expect(Suma::AnonProxy::MessageHandler::Fake.handled).to have_length(1)
     end
+
+    it "noops if webhookdb not enabled", reset_configuration: Suma::Webhookdb do
+      Suma::Webhookdb.integration_enabled = false
+      va = Suma::Fixtures.anon_proxy_vendor_account.with_contact(relay_key: "postmark").create
+      Suma::Webhookdb.postmark_inbound_messages_dataset.insert(
+        to_email: va.contact.email,
+        from_email: "fake-handler",
+        data: Sequel.pg_jsonb({"HtmlBody" => "body"}),
+        timestamp: Time.now,
+        message_id: "msgid",
+      )
+      Suma::Async::ProcessAnonProxyInboundWebhookdbRelays.new.perform(true)
+      expect(Suma::AnonProxy::MessageHandler::Fake.handled).to have_length(0)
+    end
   end
 
   describe "MemberOnboardingVerifiedDispatch" do

--- a/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
+++ b/spec/suma/payment/funding_transaction/stripe_card_strategy_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe "Suma::Payment::FundingTransaction::StripeCardStrategy", :db do
           )
       end
 
+      it "skips the table check if not enabled", reset_configuration: Suma::Webhookdb do
+        Suma::Webhookdb.integration_enabled = false
+        xaction.update(amount_cents: amount)
+        insert_charge("ch_1")
+        req = stub_request(:post, "https://api.stripe.com/v1/charges").
+          to_return(**fixture_response("stripe/charge"))
+        strategy.collect_funds
+        expect(req).to have_been_made
+      end
+
       it "reuses a recent, unassociated charge for the same amount if found" do
         xaction.update(amount_cents: amount)
         insert_charge("ch_1")
@@ -279,6 +289,14 @@ RSpec.describe "Suma::Payment::FundingTransaction::StripeCardStrategy", :db do
       expect(Suma::Support::Ticket.all).to contain_exactly(
         have_attributes(subject: "Refunding Unassociated Stripe Charge"),
       )
+    end
+
+    it "noops if webhookdb is not enabled", reset_configuration: Suma::Webhookdb do
+      Suma::Webhookdb.integration_enabled = false
+      insert("ch_needsrefund")
+      fx = Suma::Fixtures.funding_transaction.with_fake_strategy.create
+      described_class.refund_unassociated_charges
+      expect(Suma::Support::Ticket.all).to be_empty
     end
   end
 end

--- a/spec/suma/payment/ledger_spec.rb
+++ b/spec/suma/payment/ledger_spec.rb
@@ -103,6 +103,46 @@ RSpec.describe "Suma::Payment::Ledger", :db do
     end
   end
 
+  describe "balance" do
+    let(:ledger) { Suma::Fixtures.ledger.create }
+
+    it "handles no transactions" do
+      expect(ledger.debug_balances).to include(
+        associations_balance: cost(0),
+        combined_balance: cost(0),
+        in_sync: true,
+        stats_balance: cost(0),
+        view_balance: cost(0),
+      )
+    end
+
+    it "handles receiving and originating transactions" do
+      Suma::Fixtures.book_transaction.from(ledger).create(amount: money("$5"))
+      Suma::Fixtures.book_transaction.to(ledger).create(amount: money("$10"))
+      expect(ledger.debug_balances).to include(
+        associations_balance: cost("$5"),
+        combined_balance: cost("$5"),
+        in_sync: true,
+        stats_balance: cost("$5"),
+        view_balance: cost("$5"),
+      )
+    end
+
+    it "handles duplicate transactions" do
+      bx = Suma::Fixtures.book_transaction.from(ledger).create(amount: money("$5"))
+      bxv = bx.values.dup
+      bxv.delete(:id)
+      Suma::Payment::BookTransaction.create(bxv)
+      expect(ledger.debug_balances).to include(
+        associations_balance: cost("-$10"),
+        combined_balance: cost("-$10"),
+        in_sync: true,
+        stats_balance: cost("-$10"),
+        view_balance: cost("-$10"),
+      )
+    end
+  end
+
   describe "can_be_used_to_purchase?" do
     it "is true if the service has a category in the ledger category chain" do
       food = Suma::Fixtures.vendor_service_category.create

--- a/spec/suma/payment/payout_transaction/stripe_charge_refund_strategy_spec.rb
+++ b/spec/suma/payment/payout_transaction/stripe_charge_refund_strategy_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe "Suma::Payment::PayoutTransaction::StripeChargeRefundStrategy", :
       )
     end
 
+    it "noops if webhookdb is not enabled", reset_configuration: Suma::Webhookdb do
+      Suma::Webhookdb.integration_enabled = false
+      described_class.backfill_payouts_from_webhookdb
+      expect(Suma::Payment::PayoutTransaction.all).to be_empty
+    end
+
     it "creates crediting refund payout transactions if the funding transaction is used in a charge" do
       described_class.backfill_payouts_from_webhookdb
       expect(Suma::Payment::PayoutTransaction.all).to contain_exactly(

--- a/webapp/.env.development
+++ b/webapp/.env.development
@@ -1,2 +1,3 @@
 VITE_DEV_CARD_DETAILS={"name":"Your Name Here","number":"4242424242424242","expiry":"01 / 35","cvc":"123"}
 VITE_DEV_BANK_ACCOUNT_DETAILS={"name":"Test Account","routing":"111222333","account":"9123"}
+VITE_API_TIMEOUT=99999999999

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -6,6 +6,7 @@ import axiosRetry, { isIdempotentRequestError, isNetworkError } from "axios-retr
 const instance = apiBase.create(config.apiHost, {
   debug: config.debug,
   chaos: config.chaos || false,
+  timeout: config.apiTimeout,
 });
 axiosRetry(instance, {
   shouldResetTimeout: true,

--- a/webapp/src/config.js
+++ b/webapp/src/config.js
@@ -34,6 +34,7 @@ function parseIfSet(key) {
 
 const config = {
   apiHost: apiHost,
+  apiTimeout: env.VITE_API_TIMEOUT,
   chaos: env.VITE_CHAOS,
   debug: env.VITE_DEBUG,
   environment: env.NODE_ENV,

--- a/webapp/src/shared/apiBase.js
+++ b/webapp/src/shared/apiBase.js
@@ -9,10 +9,10 @@ import get from "lodash/get";
 import noop from "lodash/noop";
 
 function create(apiHost, config) {
-  const { debug, chaos, ...rest } = config || {};
+  const { debug, chaos, timeout, ...rest } = config || {};
   const instance = axios.create({
     baseURL: apiHost,
-    timeout: 20000,
+    timeout: timeout || 20000,
     withCredentials: true,
     transformRequest: [
       (data) => humps.decamelizeKeys(data),


### PR DESCRIPTION
Fix ledger balance view bug

Ledger balances were using a UNION rather than UNION ALL,
so duplicate book transactions (such as two subsidies from
the same ledger during checkout) would not be included
in the balance, causing incorrect charging.

The fix is to UNION ALL. Also make some other
improvements (add $0 rows after aggregation).

=== What happened (users see $50 charge at checkout, but charged $75)

Plain explanation provided in Slack:

The original 75/25 bug was a calculation bug:
the algorithm didn’t handle the case of different products
using the same subsidy ledger.

That was fixed correctly! Which is why the checkout process
looked correct.
However, it was tested at a ‘lower’ level than the checkout
(we use the same algorithm for many places,
like showing the price on the product screen,
so it doesn’t really make sense to test it with a
checkout/order creation unit test).

During checkout, we use the result of that algorithm
(the “predicted” contribution),
and then actual create the debits/credits
(executing the trigger steps). We immediately then re-run
a similar algorithm to get the ‘actual’ contributions: that is,
we just added $50 to your ledger based on predicted contributions,
we then subtract $50 from your ledger to include in the actual payment
(remember that when you check out, you get a subsidy credit and
then a new subsidy debit to pay for the order).

But this ‘actual’ contribution calculation was wrong,
due to a very subtle bug in how we calculate the ledger balance:
we discard identical rows. So you’d get $50 in credits,
but end up with a $25 balance, because the code that
calculates the balance (a SQL query to keep everything fast,
we don’t pull down hundreds of unnecessary transactions into
Ruby just to sum them) misses the duplicate rows.
You only get the duplicate rows if the credits are from the same ledger.

The ledger balance code is obviously unit tested too
but this identical row case was missed (by definition,
the fix is changing one line from UNION to UNION ALL,
if I had thought to check it, we wouldn’t have had the bug).

---

Add circuit breakers for webhookdb

Some async job code would use webhookdb in environments
it isn't enabled (like development).
This is harmless but adds error log spam running locally.

Add a new Webhookdb.integration_enabled flag
that is true by default, and false in development env.
Then add early-out checks in relevant code.

---

Webapp: Timeout is configurable

Set it high on development so debugger sessions don't disrupt
the frontend.